### PR TITLE
perf(recent): limit preview requests and skip notebooks

### DIFF
--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -681,7 +681,7 @@ def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
 
             if include_preview:
                 # Download and extract preview (skip notebooks - they need slow OCR)
-                file_type = get_file_type(doc)
+                file_type = get_file_type(client, doc)
                 if file_type == "notebook":
                     # Notebooks need OCR for preview, skip for performance
                     doc_info["preview_skipped"] = "notebook (use remarkable_read with include_ocr)"


### PR DESCRIPTION
## Problem

`remarkable_recent(limit=20, include_preview=True)` was very slow because:
1. It downloaded up to 50 documents sequentially when previews were requested
2. Notebooks (which are common) have no typed text, so previews were null anyway

## Solution

1. **Cap limit to 10** when `include_preview=True` (was 50)
2. **Skip notebook previews** entirely - they require OCR which is slow and this is meant to be a quick operation

For notebooks, we now return:
```json
{
  "preview": null,
  "preview_skipped": "notebook (use remarkable_read with include_ocr)"
}
```

This guides the user to use the proper tool for reading notebooks with OCR.

## Testing

- All 34 tests passing
- Lint/format checks pass