### PR TITLE
fix: move CLI entry point into package for proper wheel packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 ]
 
 [project.scripts]
-remarkable-mcp = "server:main"
+remarkable-mcp = "remarkable_mcp.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+CLI entry point for reMarkable MCP Server.
+
+Usage:
+    # As MCP server (default)
+    remarkable-mcp
+
+    # Convert one-time code to token (run once)
+    remarkable-mcp --register <one-time-code>
+"""
+
+import argparse
+import json
+import sys
+
+
+def main():
+    """Main entry point - handle CLI args or run MCP server."""
+    parser = argparse.ArgumentParser(
+        description="reMarkable MCP Server",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Register and get token (run once)
+  uvx remarkable-mcp --register abcd1234
+
+  # Run as MCP server
+  uvx remarkable-mcp
+
+  # Run with token from environment
+  REMARKABLE_TOKEN="your-token" uvx remarkable-mcp
+""",
+    )
+    parser.add_argument(
+        "--register",
+        metavar="CODE",
+        help="Register with reMarkable using a one-time code and print the token",
+    )
+
+    args = parser.parse_args()
+
+    if args.register:
+        # Registration mode - convert one-time code to token
+        # Only import what's needed for registration
+        from remarkable_mcp.api import register_and_get_token
+
+        try:
+            print(f"Registering with reMarkable using code: {args.register}")
+            token = register_and_get_token(args.register)
+            print("\n✅ Successfully registered!\n")
+            print("Your token (add to mcp.json env):")
+            print("-" * 50)
+            print(token)
+            print("-" * 50)
+            print("\nAdd to your .vscode/mcp.json:")
+            print(
+                json.dumps(
+                    {
+                        "servers": {
+                            "remarkable": {
+                                "command": "uvx",
+                                "args": ["remarkable-mcp"],
+                                "env": {"REMARKABLE_TOKEN": token},
+                            }
+                        }
+                    },
+                    indent=2,
+                )
+            )
+        except Exception as e:
+            print(f"❌ Registration failed: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # MCP server mode - only now import the full server
+        from remarkable_mcp.server import run
+
+        run()
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -12,76 +12,10 @@ Usage:
     # Convert one-time code to token (run once)
     python server.py --register <one-time-code>
 
-This is the entry point script. The actual implementation is in the remarkable_mcp package.
+This is a backwards-compatible entry point. The actual CLI is in remarkable_mcp/cli.py.
 """
 
-import argparse
-import json
-import sys
-
-
-def main():
-    """Main entry point - handle CLI args or run MCP server."""
-    parser = argparse.ArgumentParser(
-        description="reMarkable MCP Server",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Register and get token (run once)
-  uvx remarkable-mcp --register abcd1234
-
-  # Run as MCP server
-  uvx remarkable-mcp
-
-  # Run with token from environment
-  REMARKABLE_TOKEN="your-token" uvx remarkable-mcp
-""",
-    )
-    parser.add_argument(
-        "--register",
-        metavar="CODE",
-        help="Register with reMarkable using a one-time code and print the token",
-    )
-
-    args = parser.parse_args()
-
-    if args.register:
-        # Registration mode - convert one-time code to token
-        # Only import what's needed for registration
-        from remarkable_mcp.api import register_and_get_token
-
-        try:
-            print(f"Registering with reMarkable using code: {args.register}")
-            token = register_and_get_token(args.register)
-            print("\n✅ Successfully registered!\n")
-            print("Your token (add to mcp.json env):")
-            print("-" * 50)
-            print(token)
-            print("-" * 50)
-            print("\nAdd to your .vscode/mcp.json:")
-            print(
-                json.dumps(
-                    {
-                        "servers": {
-                            "remarkable": {
-                                "command": "uvx",
-                                "args": ["remarkable-mcp"],
-                                "env": {"REMARKABLE_TOKEN": token},
-                            }
-                        }
-                    },
-                    indent=2,
-                )
-            )
-        except Exception as e:
-            print(f"❌ Registration failed: {e}", file=sys.stderr)
-            sys.exit(1)
-    else:
-        # MCP server mode - only now import the full server
-        from remarkable_mcp.server import run
-
-        run()
-
+from remarkable_mcp.cli import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Problem

The entry point in `pyproject.toml` was referencing `server:main`, but `server.py` is not included in the wheel package (only `remarkable_mcp/` is packaged via the hatch build config). This caused:

```
ModuleNotFoundError: No module named 'server'
```

when running via `uvx remarkable-mcp`.

## Solution

- Move `main()` function to `remarkable_mcp/cli.py` (inside the packaged directory)
- Update entry point to `remarkable_mcp.cli:main`
- Keep `server.py` as a backwards-compatible wrapper that imports from `cli.py`

## Testing

- ✅ `uv run remarkable-mcp --help` works
- ✅ `uv run python server.py --help` works (backwards compat)
- ✅ All 34 tests pass
- ✅ Lint and format checks pass

## Release

After merge, tag v0.1.5 to publish a working version to PyPI.