### PR TITLE
Replace rmapy with custom sync client using working API endpoints

### DIFF
--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -2,10 +2,33 @@
 reMarkable MCP Server initialization.
 """
 
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
 from mcp.server.fastmcp import FastMCP
 
-# Initialize FastMCP server
-mcp = FastMCP("remarkable")
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastMCP) -> AsyncIterator[None]:
+    """Lifespan context manager for the MCP server."""
+    # Import here to avoid circular imports
+    from remarkable_mcp.resources import start_background_loader, stop_background_loader
+
+    # Start background document loader
+    task = start_background_loader()
+
+    try:
+        yield
+    finally:
+        # Stop background loader on shutdown
+        await stop_background_loader(task)
+
+
+# Initialize FastMCP server with lifespan
+mcp = FastMCP("remarkable", lifespan=lifespan)
 
 # Import tools, resources, and prompts to register them
 from remarkable_mcp import (  # noqa: E402

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -151,9 +151,12 @@ class RemarkableClient:
 
         return entries
 
-    def get_meta_items(self) -> List[Document]:
+    def get_meta_items(self, limit: Optional[int] = None) -> List[Document]:
         """
-        Fetch all documents and folders from the cloud.
+        Fetch documents and folders from the cloud.
+
+        Args:
+            limit: Maximum number of documents to fetch. If None, fetches all.
 
         Returns a list of Document objects (compatible with rmapy Collection).
         """
@@ -220,6 +223,10 @@ class RemarkableClient:
             )
 
             documents.append(doc)
+
+            # Stop early if we have enough
+            if limit is not None and len(documents) >= limit:
+                break
 
         self._documents = documents
         self._documents_by_id = {d.id: d for d in documents}


### PR DESCRIPTION
## Summary

Replaces the abandoned `rmapy` library with a custom sync client that uses the current reMarkable Cloud API (v3/v4 endpoints). The `rmapy` library was returning 500 errors because it uses deprecated API endpoints.

## Changes

### New Sync Client (`remarkable_mcp/sync.py`)
- Custom `RemarkableClient` class using working API endpoints discovered from ddvk/rmapi
- Auth endpoint: `webapp-prod.cloud.remarkable.engineering/token/json/2/device/new`
- Sync endpoint: `internal.cloud.remarkable.com/sync/v4/root`
- Files endpoint: `internal.cloud.remarkable.com/sync/v3/files/{hash}`
- `Document` dataclass with rmapy-compatible property names for minimal code changes
- `get_meta_items(limit=N)` for fetching document metadata (with optional limit for performance)
- `download()` for fetching document content as zip

### Async Background Resource Loader
- Documents are registered as MCP resources lazily in the background
- Loads in batches of 10 to avoid blocking the server
- Uses FastMCP's `lifespan` context manager for startup/shutdown hooks
- Graceful cancellation on server shutdown via `asyncio.Event`
- Import remains fast (~0.7s) - background loading only starts when server runs

### Migration
- All code migrated from `rmapy` imports to new `sync` module
- Removed `rmapy>=0.3.0` dependency from `pyproject.toml`
- Added `requests>=2.28.0` dependency

## Testing

All 34 tests pass:
```
uv run pytest test_server.py -v
```

Background loader tested manually - registers documents in batches of 10 while server runs.

## Breaking Changes

None - all existing tools and APIs work the same way.