### PR TITLE
ci: add MCP conformance test workflow

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,33 @@
+name: Conformance Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - uses: SamMorrowDrums/mcp-conformance-action@v2
+        with:
+          install_command: uv sync
+          start_command: uv run python server.py


### PR DESCRIPTION
## Summary

Adds automated API change detection using mcp-conformance-action.

This workflow:
- Compares the server's public interface (tools, resources, prompts) between branches
- Surfaces any changes in the GitHub job summary
- Runs on PRs to main, pushes to main, and tag releases

## Changes

- Added `.github/workflows/conformance.yml` with stdio transport configuration

## Testing

The conformance test will run automatically on this PR.