### PR TITLE
feat: smart tool improvements - auto-redirect, auto-OCR, batch search

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,18 @@ Your token is stored securely using VS Code's input system with `password: true`
 | Tool | Description |
 |------|-------------|
 | `remarkable_read` | Extract text from a document (with pagination and search) |
-| `remarkable_browse` | List files or search by name |
+| `remarkable_browse` | List files, search by name, or auto-redirect to read documents |
+| `remarkable_search` | Search across multiple documents and return matching content |
 | `remarkable_recent` | Get recently modified documents |
 | `remarkable_status` | Check connection status |
 
 All tools are read-only and return structured JSON with hints for next actions.
+
+### Smart Features
+
+- **Auto-redirect**: Browsing a document path (e.g., `/Journals/November`) automatically returns the first page instead of an error
+- **Auto-OCR**: If a notebook has no typed text, OCR is automatically enabled and you're notified in the response
+- **Batch search**: Use `remarkable_search` to find content across multiple documents in one call
 
 ### `remarkable_read` Parameters
 
@@ -206,6 +213,15 @@ All tools are read-only and return structured JSON with hints for next actions.
 | `content_type` | string | `"all"` | `"all"`, `"annotations"`, or `"raw"` |
 | `page` | int | `1` | Page number for pagination |
 | `grep` | string | `None` | Search for keywords (returns matches with context) |
