### PR TITLE
fix: correct mcp-name case in README for registry validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for accessing your reMarkable tablet data through the reMarkable Cloud.
 
-<!-- mcp-name: io.github.sammorrowdrums/remarkable -->
+<!-- mcp-name: io.github.SamMorrowDrums/remarkable -->
 
 ## Quick Install
 


### PR DESCRIPTION
## Fix

Correct the case in the `mcp-name` comment in README.md for MCP Registry validation:

```diff
-<!-- mcp-name: io.github.sammorrowdrums/remarkable -->
+<!-- mcp-name: io.github.SamMorrowDrums/remarkable -->
```

The MCP Registry requires this string to exactly match the server name for PyPI ownership validation.