### PR TITLE
Replace broken rmapy library with custom sync client

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -173,7 +173,7 @@ def remarkable_example(param: str) -> str:
 ## Key Dependencies
 
 - `mcp` - Model Context Protocol SDK
-- `rmapy` - reMarkable Cloud API client
+- `requests` - HTTP client for reMarkable Cloud API
 - `rmscene` - Native .rm file parser for text extraction (v3+ format)
 - `pytesseract` - OCR for handwritten content
 - `rmc` - reMarkable file conversion utilities

--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ MIT
 
 ---
 
-Built with [rmapy](https://github.com/subutux/rmapy), [rmscene](https://github.com/ricklupton/rmscene), and inspiration from [Scrybble](https://github.com/Scrybbling-together/scrybble).
+Built with [rmscene](https://github.com/ricklupton/rmscene), inspiration from [ddvk/rmapi](https://github.com/ddvk/rmapi) for the sync protocol, and [Scrybble](https://github.com/Scrybbling-together/scrybble) for text extraction ideas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.0.0",
-    "rmapy>=0.3.0",
     "rmscene>=0.6.0",
     "pytesseract>=0.3.10",
     "Pillow>=10.0.0",
     "rmc>=0.3.0",
+    "requests>=2.28.0",
 ]
 
 [project.optional-dependencies]

--- a/remarkable_mcp/resources.py
+++ b/remarkable_mcp/resources.py
@@ -22,10 +22,9 @@ def register_document_resources():
     becomes its own resource with URI like remarkable://doc/{name}.
     """
     try:
-        from rmapy.document import Document
-
         from remarkable_mcp.api import get_item_path, get_items_by_id, get_rmapi
         from remarkable_mcp.extract import extract_text_from_document_zip
+        from remarkable_mcp.sync import Document
 
         client = get_rmapi()
         collection = client.get_meta_items()
@@ -101,7 +100,7 @@ def register_document_resources():
         )
         def folders_resource() -> str:
             """Return folder structure as a resource."""
-            from rmapy.folder import Folder
+            from remarkable_mcp.sync import Folder
 
             try:
                 folders = []

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -1,0 +1,332 @@
+"""
+reMarkable Cloud Sync Client
+
+A replacement for rmapy that uses the current reMarkable sync API (v3/v4).
+rmapy is abandoned and uses deprecated endpoints that return 500 errors.
+
+Based on the protocol used by ddvk/rmapi.
+"""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+# API endpoints
+# Note: my.remarkable.com endpoints redirect to doesnotexist.remarkable.com
+# So we use webapp-prod.cloud.remarkable.engineering for auth
+AUTH_HOST = "https://webapp-prod.cloud.remarkable.engineering"
+DEVICE_TOKEN_URL = f"{AUTH_HOST}/token/json/2/device/new"
+USER_TOKEN_URL = f"{AUTH_HOST}/token/json/2/user/new"
+
+SYNC_HOST = "https://internal.cloud.remarkable.com"
+ROOT_URL = f"{SYNC_HOST}/sync/v4/root"
+FILES_URL = f"{SYNC_HOST}/sync/v3/files"
+
+
+@dataclass
+class Document:
+    """Represents a document or folder in the reMarkable cloud."""
+
+    id: str
+    hash: str
+    name: str
+    doc_type: str  # "DocumentType" or "CollectionType"
+    parent: str = ""
+    deleted: bool = False
+    pinned: bool = False
+    last_modified: Optional[datetime] = None
+    size: int = 0
+    files: List[Dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def is_folder(self) -> bool:
+        return self.doc_type == "CollectionType"
+
+    @property
+    def VissibleName(self) -> str:
+        """Compatibility with rmapy naming."""
+        return self.name
+
+    @property
+    def ID(self) -> str:
+        """Compatibility with rmapy naming."""
+        return self.id
+
+    @property
+    def Parent(self) -> str:
+        """Compatibility with rmapy naming."""
+        return self.parent
+
+    @property
+    def Type(self) -> str:
+        """Compatibility with rmapy naming."""
+        return self.doc_type
+
+    @property
+    def ModifiedClient(self) -> Optional[datetime]:
+        """Compatibility with rmapy naming."""
+        return self.last_modified
+
+
+# Alias for backward compatibility with rmapy-style code
+# In our sync module, both Document and Folder are the same class,
+# distinguished by the is_folder property
+Folder = Document
+
+
+class RemarkableClient:
+    """Client for reMarkable Cloud sync API."""
+
+    def __init__(self, device_token: str = "", user_token: str = ""):
+        self.device_token = device_token
+        self.user_token = user_token
+        self._documents: List[Document] = []
+        self._documents_by_id: Dict[str, Document] = {}
+
+    def renew_token(self) -> str:
+        """Exchange device token for a fresh user token."""
+        if not self.device_token:
+            raise RuntimeError("No device token available")
+
+        headers = {"Authorization": f"Bearer {self.device_token}"}
+
+        try:
+            response = requests.post(USER_TOKEN_URL, headers=headers, timeout=30)
+            if response.status_code == 200 and response.text:
+                self.user_token = response.text.strip()
+                return self.user_token
+        except requests.RequestException as e:
+            raise RuntimeError(f"Network error during token renewal: {e}")
+
+        raise RuntimeError(
+            f"Failed to renew user token (HTTP {response.status_code}).\n"
+            "Your device may need to be re-registered.\n"
+            "Get a new code from: https://my.remarkable.com/device/desktop/connect"
+        )
+
+    def _request(self, url: str, method: str = "GET") -> requests.Response:
+        """Make an authenticated request."""
+        if not self.user_token:
+            self.renew_token()
+
+        headers = {"Authorization": f"Bearer {self.user_token}"}
+        response = requests.request(method, url, headers=headers, timeout=60)
+
+        if response.status_code == 401:
+            # Token expired, try to renew
+            self.renew_token()
+            headers = {"Authorization": f"Bearer {self.user_token}"}
+            response = requests.request(method, url, headers=headers, timeout=60)
+
+        return response
+
+    def _get_file(self, file_hash: str) -> bytes:
+        """Download a file by its hash."""
+        response = self._request(f"{FILES_URL}/{file_hash}")
+        response.raise_for_status()
+        return response.content
+
+    def _parse_index(self, content: bytes) -> List[Dict[str, Any]]:
+        """Parse an index file into entries."""
+        lines = content.decode("utf-8").strip().split("\n")
+        entries = []
+
+        # First line is schema version
+        for line in lines[1:]:
+            parts = line.split(":")
+            if len(parts) >= 5:
+                entries.append(
+                    {
+                        "hash": parts[0],
+                        "type": parts[1],
+                        "id": parts[2],
+                        "subfiles": int(parts[3]),
+                        "size": int(parts[4]),
+                    }
+                )
+
+        return entries
+
+    def get_meta_items(self) -> List[Document]:
+        """
+        Fetch all documents and folders from the cloud.
+
+        Returns a list of Document objects (compatible with rmapy Collection).
+        """
+        # Get root hash
+        response = self._request(ROOT_URL)
+        response.raise_for_status()
+        root_data = response.json()
+        root_hash = root_data["hash"]
+
+        # Get root index
+        root_index = self._get_file(root_hash)
+        entries = self._parse_index(root_index)
+
+        documents = []
+
+        for entry in entries:
+            doc_id = entry["id"]
+            doc_hash = entry["hash"]
+
+            # Fetch the document's blob index
+            try:
+                blob_content = self._get_file(doc_hash)
+                blob_entries = self._parse_index(blob_content)
+            except Exception:
+                continue
+
+            # Find and fetch the metadata file
+            metadata = {}
+            files = []
+
+            for blob_entry in blob_entries:
+                files.append(blob_entry)
+                if blob_entry["id"].endswith(".metadata"):
+                    try:
+                        meta_content = self._get_file(blob_entry["hash"])
+                        metadata = json.loads(meta_content.decode("utf-8"))
+                    except Exception:
+                        pass
+
+            # Skip deleted documents
+            if metadata.get("deleted", False):
+                continue
+
+            # Parse last modified timestamp
+            last_modified = None
+            if "lastModified" in metadata:
+                try:
+                    ts = int(metadata["lastModified"]) / 1000  # Convert ms to seconds
+                    last_modified = datetime.fromtimestamp(ts)
+                except (ValueError, TypeError):
+                    pass
+
+            doc = Document(
+                id=doc_id,
+                hash=doc_hash,
+                name=metadata.get("visibleName", doc_id),
+                doc_type=metadata.get("type", "DocumentType"),
+                parent=metadata.get("parent", ""),
+                deleted=metadata.get("deleted", False),
+                pinned=metadata.get("pinned", False),
+                last_modified=last_modified,
+                size=entry["size"],
+                files=files,
+            )
+
+            documents.append(doc)
+
+        self._documents = documents
+        self._documents_by_id = {d.id: d for d in documents}
+
+        return documents
+
+    def get_doc(self, doc_id: str) -> Optional[Document]:
+        """Get a document by ID."""
+        if not self._documents_by_id:
+            self.get_meta_items()
+        return self._documents_by_id.get(doc_id)
+
+    def download(self, doc: Document) -> bytes:
+        """Download a document's content as a zip file."""
+        # The document blob contains all the files
+        # We need to fetch each file and create a zip
+        import io
+        import zipfile
+
+        blob_content = self._get_file(doc.hash)
+        blob_entries = self._parse_index(blob_content)
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for entry in blob_entries:
+                file_id = entry["id"]
+                file_hash = entry["hash"]
+
+                # Download the file
+                try:
+                    file_content = self._get_file(file_hash)
+                    zf.writestr(file_id, file_content)
+                except Exception:
+                    continue
+
+        zip_buffer.seek(0)
+        return zip_buffer.read()
+
+
+def register_device(one_time_code: str) -> Dict[str, str]:
+    """
+    Register a new device with reMarkable cloud.
+
+    Args:
+        one_time_code: Code from https://my.remarkable.com/device/desktop/connect
+
+    Returns:
+        Dict with devicetoken and usertoken keys
+    """
+    from uuid import uuid4
+
+    body = {
+        "code": one_time_code,
+        "deviceDesc": "desktop-linux",
+        "deviceID": str(uuid4()),
+    }
+
+    try:
+        response = requests.post(DEVICE_TOKEN_URL, json=body, timeout=30)
+        if response.status_code == 200 and response.text:
+            device_token = response.text.strip()
+            return {"devicetoken": device_token, "usertoken": ""}
+    except requests.RequestException as e:
+        raise RuntimeError(f"Network error during registration: {e}")
+
+    raise RuntimeError(
+        f"Registration failed (HTTP {response.status_code}). This usually means:\n"
+        "  1. The code has expired (codes are single-use)\n"
+        "  2. The code was already used\n"
+        "  3. The code was typed incorrectly\n\n"
+        "Get a new code from: https://my.remarkable.com/device/desktop/connect"
+    )
+
+
+def load_client_from_token(token_json: str) -> RemarkableClient:
+    """
+    Create a client from a JSON token string.
+
+    Args:
+        token_json: JSON string with devicetoken and optional usertoken
+
+    Returns:
+        Configured RemarkableClient
+    """
+    token_data = json.loads(token_json)
+    client = RemarkableClient(
+        device_token=token_data.get("devicetoken", ""),
+        user_token=token_data.get("usertoken", ""),
+    )
+    return client
+
+
+def load_client_from_file(token_file: Path = Path.home() / ".rmapi") -> RemarkableClient:
+    """
+    Load a client from a token file.
+
+    Args:
+        token_file: Path to JSON token file (default: ~/.rmapi)
+
+    Returns:
+        Configured RemarkableClient
+    """
+    if not token_file.exists():
+        raise RuntimeError(
+            f"Token file not found: {token_file}\n"
+            "Register first with: uvx remarkable-mcp --register <code>"
+        )
+
+    token_json = token_file.read_text()
+    return load_client_from_token(token_json)

--- a/server.py
+++ b/server.py
@@ -3,7 +3,7 @@
 reMarkable MCP Server
 
 An MCP server that provides access to reMarkable tablet data through the reMarkable Cloud API.
-Uses rmapy for cloud sync and rmscene for native text extraction.
+Uses rmscene for native text extraction.
 
 Usage:
     # As MCP server (default)

--- a/uv.lock
+++ b/uv.lock
@@ -621,18 +621,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyaml"
-version = "19.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/0c/bf62f049446da78498eb607bc8cbb0604cf1e8d618f2f733e538dcb6e0bc/pyaml-19.4.1.tar.gz", hash = "sha256:c79ae98ececda136a034115ca178ee8bf3aa7df236c488c2f55d12f177b88f1e", size = 20078, upload-time = "2019-04-17T02:29:07.676Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/1a/936074f3492156693fc9e471269fc5747fa3b7d9d7f8a33af054f6b24066/pyaml-19.4.1-py2.py3-none-any.whl", hash = "sha256:a2dcbc4a8bb00b541efd1c5a064d93474d4f41ded1484fbb08bec9d236523931", size = 16860, upload-time = "2019-04-17T02:29:09.91Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -906,70 +894,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
-    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -991,7 +915,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pillow" },
     { name = "pytesseract" },
-    { name = "rmapy" },
+    { name = "requests" },
     { name = "rmc" },
     { name = "rmscene" },
 ]
