### PR TITLE
ci: auto-create GitHub releases on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,29 @@
 name: Publish to PyPI and MCP Registry
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v6
+      
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +47,7 @@ jobs:
         run: uv run ruff check .
 
   build:
-    needs: test
+    needs: [create-release, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Changes the publish workflow to automatically create GitHub releases when a version tag is pushed (e.g., `v0.2.0`).

## Changes

- Trigger workflow on `push: tags: ['v*']` instead of `release: [published]`
- Add `create-release` job using `softprops/action-gh-release@v2` with auto-generated release notes
- Build job now waits for both release creation and tests to pass

## Workflow

1. Push a tag: `git tag v0.2.0 && git push origin v0.2.0`
2. Workflow auto-creates a GitHub release with generated notes
3. Tests run in parallel
4. Build creates artifacts
5. Publish to PyPI and MCP Registry

This removes the need to manually create releases on GitHub.