### PR TITLE
Add retry logic with exponential backoff for transient errors (#29)

### DIFF
--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -8,12 +8,18 @@ Based on the protocol used by ddvk/rmapi.
 """
 
 import json
+import logging
+import os
+import random
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 # API endpoints
 # Note: my.remarkable.com endpoints redirect to doesnotexist.remarkable.com
@@ -25,6 +31,138 @@ USER_TOKEN_URL = f"{AUTH_HOST}/token/json/2/user/new"
 SYNC_HOST = "https://internal.cloud.remarkable.com"
 ROOT_URL = f"{SYNC_HOST}/sync/v4/root"
 FILES_URL = f"{SYNC_HOST}/sync/v3/files"
+
+# -----------------------------------------------------------------------------
+# Retry / backoff configuration (see Issue #29)
+# -----------------------------------------------------------------------------
+# Values are read from environment variables at call time so tests (and users)
+# can override the behaviour without re-importing the module. Defaults are
+# chosen to stay well below common MCP stdio client timeouts: with
+# attempts=3 and base_delay=2 the worst-case total wait is ~14s + jitter.
+DEFAULT_RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_DELAY = 2.0  # seconds; base for exponential backoff
+MAX_RETRY_DELAY = 20.0  # hard cap on any single sleep
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def _get_retry_attempts() -> int:
+    """Read REMARKABLE_RETRY_ATTEMPTS from the environment."""
+    try:
+        value = int(os.environ.get("REMARKABLE_RETRY_ATTEMPTS", DEFAULT_RETRY_ATTEMPTS))
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_ATTEMPTS
+    return max(1, value)
+
+
+def _get_retry_delay() -> float:
+    """Read REMARKABLE_RETRY_DELAY from the environment."""
+    try:
+        value = float(os.environ.get("REMARKABLE_RETRY_DELAY", DEFAULT_RETRY_DELAY))
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_DELAY
+    return max(0.0, value)
+
+
+def _parse_retry_after(header_value: Optional[str]) -> Optional[float]:
+    """Parse a ``Retry-After`` header. Returns seconds or ``None``.
+
+    Only the numeric form is honoured (the HTTP-date form is rarely used
+    by cloud APIs for 429 and would require timezone-aware parsing).
+    """
+    if not header_value:
+        return None
+    try:
+        return max(0.0, float(header_value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _compute_sleep(
+    attempt: int,
+    base_delay: float,
+    retry_after: Optional[float] = None,
+) -> float:
+    """Compute seconds to sleep before the next retry.
+
+    Honours a server-provided ``Retry-After`` when present; otherwise uses
+    exponential backoff with full jitter, as recommended in
+    https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/.
+    """
+    if retry_after is not None and retry_after > 0:
+        return min(retry_after, MAX_RETRY_DELAY)
+    window = min(base_delay * (2 ** attempt), MAX_RETRY_DELAY)
+    return random.uniform(0, window)
+
+
+def _http_request_with_retry(
+    method: str,
+    url: str,
+    *,
+    attempts: Optional[int] = None,
+    base_delay: Optional[float] = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Wrapper around ``requests.request`` with retry/backoff.
+
+    Retries on:
+        * :class:`requests.ConnectionError`
+        * :class:`requests.Timeout`
+        * HTTP 429 / 500 / 502 / 503 / 504
+
+    Does **not** retry on HTTP 401 (token renewal lives in the caller) or
+    any other 4xx (client errors are not transient).
+
+    The final response (or exception) is returned/raised unchanged so that
+    callers can surface the original error to the user.
+    """
+    if attempts is None:
+        attempts = _get_retry_attempts()
+    if base_delay is None:
+        base_delay = _get_retry_delay()
+
+    last_exc: Optional[BaseException] = None
+    response: Optional[requests.Response] = None
+
+    for attempt in range(attempts):
+        retry_after: Optional[float] = None
+        try:
+            response = requests.request(method, url, **kwargs)
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            last_exc = exc
+            response = None
+            logger.warning(
+                "remarkable_mcp: %s %s failed with %s (attempt %d/%d)",
+                method,
+                url,
+                exc.__class__.__name__,
+                attempt + 1,
+                attempts,
+            )
+        else:
+            if response.status_code not in RETRYABLE_STATUS_CODES:
+                return response
+            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+            last_exc = None  # we have a response; will return it after retries
+            logger.warning(
+                "remarkable_mcp: %s %s returned HTTP %d (attempt %d/%d)",
+                method,
+                url,
+                response.status_code,
+                attempt + 1,
+                attempts,
+            )
+
+        # Don't sleep after the final attempt.
+        if attempt == attempts - 1:
+            break
+        time.sleep(_compute_sleep(attempt, base_delay, retry_after))
+
+    if last_exc is not None:
+        raise last_exc
+    # Exhausted retries with a retryable status: return the last response so
+    # the caller's ``raise_for_status()`` / status-code check surfaces it.
+    assert response is not None  # at least one iteration ran
+    return response
 
 
 @dataclass
@@ -96,12 +234,15 @@ class RemarkableClient:
         headers = {"Authorization": f"Bearer {self.device_token}"}
 
         try:
-            response = requests.post(USER_TOKEN_URL, headers=headers, timeout=30)
-            if response.status_code == 200 and response.text:
-                self.user_token = response.text.strip()
-                return self.user_token
+            response = _http_request_with_retry(
+                "POST", USER_TOKEN_URL, headers=headers, timeout=30
+            )
         except requests.RequestException as e:
             raise RuntimeError(f"Network error during token renewal: {e}")
+
+        if response.status_code == 200 and response.text:
+            self.user_token = response.text.strip()
+            return self.user_token
 
         raise RuntimeError(
             f"Failed to renew user token (HTTP {response.status_code}).\n"
@@ -115,13 +256,13 @@ class RemarkableClient:
             self.renew_token()
 
         headers = {"Authorization": f"Bearer {self.user_token}"}
-        response = requests.request(method, url, headers=headers, timeout=60)
+        response = _http_request_with_retry(method, url, headers=headers, timeout=60)
 
         if response.status_code == 401:
             # Token expired, try to renew
             self.renew_token()
             headers = {"Authorization": f"Bearer {self.user_token}"}
-            response = requests.request(method, url, headers=headers, timeout=60)
+            response = _http_request_with_retry(method, url, headers=headers, timeout=60)
 
         return response
 
@@ -306,12 +447,13 @@ def register_device(one_time_code: str) -> Dict[str, str]:
     }
 
     try:
-        response = requests.post(DEVICE_TOKEN_URL, json=body, timeout=30)
-        if response.status_code == 200 and response.text:
-            device_token = response.text.strip()
-            return {"devicetoken": device_token, "usertoken": ""}
+        response = _http_request_with_retry("POST", DEVICE_TOKEN_URL, json=body, timeout=30)
     except requests.RequestException as e:
         raise RuntimeError(f"Network error during registration: {e}")
+
+    if response.status_code == 200 and response.text:
+        device_token = response.text.strip()
+        return {"devicetoken": device_token, "usertoken": ""}
 
     raise RuntimeError(
         f"Registration failed (HTTP {response.status_code}). This usually means:\n"

--- a/test_server.py
+++ b/test_server.py
@@ -626,15 +626,15 @@ class TestRemarkableImage:
 class TestRegistration:
     """Test registration functionality."""
 
-    @patch("requests.post")
+    @patch("remarkable_mcp.sync.requests.request")
     @patch("pathlib.Path.write_text")
-    def test_register_and_get_token(self, mock_write_text, mock_post):
+    def test_register_and_get_token(self, mock_write_text, mock_request):
         """Test registration process."""
         # Mock successful API response
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = "test_device_token_12345"
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         token = register_and_get_token("test_code")
 
@@ -645,22 +645,28 @@ class TestRegistration:
         assert token_data["devicetoken"] == "test_device_token_12345"
         assert "usertoken" in token_data
 
-        # Verify API was called
-        mock_post.assert_called_once()
-        call_args = mock_post.call_args
-        assert "webapp-prod.cloud.remarkable.engineering" in call_args[0][0]
+        # Verify API was called with POST to device-token URL
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        # register_device uses _http_request_with_retry("POST", DEVICE_TOKEN_URL, ...)
+        assert call_args[0][0] == "POST"
+        assert "webapp-prod.cloud.remarkable.engineering" in call_args[0][1]
 
-    @patch("requests.post")
-    def test_register_invalid_code(self, mock_post):
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_register_invalid_code(self, mock_request):
         """Test registration with invalid/expired code."""
-        # Mock 400 response (invalid code)
+        # Mock 400 response (invalid code - NOT in RETRYABLE_STATUS_CODES)
         mock_response = Mock()
         mock_response.status_code = 400
         mock_response.text = ""
-        mock_post.return_value = mock_response
+        mock_response.headers = {}
+        mock_request.return_value = mock_response
 
         with pytest.raises(RuntimeError, match="Registration failed"):
             register_and_get_token("invalid_code")
+
+        # 400 is not retryable, so request should be called exactly once
+        assert mock_request.call_count == 1
 
 
 # =============================================================================
@@ -1503,3 +1509,230 @@ class TestUSBWebInterface:
                 import remarkable_mcp.api
 
                 importlib.reload(remarkable_mcp.api)
+
+
+# =============================================================================
+# Retry / Backoff (Issue #29)
+# =============================================================================
+
+
+class TestRetryBackoff:
+    """Tests for the retry/backoff wrapper in remarkable_mcp.sync."""
+
+    def _make_response(self, status_code, text="", headers=None):
+        resp = Mock()
+        resp.status_code = status_code
+        resp.text = text
+        resp.headers = headers or {}
+        return resp
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_on_429_then_success(self, mock_request, mock_sleep):
+        """HTTP 429 should trigger a retry and eventually succeed."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        throttled = self._make_response(429, headers={"Retry-After": "0"})
+        ok = self._make_response(200, text="ok")
+        mock_request.side_effect = [throttled, ok]
+
+        response = _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        assert response is ok
+        assert mock_request.call_count == 2
+        # One sleep between the two attempts.
+        assert mock_sleep.call_count == 1
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_on_503_then_success(self, mock_request, mock_sleep):
+        """HTTP 503 should be retried (server-side transient)."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        unavailable = self._make_response(503)
+        ok = self._make_response(200, text="ok")
+        mock_request.side_effect = [unavailable, ok]
+
+        response = _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        assert response.status_code == 200
+        assert mock_request.call_count == 2
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_on_connection_error_then_success(self, mock_request, mock_sleep):
+        """Network failures should be retried."""
+        import requests as _requests
+
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        ok = self._make_response(200, text="ok")
+        mock_request.side_effect = [
+            _requests.ConnectionError("boom"),
+            _requests.Timeout("slow"),
+            ok,
+        ]
+
+        response = _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        assert response is ok
+        assert mock_request.call_count == 3
+        # Two sleeps between three attempts.
+        assert mock_sleep.call_count == 2
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_exhausted_retries_raises_last_exception(self, mock_request, mock_sleep):
+        """When every attempt fails with an exception, the last one is raised."""
+        import requests as _requests
+
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        mock_request.side_effect = _requests.ConnectionError("down")
+
+        with pytest.raises(_requests.ConnectionError):
+            _http_request_with_retry(
+                "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+            )
+
+        assert mock_request.call_count == 3
+        # Sleeps only between attempts, not after the last one.
+        assert mock_sleep.call_count == 2
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_exhausted_retries_returns_last_response(self, mock_request, mock_sleep):
+        """When retries are exhausted on a retryable status, return the response."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        mock_request.return_value = self._make_response(503)
+
+        response = _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=2, base_delay=0.01
+        )
+
+        assert response.status_code == 503
+        assert mock_request.call_count == 2
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_no_retry_on_401(self, mock_request, mock_sleep):
+        """401 is handled by the caller (token renewal), never retried here."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        mock_request.return_value = self._make_response(401)
+
+        response = _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        assert response.status_code == 401
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_no_retry_on_400(self, mock_request, mock_sleep):
+        """Other 4xx client errors are not transient and must not be retried."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        mock_request.return_value = self._make_response(400)
+
+        response = _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        assert response.status_code == 400
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_after_header_is_honored(self, mock_request, mock_sleep):
+        """A numeric Retry-After header should drive the sleep duration."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        throttled = self._make_response(429, headers={"Retry-After": "7"})
+        ok = self._make_response(200, text="ok")
+        mock_request.side_effect = [throttled, ok]
+
+        _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        assert mock_sleep.call_count == 1
+        sleep_duration = mock_sleep.call_args[0][0]
+        # Retry-After: 7 -> exactly 7s (capped at MAX_RETRY_DELAY=20).
+        assert sleep_duration == 7
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_after_is_capped(self, mock_request, mock_sleep):
+        """Retry-After above MAX_RETRY_DELAY must be clamped."""
+        from remarkable_mcp.sync import MAX_RETRY_DELAY, _http_request_with_retry
+
+        throttled = self._make_response(429, headers={"Retry-After": "9999"})
+        ok = self._make_response(200, text="ok")
+        mock_request.side_effect = [throttled, ok]
+
+        _http_request_with_retry(
+            "GET", "https://example.invalid/x", attempts=3, base_delay=0.01
+        )
+
+        sleep_duration = mock_sleep.call_args[0][0]
+        assert sleep_duration == MAX_RETRY_DELAY
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_env_var_overrides_attempts(self, mock_request, mock_sleep, monkeypatch):
+        """REMARKABLE_RETRY_ATTEMPTS env var controls default attempt count."""
+        import requests as _requests
+
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        monkeypatch.setenv("REMARKABLE_RETRY_ATTEMPTS", "5")
+        monkeypatch.setenv("REMARKABLE_RETRY_DELAY", "0.01")
+
+        mock_request.side_effect = _requests.ConnectionError("down")
+
+        with pytest.raises(_requests.ConnectionError):
+            # No explicit attempts/base_delay -> env vars must be read.
+            _http_request_with_retry("GET", "https://example.invalid/x")
+
+        assert mock_request.call_count == 5
+
+    def test_compute_sleep_uses_exponential_backoff_with_jitter(self):
+        """Without Retry-After, sleep is in [0, base*2**attempt] capped at MAX."""
+        from remarkable_mcp.sync import MAX_RETRY_DELAY, _compute_sleep
+
+        # With attempt=0, base_delay=1: window=1 -> sleep in [0, 1)
+        for _ in range(20):
+            s = _compute_sleep(attempt=0, base_delay=1.0, retry_after=None)
+            assert 0 <= s <= 1.0
+
+        # Cap is enforced.
+        s = _compute_sleep(attempt=20, base_delay=1.0, retry_after=None)
+        assert s <= MAX_RETRY_DELAY
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_renew_token_retries_on_502(self, mock_request, mock_sleep):
+        """RemarkableClient.renew_token must use the retry wrapper."""
+        from remarkable_mcp.sync import RemarkableClient
+
+        bad = self._make_response(502)
+        ok = self._make_response(200, text="fresh_user_token")
+        mock_request.side_effect = [bad, ok]
+
+        client = RemarkableClient(device_token="dev-token")
+        token = client.renew_token()
+
+        assert token == "fresh_user_token"
+        assert client.user_token == "fresh_user_token"
+        assert mock_request.call_count == 2


### PR DESCRIPTION
Closes part of #29 (retries only — periodic health-checks deferred to a follow-up PR so this change stays small and reviewable).

## Why

Every reMarkable Cloud call from this MCP currently fails the whole MCP tool invocation on any transient blip — a 503 from `internal.cloud.remarkable.com`, a TCP reset, a brief 429 during a sync burst. The user sees a hard error in their MCP client (Claude Desktop, Cursor, …) and has to retry the tool manually. In practice this makes the server feel flaky even when the cloud is only briefly degraded.

## What

Adds a single retry wrapper — `_http_request_with_retry` in `remarkable_mcp/sync.py` — and routes every outbound cloud HTTP call through it:

- `RemarkableClient._request` (sync/list/download — both the initial call and the post-401 retry after `renew_token`)
- `RemarkableClient.renew_token` (device → user token exchange)
- `register_device` (one-time code registration)

**Retry policy:**
- Retries on `requests.ConnectionError`, `requests.Timeout`, and HTTP `429 / 500 / 502 / 503 / 504`.
- Does **not** retry on `401` — that's the caller's responsibility (token renewal lives in `_request` already) — nor on any other 4xx (client errors are not transient).
- Exponential backoff with full jitter (AWS builders' library pattern): the next sleep is `Uniform(0, min(base * 2**attempt, MAX_RETRY_DELAY))`.
- Honours a numeric `Retry-After` header when present, capped at `MAX_RETRY_DELAY`.
- Hard cap per sleep: `MAX_RETRY_DELAY = 20s`. With the default `attempts=3` / `base_delay=2s` this keeps the worst-case total well below the ~60s stdio client timeout most MCP clients use.

**Configuration** (env vars, read at call time so no re-import needed):
- `REMARKABLE_RETRY_ATTEMPTS` (default `3`)
- `REMARKABLE_RETRY_DELAY` (default `2.0` seconds, the base for backoff)

**Observability:** each retry logs a warning via the module logger (`remarkable_mcp.sync`) with method, URL, failure cause, and attempt counter — useful when users report "it hung for a bit then worked".

## Tests

New `TestRetryBackoff` class (`test_server.py`) with 11 tests, `time.sleep` patched throughout so the suite stays fast:

- retry on `429`, `503`, `ConnectionError`, `Timeout` until success
- retry exhaustion → raises the last exception when all attempts threw
- retry exhaustion → returns the last response when all attempts were retryable statuses (so the caller's `raise_for_status()` / status check still surfaces it)
- no retry on `401` or `400`
- `Retry-After` header is honoured and clamped at `MAX_RETRY_DELAY`
- `REMARKABLE_RETRY_ATTEMPTS` env var overrides default attempts
- `_compute_sleep` stays within `[0, MAX_RETRY_DELAY]` across 20 samples at `attempt=0` and when `attempt` is large
- `RemarkableClient.renew_token` retries transparently through the wrapper on `502`

Also updated the two existing `TestRegistration` tests (`test_register_and_get_token`, `test_register_invalid_code`) to patch `remarkable_mcp.sync.requests.request` instead of `requests.post` — `register_device` now funnels through the wrapper which calls `requests.request(method, url, …)`. The invalid-code test additionally asserts that a `400` response is **not** retried.

## Out of scope (follow-up)

- Periodic health-checks / connection monitoring mentioned in #29 — better suited to a separate PR with its own tests and user-facing config surface.
- Caching (#28) — independent concern.