### PR TITLE
security: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
       - 'v*'
   workflow_dispatch:  # Allow manual triggering
 
+# Default to minimal permissions, jobs override as needed
+permissions:
+  contents: read
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -26,6 +30,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       
@@ -49,6 +55,8 @@ jobs:
   build:
     needs: [create-release, test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       


### PR DESCRIPTION
## Summary

Adds explicit least-privilege permissions to all GitHub Actions workflows following security best practices.

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- Added `permissions: contents: read` at workflow level
- The lint and test jobs only need to read repository contents

### Publish Workflow (`.github/workflows/publish.yml`)
- Added default `permissions: contents: read` at workflow level
- Added explicit `permissions: contents: read` to `test` and `build` jobs
- Existing job-level permissions for `create-release`, `publish-pypi`, and `publish-mcp-registry` remain unchanged

## Why

- Follows the principle of least privilege
- Protects against potential security issues from compromised actions
- Repositories created before February 2023 may have overly permissive defaults
- Explicit permissions make it clear what each workflow needs