+| `include_ocr` | bool | `False` | Enable OCR for handwritten content |
+
+### `remarkable_search` Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | *required* | Search term for document names |
+| `grep` | string | `None` | Pattern to search within document content |
+| `limit` | int | `5` | Max documents to return (max: 5) |
 | `include_ocr` | bool | `False` | Enable OCR for handwritten content |
 
 **Content Types:**

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -326,7 +326,26 @@ def remarkable_read(
         start_idx = (page - 1) * page_size
         end_idx = start_idx + page_size
 
-        # Handle empty content case - page 1 should still work
+        # Handle empty content case - auto-retry with OCR if not already enabled
+        if total_chars == 0 and not include_ocr and file_type not in ("pdf", "epub"):
+            # Auto-retry with OCR for notebooks
+            import json
+
+            ocr_result = remarkable_read(
+                document=document,
+                content_type=content_type,
+                page=page,
+                grep=grep,
+                include_ocr=True,  # Enable OCR automatically
+            )
+            result_data = json.loads(ocr_result)
+            if "_error" not in result_data:
+                result_data["_ocr_auto_enabled"] = True
+                result_data["_hint"] = (
+                    "OCR auto-enabled (notebook had no typed text). " + result_data.get("_hint", "")
+                )
+            return json.dumps(result_data, indent=2)
+
         if total_chars == 0:
             if page > 1:
                 return make_error(
@@ -523,18 +542,20 @@ def remarkable_browse(path: str = "/", query: Optional[str] = None) -> str:
                 if not found:
                     # Check if it's a document (only valid as the last path part)
                     if found_document and i == len(path_parts) - 1:
-                        # User is trying to browse a document - suggest remarkable_read
+                        # Auto-redirect: return first page of the document
                         doc_path = get_item_path(found_document, items_by_id)
-                        parent_path = "/".join([""] + path_parts[:-1]) or "/"
-                        return make_error(
-                            error_type="path_is_document",
-                            message=f"'{part}' is a document, not a folder.",
-                            suggestion=(
-                                f"Use remarkable_read('{doc_path}') to read this document, "
-                                f"or remarkable_browse('{parent_path}') "
-                                "to browse the parent folder."
-                            ),
-                        )
+                        # Call remarkable_read internally and add redirect note
+                        read_result = remarkable_read(doc_path, page=1)
+                        import json
+
+                        result_data = json.loads(read_result)
+                        if "_error" not in result_data:
+                            result_data["_redirected_from"] = f"browse:{path}"
+                            result_data["_hint"] = (
+                                f"Auto-redirected from browse to read. "
+                                f"{result_data.get('_hint', '')}"
+                            )
+                        return json.dumps(result_data, indent=2)
 
                     # Folder not found - suggest alternatives
                     available_folders = [
@@ -698,6 +719,122 @@ def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
     except Exception as e:
         return make_error(
             error_type="recent_failed",
+            message=str(e),
+            suggestion="Check remarkable_status() to verify your connection.",
+        )
+
+
+@mcp.tool(annotations=READ_ONLY_ANNOTATIONS)
+def remarkable_search(
+    query: str,
+    grep: Optional[str] = None,
+    limit: int = 5,
+    include_ocr: bool = False,
+) -> str:
+    """
+    <usecase>Search across multiple documents and return matching content.</usecase>
+    <instructions>
+    Searches document names for the query, then optionally searches content with grep.
+    Returns summaries from multiple documents in a single call.
+
+    This is efficient for finding information across your library without
+    making many individual tool calls.
+
+    Limits:
+    - Max 5 documents per search (to keep response size manageable)
+    - Returns first page (~8000 chars) of each matching document
+    - Use grep to filter to relevant sections
+    </instructions>
+    <parameters>
+    - query: Search term for document names
+    - grep: Optional pattern to search within document content
+    - limit: Max documents to return (default: 5, max: 5)
+    - include_ocr: Enable OCR for handwritten content (default: False)
+    </parameters>
+    <examples>
+    - remarkable_search("meeting")  # Find docs with "meeting" in name
+    - remarkable_search("journal", grep="project")  # Find "project" in journals
+    - remarkable_search("notes", include_ocr=True)  # Search with OCR enabled
+    </examples>
+    """
+    import json
+
+    try:
+        # Enforce limits
+        limit = min(max(1, limit), 5)
+
+        # First, find matching documents
+        browse_result = remarkable_browse(query=query)
+        browse_data = json.loads(browse_result)
+
+        if "_error" in browse_data:
+            return browse_result
+
+        results = browse_data.get("results", [])
+        documents = [r for r in results if r.get("type") == "document"][:limit]
+
+        if not documents:
+            return make_error(
+                error_type="no_documents_found",
+                message=f"No documents found matching '{query}'.",
+                suggestion="Try a different search term or use remarkable_browse('/') to list all.",
+            )
+
+        # Read each document
+        search_results = []
+        for doc in documents:
+            doc_result = {
+                "name": doc["name"],
+                "path": doc["path"],
+                "modified": doc.get("modified"),
+            }
+
+            try:
+                read_result = remarkable_read(
+                    document=doc["path"],
+                    page=1,
+                    grep=grep,
+                    include_ocr=include_ocr,
+                )
+                read_data = json.loads(read_result)
+
+                if "_error" not in read_data:
+                    doc_result["content"] = read_data.get("content", "")[:2000]  # Limit per doc
+                    doc_result["total_pages"] = read_data.get("total_pages", 1)
+                    if grep:
+                        doc_result["grep_matches"] = read_data.get("grep_matches", 0)
+                    if len(read_data.get("content", "")) > 2000:
+                        doc_result["truncated"] = True
+                else:
+                    doc_result["error"] = read_data["_error"]["message"]
+            except Exception as e:
+                doc_result["error"] = str(e)
+
+            search_results.append(doc_result)
+
+        result = {
+            "query": query,
+            "grep": grep,
+            "count": len(search_results),
+            "documents": search_results,
+        }
+
+        # Build hint
+        docs_with_content = [d for d in search_results if "content" in d]
+        if grep:
+            matches = sum(d.get("grep_matches", 0) for d in docs_with_content)
+            hint = f"Found {len(docs_with_content)} document(s) with {matches} grep match(es)."
+        else:
+            hint = f"Found {len(docs_with_content)} document(s) matching '{query}'."
+
+        if docs_with_content:
+            hint += f" To read more: remarkable_read('{docs_with_content[0]['path']}')."
+
+        return make_response(result, hint)
+
+    except Exception as e:
+        return make_error(
+            error_type="search_failed",
             message=str(e),
             suggestion="Check remarkable_status() to verify your connection.",
         )

--- a/test_server.py
+++ b/test_server.py
@@ -96,6 +96,7 @@ class TestMCPServerInitialization:
             "remarkable_read",
             "remarkable_browse",
             "remarkable_recent",
+            "remarkable_search",
             "remarkable_status",
         ]
 
@@ -104,9 +105,9 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Test that we have exactly 4 intent-based tools."""
+        """Test that we have exactly 5 intent-based tools."""
         tools = await mcp.list_tools()
-        assert len(tools) == 4, f"Expected 4 tools, got {len(tools)}"
+        assert len(tools) == 5, f"Expected 5 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -529,7 +530,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 4
+        assert len(tools) == 5
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:


### PR DESCRIPTION
## Summary

Smart UX improvements to reduce round-trips and make the tools more intuitive.

## Changes

### 1. Auto-redirect browse → read
When browsing a path like `/Journals/November` where the final component is a document, automatically return the first page of content instead of an error.

**Before:** Error suggesting to use `remarkable_read()`
**After:** Returns first page with `_redirected_from: "browse:/Journals/November"`

### 2. Auto-OCR for empty notebooks
When a notebook has no typed text and OCR wasn't requested, automatically retry with OCR enabled.

**Before:** Empty content with hint "try include_ocr=True"
**After:** Returns OCR content with `_ocr_auto_enabled: true`

### 3. New `remarkable_search` tool
Search across multiple documents in one call with sane limits:
- Max 5 documents per search
- 2000 characters per document (truncated if longer)
- Supports grep filtering within content
- Returns summaries from all matching docs

```python
remarkable_search("journal", grep="project")  # Find "project" in journals
```

## Testing

- All 34 tests passing (updated for 5 tools)
- Manually tested auto-redirect and auto-OCR via MCP
- Lint and format checks pass