### PR TITLE
fix: set package version from git tag during build

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -219,10 +219,25 @@ async def test_with_mock(mock_get_rmapi):
 
 ### Making a Release
 
-1. Update version in `pyproject.toml`
+Releases are automated via GitHub Actions. The version is derived from the git tag.
+
+**Steps:**
+1. Ensure all changes are merged to `main`
 2. Ensure README.md is current
-3. Run full test suite: `uv run pytest test_server.py -v`
-4. Run linting: `uv run ruff check .`
-5. Run formatting check: `uv run ruff format --check .`
-6. Commit all changes
-7. Create a GitHub release (triggers PyPI publish)
+3. Ensure CI is passing on `main`
+4. Create and push a version tag:
+   ```bash
+   # Get the current version from pyproject.toml or latest tag
+   git tag -l 'v*' | sort -V | tail -1
+   
+   # Create next version tag (e.g., v0.2.0)
+   git tag v0.2.0
+   git push origin v0.2.0
+   ```
+5. The workflow automatically:
+   - Creates a GitHub release with generated notes
+   - Builds the package with the tag version
+   - Publishes to PyPI
+   - Publishes to MCP Registry
+
+**Note:** The version in `pyproject.toml` is updated automatically during the build from the git tag. You don't need to manually update it.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
       
+      - name: Update version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Setting version to $VERSION"
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+          cat pyproject.toml | grep "^version"
+      
       - name: Build package
         run: uv build
       


### PR DESCRIPTION
## Problem

The build workflow was using the version from `pyproject.toml` (0.1.0) instead of the git tag version (e.g., v0.1.2), causing version mismatches.

## Solution

Added a step in the build job to update `pyproject.toml` version from the git tag before building:

```yaml
- name: Update version from tag
  run: |
    VERSION=${GITHUB_REF#refs/tags/v}
    sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
```

Also updated copilot instructions to document the new tag-based release workflow.

## Changes

- `publish.yml`: Add version update step before `uv build`
- `copilot-instructions.md`: Update "Making a Release" section to reflect tag-based versioning