@@ -1018,7 +942,7 @@ requires-dist = [
     { name = "pytesseract", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "rmapy", specifier = ">=0.3.0" },
+    { name = "requests", specifier = ">=2.28.0" },
     { name = "rmc", specifier = ">=0.3.0" },
     { name = "rmscene", specifier = ">=0.6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -1044,19 +968,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "rmapy"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyaml" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/29/ad4f9f06adbff610e1b6da6d98aa39530c2efd23364c84edb9b8db48ed9f/rmapy-0.3.1.tar.gz", hash = "sha256:39664f903c70ac7e04d339a914a9a4e6025746c13196e52daeb6f9c89fff8fe2", size = 15050, upload-time = "2021-07-23T08:38:51.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/ee/349cd77e11d018b11d42a113df8202d4035b00b621dd8716b181ebba8255/rmapy-0.3.1-py3-none-any.whl", hash = "sha256:60b04eb0ce9f8c47a819ec775a1922e813ea4ac380ff77ec91556178563dc169", size = 14632, upload-time = "2021-07-23T08:38:49.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR replaces the broken `rmapy` library with a custom sync client implementation. The `rmapy` library uses deprecated reMarkable API endpoints that now return errors:

- `my.remarkable.com` redirects to `doesnotexist.remarkable.com`
- `document-storage-production-dot-remarkable-production.appspot.com` returns 500 errors

## Changes

### New Files
- **`remarkable_mcp/sync.py`** - Custom sync client using the v3/v4 API endpoints (discovered from ddvk/rmapi)
  - `RemarkableClient` class with `get_meta_items()`, `download()`, `renew_token()` methods
  - `Document` class with compatibility properties (`VissibleName`, `ID`, `Parent`, etc.)
  - `Folder` alias for backward compatibility
  - `register_device()` function for one-time code registration
  - `load_client_from_token()` and `load_client_from_file()` helpers

### Modified Files
- **`remarkable_mcp/api.py`** - Updated to use new sync client instead of rmapy
- **`remarkable_mcp/tools.py`** - Updated imports to use `sync.Document` and `sync.Folder`
- **`remarkable_mcp/resources.py`** - Updated imports to use sync module
- **`pyproject.toml`** - Removed `rmapy>=0.3.0`, added `requests>=2.28.0`
- **`uv.lock`** - Updated dependencies
- **`README.md`** - Updated credits section
- **`.github/copilot-instructions.md`** - Updated key dependencies
- **`server.py`** - Updated docstring

## Working Endpoints

| Purpose | Endpoint |
|---------|----------|
| Device Registration | `webapp-prod.cloud.remarkable.engineering/token/json/2/device/new` |
| User Token | `webapp-prod.cloud.remarkable.engineering/token/json/2/user/new` |
| Sync Root | `internal.cloud.remarkable.com/sync/v4/root` |
| File Download | `internal.cloud.remarkable.com/sync/v3/files/{hash}` |

## Testing

- All 34 tests pass ✅
- Lint checks pass ✅
- Format checks pass ✅
- Tested with real reMarkable account (349 documents retrieved successfully)

## Impact

- **Breaking**: None - API remains the same
- **Fixed**: Authentication now works (was returning 500 errors)
- **Improved**: No longer depends on abandoned `rmapy` library
