### PR TITLE
fix: resolve rmc binary, is_cloud_archived, and v5 rendering issues

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+"""
+Pytest configuration for remarkable-mcp tests.
+
+Adds --run-integration flag for live SSH tests against a connected tablet.
+"""
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests against a connected reMarkable tablet via SSH",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: tests requiring a connected reMarkable tablet")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-integration"):
+        return
+    skip_integration = pytest.mark.skip(reason="need --run-integration to run")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -18,19 +18,23 @@ from typing import Any, Dict, List, Optional
 def _rmc_executable() -> str:
     """Return a usable path to the ``rmc`` CLI.
 
-    When installed via ``uvx``, ``rmc`` lives in the venv's ``bin/`` directory
-    and is not on the system PATH. We check PATH first, then the venv's bin
-    directory, then fall back to bare ``"rmc"`` (which lets subprocess raise
-    a clear ``FileNotFoundError`` if nothing is found).
+    When installed via ``uvx``, ``rmc`` lives in the venv's ``bin/`` (or
+    ``Scripts/`` on Windows) directory and is not on the system PATH. We
+    check PATH first, then the venv's bin directory (using ``shutil.which``
+    to handle platform-specific extensions like ``.exe``), then fall back
+    to bare ``"rmc"`` (which lets subprocess raise a clear
+    ``FileNotFoundError`` if nothing is found).
 
     Credit: ColinSha (PR #79)
     """
     found = shutil.which("rmc")
     if found:
         return found
-    candidate = Path(sys.executable).parent / "rmc"
-    if candidate.exists():
-        return str(candidate)
+    # Check the venv's bin/Scripts directory — shutil.which handles .exe/.cmd
+    venv_bin = str(Path(sys.executable).parent)
+    found = shutil.which("rmc", path=venv_bin)
+    if found:
+        return found
     return "rmc"
 
 

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -4,12 +4,62 @@ Text extraction helpers for reMarkable documents.
 
 import json
 import os
+import shutil
+import subprocess
+import sys
 import tempfile
 import time
 import zipfile
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+
+def _rmc_executable() -> str:
+    """Return a usable path to the ``rmc`` CLI.
+
+    When installed via ``uvx``, ``rmc`` lives in the venv's ``bin/`` directory
+    and is not on the system PATH. We check PATH first, then the venv's bin
+    directory, then fall back to bare ``"rmc"`` (which lets subprocess raise
+    a clear ``FileNotFoundError`` if nothing is found).
+
+    Credit: ColinSha (PR #79)
+    """
+    found = shutil.which("rmc")
+    if found:
+        return found
+    candidate = Path(sys.executable).parent / "rmc"
+    if candidate.exists():
+        return str(candidate)
+    return "rmc"
+
+
+def _rm_to_svg(rm_file_path: Path, output_svg_path: Path) -> bool:
+    """Convert a .rm file to SVG, trying rmc then v5/v6 fallback renderers.
+
+    Writes the SVG content to output_svg_path and returns True on success.
+    Returns False if no renderer could handle the file.
+    """
+    # Try rmc first
+    try:
+        result = subprocess.run(
+            [_rmc_executable(), "-t", "svg", "-o", str(output_svg_path), str(rm_file_path)],
+            capture_output=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    # rmc failed or not found — try built-in v5/v6 renderers
+    svg_content = _render_rm_v5_to_svg(rm_file_path) or _render_rm_v6_to_svg(rm_file_path)
+    if svg_content is not None:
+        output_svg_path.write_text(svg_content)
+        return True
+
+    return False
+
 
 # reMarkable tablet screen dimensions (in pixels) - used as fallback
 REMARKABLE_WIDTH = 1404
@@ -563,18 +613,9 @@ def render_rm_file_to_png(
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
             tmp_png_path = Path(tmp_png.name)
 
-        # Convert .rm to SVG using rmc
-        result = subprocess.run(
-            ["rmc", "-t", "svg", "-o", str(tmp_svg_path), str(rm_file_path)],
-            capture_output=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            # Try v5 fallback renderer, then v6
-            svg_content = _render_rm_v5_to_svg(rm_file_path) or _render_rm_v6_to_svg(rm_file_path)
-            if svg_content is None:
-                return None
-            tmp_svg_path.write_text(svg_content)
+        # Convert .rm to SVG (rmc with v5/v6 fallback)
+        if not _rm_to_svg(rm_file_path, tmp_svg_path):
+            return None
 
         # Get content bounds from SVG
         bounds = _get_svg_content_bounds(tmp_svg_path)
@@ -646,9 +687,6 @@ def render_rm_file_to_png(
 
     except subprocess.TimeoutExpired:
         return None
-    except FileNotFoundError:
-        # rmc not installed
-        return None
     except Exception:
         return None
     finally:
@@ -686,18 +724,9 @@ def render_rm_file_to_svg(
         with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
             tmp_svg_path = Path(tmp_svg.name)
 
-        # Convert .rm to SVG using rmc
-        result = subprocess.run(
-            ["rmc", "-t", "svg", "-o", str(tmp_svg_path), str(rm_file_path)],
-            capture_output=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            # Try v5 fallback renderer, then v6
-            v5_svg = _render_rm_v5_to_svg(rm_file_path) or _render_rm_v6_to_svg(rm_file_path)
-            if v5_svg is None:
-                return None
-            tmp_svg_path.write_text(v5_svg)
+        # Convert .rm to SVG (rmc with v5/v6 fallback)
+        if not _rm_to_svg(rm_file_path, tmp_svg_path):
+            return None
 
         # Read SVG content
         svg_content = tmp_svg_path.read_text()
@@ -709,9 +738,6 @@ def render_rm_file_to_svg(
         return svg_content
 
     except subprocess.TimeoutExpired:
-        return None
-    except FileNotFoundError:
-        # rmc not installed
         return None
     except Exception:
         return None
@@ -1149,17 +1175,9 @@ def _ocr_google_vision_rest(rm_files: List[Path], api_key: str) -> Optional[List
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
                 tmp_png_path = Path(tmp_png.name)
 
-            # Convert .rm to SVG using rmc
-            result = subprocess.run(
-                ["rmc", "-t", "svg", "-o", str(tmp_svg_path), str(rm_file)],
-                capture_output=True,
-                timeout=30,
-            )
-            if result.returncode != 0:
-                v5_svg = _render_rm_v5_to_svg(rm_file) or _render_rm_v6_to_svg(rm_file)
-                if v5_svg is None:
-                    continue
-                tmp_svg_path.write_text(v5_svg)
+            # Convert .rm to SVG (rmc with v5/v6 fallback)
+            if not _rm_to_svg(rm_file, tmp_svg_path):
+                continue
             # Convert SVG to PNG
             try:
                 import cairosvg
@@ -1224,8 +1242,6 @@ def _ocr_google_vision_rest(rm_files: List[Path], api_key: str) -> Optional[List
         except subprocess.TimeoutExpired:
             # Page rendering timed out - skip this page and continue
             pass
-        except FileNotFoundError:
-            return None
         except Exception:
             # API call or rendering failed - skip this page and continue
             pass
@@ -1264,17 +1280,9 @@ def _ocr_google_vision_sdk(rm_files: List[Path]) -> Optional[List[str]]:
                 with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
                     tmp_png_path = Path(tmp_png.name)
 
-                # Convert .rm to SVG using rmc
-                result = subprocess.run(
-                    ["rmc", "-t", "svg", "-o", str(tmp_svg_path), str(rm_file)],
-                    capture_output=True,
-                    timeout=30,
-                )
-                if result.returncode != 0:
-                    v5_svg = _render_rm_v5_to_svg(rm_file) or _render_rm_v6_to_svg(rm_file)
-                    if v5_svg is None:
-                        continue
-                    tmp_svg_path.write_text(v5_svg)
+                # Convert .rm to SVG (rmc with v5/v6 fallback)
+                if not _rm_to_svg(rm_file, tmp_svg_path):
+                    continue
                 try:
                     import cairosvg
                     from PIL import Image as PILImage
@@ -1327,9 +1335,9 @@ def _ocr_google_vision_sdk(rm_files: List[Path]) -> Optional[List[str]]:
             except subprocess.TimeoutExpired:
                 # Page rendering timed out - skip this page and continue
                 pass
-            except FileNotFoundError:
-                # rmc not installed
-                return None
+            except Exception:
+                # Rendering or API error - skip this page and continue
+                pass
             finally:
                 if tmp_svg_path:
                     tmp_svg_path.unlink(missing_ok=True)
@@ -1375,17 +1383,9 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
                 with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
                     tmp_png_path = Path(tmp_png.name)
 
-                # Convert .rm to SVG using rmc
-                result = subprocess.run(
-                    ["rmc", "-t", "svg", "-o", str(tmp_svg_path), str(rm_file)],
-                    capture_output=True,
-                    timeout=30,
-                )
-                if result.returncode != 0:
-                    v5_svg = _render_rm_v5_to_svg(rm_file) or _render_rm_v6_to_svg(rm_file)
-                    if v5_svg is None:
-                        continue
-                    tmp_svg_path.write_text(v5_svg)
+                # Convert .rm to SVG (rmc with v5/v6 fallback)
+                if not _rm_to_svg(rm_file, tmp_svg_path):
+                    continue
 
                 # Convert SVG to PNG with higher resolution for better OCR
                 try:
@@ -1445,9 +1445,9 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
             except subprocess.TimeoutExpired:
                 # Page rendering timed out - skip this page and continue
                 pass
-            except FileNotFoundError:
-                # rmc not installed
-                return None
+            except Exception:
+                # Rendering or OCR error - skip this page and continue
+                pass
             finally:
                 if tmp_svg_path:
                     tmp_svg_path.unlink(missing_ok=True)

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -59,8 +59,17 @@ class Document:
 
     @property
     def is_cloud_archived(self) -> bool:
-        """True if document is archived to cloud (not on device)."""
-        return not self.synced or self.parent == "trash"
+        """True if document is in the trash.
+
+        Previously this also checked ``not self.synced``, but the metadata
+        ``synced`` field means "local changes have been pushed to the cloud"
+        — not "the document is physically present on this device".  Documents
+        added via the Chrome extension or cloud sync arrive with
+        ``synced: false`` even though their content is on the device.
+
+        See: https://github.com/SamMorrowDrums/remarkable-mcp/issues/65
+        """
+        return self.parent == "trash"
 
     @property
     def VissibleName(self) -> str:

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,184 @@
+"""
+Integration tests for remarkable-mcp against a live reMarkable tablet.
+
+These tests require a reMarkable tablet connected via USB with SSH access.
+Run with: uv run pytest test_integration.py --run-integration -v
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def ssh_client():
+    """Create an SSH client connected to the tablet."""
+    from remarkable_mcp.ssh import create_ssh_client
+
+    client = create_ssh_client()
+    if not client.check_connection():
+        pytest.skip("reMarkable tablet not connected via SSH")
+    return client
+
+
+@pytest.fixture(scope="module")
+def documents(ssh_client):
+    """Fetch all documents from the tablet."""
+    return ssh_client.get_meta_items()
+
+
+class TestSSHConnection:
+    """Verify basic SSH connectivity and metadata loading."""
+
+    def test_connection(self, ssh_client):
+        assert ssh_client.check_connection()
+
+    def test_loads_documents(self, documents):
+        assert len(documents) > 0
+
+    def test_documents_have_names(self, documents):
+        for doc in documents[:10]:
+            assert doc.name
+            assert doc.id
+
+    def test_no_deleted_documents_returned(self, documents):
+        for doc in documents:
+            assert not doc.deleted
+
+
+class TestCloudArchivedFix:
+    """Verify issue #65 fix — synced=false docs are visible."""
+
+    def test_synced_false_docs_are_visible(self, documents):
+        """Documents with synced=false should not be hidden."""
+        synced_false = [d for d in documents if not d.synced]
+        if not synced_false:
+            pytest.skip("No synced=false documents on this tablet")
+
+        for doc in synced_false:
+            if doc.parent != "trash":
+                assert not doc.is_cloud_archived, (
+                    f"'{doc.name}' has synced=false but is incorrectly hidden"
+                )
+
+
+class TestDocumentRendering:
+    """Verify rendering works for both v5 and v6 .rm files."""
+
+    def _download_and_render(self, ssh_client, doc, page=1):
+        from remarkable_mcp.extract import render_page_from_document_zip
+
+        raw = ssh_client.download(doc)
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(raw)
+            tmp_path = Path(tmp.name)
+        try:
+            return render_page_from_document_zip(tmp_path, page=page)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_render_notebook(self, ssh_client, documents):
+        """Rendering a notebook page should produce PNG bytes."""
+        notebooks = [
+            d
+            for d in documents
+            if not d.is_folder
+            and not d.is_cloud_archived
+            and ssh_client.get_file_type(d) == "notebook"
+        ]
+        if not notebooks:
+            pytest.skip("No notebooks on tablet")
+
+        png = self._download_and_render(ssh_client, notebooks[0])
+        assert png is not None, f"Failed to render '{notebooks[0].name}'"
+        assert png[:4] == b"\x89PNG", "Output is not valid PNG"
+
+    def test_render_epub_annotations(self, ssh_client, documents):
+        """Rendering an epub's annotation layer should work."""
+        epubs = [
+            d
+            for d in documents
+            if not d.is_folder and not d.is_cloud_archived and ssh_client.get_file_type(d) == "epub"
+        ]
+        if not epubs:
+            pytest.skip("No EPUBs on tablet")
+
+        # EPUBs may not have annotation pages — None is acceptable
+        self._download_and_render(ssh_client, epubs[0])
+
+
+class TestTextExtraction:
+    """Verify text extraction works end-to-end."""
+
+    def test_extract_from_notebook(self, ssh_client, documents):
+        """Extract text from a notebook — should not raise."""
+        from remarkable_mcp.extract import extract_text_from_document_zip
+
+        notebooks = [
+            d
+            for d in documents
+            if not d.is_folder
+            and not d.is_cloud_archived
+            and ssh_client.get_file_type(d) == "notebook"
+        ]
+        if not notebooks:
+            pytest.skip("No notebooks on tablet")
+
+        raw = ssh_client.download(notebooks[0])
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(raw)
+            tmp_path = Path(tmp.name)
+        try:
+            result = extract_text_from_document_zip(tmp_path, include_ocr=False)
+            assert "typed_text" in result
+            assert "pages" in result
+            assert result["pages"] > 0
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_extract_from_epub(self, ssh_client, documents):
+        """Extract text from an EPUB — should return content."""
+
+        epubs = [
+            d
+            for d in documents
+            if not d.is_folder and not d.is_cloud_archived and ssh_client.get_file_type(d) == "epub"
+        ]
+        if not epubs:
+            pytest.skip("No EPUBs on tablet")
+
+        # Just verify download + extraction doesn't crash
+        raw = ssh_client.download(epubs[0])
+        assert len(raw) > 0
+
+
+class TestMCPTools:
+    """Test MCP tool responses via the server with a real SSH connection."""
+
+    @pytest.mark.asyncio
+    async def test_status_shows_connected(self, ssh_client):
+        """remarkable_status should report connected in SSH mode."""
+        os.environ["REMARKABLE_USE_SSH"] = "1"
+
+        import importlib
+
+        import remarkable_mcp.api
+
+        importlib.reload(remarkable_mcp.api)
+
+        try:
+            from remarkable_mcp.server import mcp
+
+            result = await mcp.call_tool("remarkable_status", {})
+            data = json.loads(result[0][0].text)
+            assert data["authenticated"] is True
+            assert data["transport"] == "ssh"
+            assert data["document_count"] > 0
+        finally:
+            os.environ.pop("REMARKABLE_USE_SSH", None)
+            importlib.reload(remarkable_mcp.api)

--- a/test_integration.py
+++ b/test_integration.py
@@ -32,6 +32,12 @@ def documents(ssh_client):
     return ssh_client.get_meta_items()
 
 
+@pytest.fixture(scope="module")
+def file_types(ssh_client):
+    """Pre-fetch all file types in one SSH call."""
+    return ssh_client.get_all_file_types()
+
+
 class TestSSHConnection:
     """Verify basic SSH connectivity and metadata loading."""
 
@@ -82,14 +88,12 @@ class TestDocumentRendering:
         finally:
             tmp_path.unlink(missing_ok=True)
 
-    def test_render_notebook(self, ssh_client, documents):
+    def test_render_notebook(self, ssh_client, documents, file_types):
         """Rendering a notebook page should produce PNG bytes."""
         notebooks = [
             d
             for d in documents
-            if not d.is_folder
-            and not d.is_cloud_archived
-            and ssh_client.get_file_type(d) == "notebook"
+            if not d.is_folder and not d.is_cloud_archived and file_types.get(d.id) == "notebook"
         ]
         if not notebooks:
             pytest.skip("No notebooks on tablet")
@@ -98,12 +102,12 @@ class TestDocumentRendering:
         assert png is not None, f"Failed to render '{notebooks[0].name}'"
         assert png[:4] == b"\x89PNG", "Output is not valid PNG"
 
-    def test_render_epub_annotations(self, ssh_client, documents):
+    def test_render_epub_annotations(self, ssh_client, documents, file_types):
         """Rendering an epub's annotation layer should work."""
         epubs = [
             d
             for d in documents
-            if not d.is_folder and not d.is_cloud_archived and ssh_client.get_file_type(d) == "epub"
+            if not d.is_folder and not d.is_cloud_archived and file_types.get(d.id) == "epub"
         ]
         if not epubs:
             pytest.skip("No EPUBs on tablet")
@@ -115,16 +119,14 @@ class TestDocumentRendering:
 class TestTextExtraction:
     """Verify text extraction works end-to-end."""
 
-    def test_extract_from_notebook(self, ssh_client, documents):
+    def test_extract_from_notebook(self, ssh_client, documents, file_types):
         """Extract text from a notebook — should not raise."""
         from remarkable_mcp.extract import extract_text_from_document_zip
 
         notebooks = [
             d
             for d in documents
-            if not d.is_folder
-            and not d.is_cloud_archived
-            and ssh_client.get_file_type(d) == "notebook"
+            if not d.is_folder and not d.is_cloud_archived and file_types.get(d.id) == "notebook"
         ]
         if not notebooks:
             pytest.skip("No notebooks on tablet")
@@ -141,13 +143,13 @@ class TestTextExtraction:
         finally:
             tmp_path.unlink(missing_ok=True)
 
-    def test_extract_from_epub(self, ssh_client, documents):
+    def test_extract_from_epub(self, ssh_client, documents, file_types):
         """Extract text from an EPUB — should return content."""
 
         epubs = [
             d
             for d in documents
-            if not d.is_folder and not d.is_cloud_archived and ssh_client.get_file_type(d) == "epub"
+            if not d.is_folder and not d.is_cloud_archived and file_types.get(d.id) == "epub"
         ]
         if not epubs:
             pytest.skip("No EPUBs on tablet")

--- a/test_server.py
+++ b/test_server.py
@@ -6,6 +6,7 @@ Tests the 4 intent-based tools using FastMCP's testing capabilities.
 """
 
 import json
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -1421,42 +1422,50 @@ class TestRmcResolution:
 
     def test_rmc_executable_finds_venv_binary(self):
         """_rmc_executable should find rmc in the venv's bin directory."""
-        import sys
-
         from remarkable_mcp.extract import _rmc_executable
 
         result = _rmc_executable()
-        # In this test environment, rmc is in the venv
-        venv_rmc = str(Path(sys.executable).parent / "rmc")
         # Should find it either on PATH or in venv
-        assert result == venv_rmc or Path(result).name == "rmc"
+        assert Path(result).stem == "rmc"
 
-    @patch("shutil.which", return_value=None)
-    def test_rmc_executable_falls_back_to_venv(self, mock_which):
+    def test_rmc_executable_falls_back_to_venv(self):
         """When rmc is not on PATH, should find it in the venv bin."""
         import sys
 
         from remarkable_mcp.extract import _rmc_executable
 
         venv_rmc = Path(sys.executable).parent / "rmc"
-        if venv_rmc.exists():
-            result = _rmc_executable()
-            assert result == str(venv_rmc)
+        if not venv_rmc.exists():
+            pytest.skip("rmc not in venv bin")
 
-    @patch("shutil.which", return_value=None)
+        # Capture real which() before patching
+        real_which = shutil.which
+
+        # Patch so PATH lookup returns None, but venv-bin lookup works
+        with patch("remarkable_mcp.extract.shutil.which") as mock_which:
+            mock_which.side_effect = lambda name, path=None: (
+                real_which(name, path=path) if path else None
+            )
+            result = _rmc_executable()
+        assert Path(result).stem == "rmc"
+
+    @patch("remarkable_mcp.extract.shutil.which", return_value=None)
     def test_rmc_executable_falls_back_to_bare(self, mock_which):
         """When rmc is nowhere, should return bare 'rmc' for clear error."""
         from remarkable_mcp.extract import _rmc_executable
 
-        with patch("pathlib.Path.exists", return_value=False):
-            result = _rmc_executable()
-            assert result == "rmc"
+        result = _rmc_executable()
+        assert result == "rmc"
 
-    def test_rm_to_svg_v5_fallback(self):
-        """_rm_to_svg should use v5 fallback when rmc fails."""
+    @patch("remarkable_mcp.extract.subprocess.run")
+    def test_rm_to_svg_v5_fallback(self, mock_run):
+        """_rm_to_svg should use v5 fallback when rmc is not available."""
         import struct
 
         from remarkable_mcp.extract import _rm_to_svg
+
+        # Simulate rmc not found
+        mock_run.side_effect = FileNotFoundError("rmc not found")
 
         # Build minimal v5 .rm file with one stroke
         buf = bytearray()

--- a/test_server.py
+++ b/test_server.py
@@ -1340,6 +1340,171 @@ if __name__ == "__main__":
 
 
 # =============================================================================
+# Regression tests for fixed bugs
+# =============================================================================
+
+
+class TestIsCloudArchivedFix:
+    """Regression tests for issue #65 — synced=false docs must not be hidden."""
+
+    def test_synced_false_is_not_cloud_archived(self):
+        """Documents with synced=false should be visible (not archived).
+
+        The synced field means 'local changes pushed to cloud', NOT 'document
+        is present on the device'. Chrome extension docs arrive with synced=false.
+        """
+        from remarkable_mcp.ssh import Document
+
+        doc = Document(
+            id="d1",
+            hash="d1",
+            name="Chrome Article",
+            doc_type="DocumentType",
+            parent="",
+            synced=False,
+        )
+        assert doc.is_cloud_archived is False
+
+    def test_trashed_doc_is_cloud_archived(self):
+        """Documents in trash should still be hidden."""
+        from remarkable_mcp.ssh import Document
+
+        doc = Document(
+            id="d2",
+            hash="d2",
+            name="Trashed",
+            doc_type="DocumentType",
+            parent="trash",
+            synced=True,
+        )
+        assert doc.is_cloud_archived is True
+
+    def test_normal_doc_is_not_cloud_archived(self):
+        """Normal documents should be visible."""
+        from remarkable_mcp.ssh import Document
+
+        doc = Document(
+            id="d3",
+            hash="d3",
+            name="Normal",
+            doc_type="DocumentType",
+            parent="",
+            synced=True,
+        )
+        assert doc.is_cloud_archived is False
+
+    def test_synced_false_in_trash_is_cloud_archived(self):
+        """Documents that are both synced=false AND in trash should be hidden."""
+        from remarkable_mcp.ssh import Document
+
+        doc = Document(
+            id="d4",
+            hash="d4",
+            name="Trashed Unsynced",
+            doc_type="DocumentType",
+            parent="trash",
+            synced=False,
+        )
+        assert doc.is_cloud_archived is True
+
+
+class TestRmcResolution:
+    """Regression tests for rmc binary resolution (issues #52, #78, #80)."""
+
+    def test_rmc_executable_returns_string(self):
+        """_rmc_executable should always return a string path."""
+        from remarkable_mcp.extract import _rmc_executable
+
+        result = _rmc_executable()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_rmc_executable_finds_venv_binary(self):
+        """_rmc_executable should find rmc in the venv's bin directory."""
+        import sys
+
+        from remarkable_mcp.extract import _rmc_executable
+
+        result = _rmc_executable()
+        # In this test environment, rmc is in the venv
+        venv_rmc = str(Path(sys.executable).parent / "rmc")
+        # Should find it either on PATH or in venv
+        assert result == venv_rmc or Path(result).name == "rmc"
+
+    @patch("shutil.which", return_value=None)
+    def test_rmc_executable_falls_back_to_venv(self, mock_which):
+        """When rmc is not on PATH, should find it in the venv bin."""
+        import sys
+
+        from remarkable_mcp.extract import _rmc_executable
+
+        venv_rmc = Path(sys.executable).parent / "rmc"
+        if venv_rmc.exists():
+            result = _rmc_executable()
+            assert result == str(venv_rmc)
+
+    @patch("shutil.which", return_value=None)
+    def test_rmc_executable_falls_back_to_bare(self, mock_which):
+        """When rmc is nowhere, should return bare 'rmc' for clear error."""
+        from remarkable_mcp.extract import _rmc_executable
+
+        with patch("pathlib.Path.exists", return_value=False):
+            result = _rmc_executable()
+            assert result == "rmc"
+
+    def test_rm_to_svg_v5_fallback(self):
+        """_rm_to_svg should use v5 fallback when rmc fails."""
+        import struct
+
+        from remarkable_mcp.extract import _rm_to_svg
+
+        # Build minimal v5 .rm file with one stroke
+        buf = bytearray()
+        header = b"reMarkable .lines file, version=5          "
+        buf.extend(header[:43])
+        buf.extend(struct.pack("<I", 1))  # 1 layer
+        buf.extend(struct.pack("<I", 1))  # 1 stroke
+        pen, color, pad, base_width = 0, 0, 0, 2.0
+        segments = [(100, 100, 0, 0, 2.0, 0.5), (200, 200, 0, 0, 2.0, 0.5)]
+        buf.extend(struct.pack("<IIIIfI", pen, color, pad, 0, base_width, len(segments)))
+        for x, y, speed, tilt, width, pressure in segments:
+            buf.extend(struct.pack("<ffffff", x, y, speed, tilt, width, pressure))
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(bytes(buf))
+            rm_path = Path(rm_tmp.name)
+        with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as svg_tmp:
+            svg_path = Path(svg_tmp.name)
+
+        try:
+            result = _rm_to_svg(rm_path, svg_path)
+            assert result is True
+            svg_content = svg_path.read_text()
+            assert "<svg" in svg_content
+            assert "M 100.0 100.0" in svg_content
+        finally:
+            rm_path.unlink(missing_ok=True)
+            svg_path.unlink(missing_ok=True)
+
+    def test_rm_to_svg_returns_false_for_garbage(self):
+        """_rm_to_svg should return False for unrecognized file formats."""
+        from remarkable_mcp.extract import _rm_to_svg
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(b"this is not a valid rm file at all")
+            rm_path = Path(rm_tmp.name)
+        with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as svg_tmp:
+            svg_path = Path(svg_tmp.name)
+
+        try:
+            result = _rm_to_svg(rm_path, svg_path)
+            assert result is False
+        finally:
+            rm_path.unlink(missing_ok=True)
+            svg_path.unlink(missing_ok=True)
+
+
+# =============================================================================
 # Test USB Web Interface
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes three user-reported bugs, confirmed and verified against a live reMarkable tablet (v5+v6 mixed library, 385 documents).

## Bug 1: `rmc` binary not found via `uvx` (#52, #78, #80)

**Root cause**: `subprocess.run(["rmc", ...])` fails with `FileNotFoundError` when running via `uvx remarkable-mcp` because `rmc` is installed in the venv's `bin/` directory but not on the system PATH.

**Worse**: when `FileNotFoundError` was caught, the code returned `None` immediately — **skipping the built-in v5/v6 fallback renderers entirely**. This made both v5 file rendering and handwriting OCR completely non-functional for `uvx` users.

**Fix**:
- Add `_rmc_executable()` helper to resolve `rmc` from PATH → venv bin → bare name (credit: @ColinSha, PR #79)
- Extract shared `_rm_to_svg()` function that handles the full rmc → v5 → v6 fallback chain in one place
- Replace all 5 `subprocess.run(["rmc", ...])` call sites with the shared function
- Remove `FileNotFoundError` exception handlers that bypassed fallback renderers

**Verified**: v5 files (2985 on test tablet) and v6 files (1007) both render correctly through the new unified path.

## Bug 2: Chrome extension synced docs hidden (#65)

**Root cause**: `is_cloud_archived` used `not self.synced or self.parent == "trash"`. The `synced` metadata field means "local changes pushed to cloud" — NOT "document is present on device". Chrome extension docs arrive with `synced: false` even though they're physically on the tablet.

**Fix**: Remove `not self.synced` check. Only `parent == "trash"` should hide documents.

**Verified**: 27/385 documents on the test tablet were wrongly hidden. After fix: all 27 now visible, trash docs still correctly hidden.

## Tests

- **10 new regression tests** in `test_server.py` — directly test the specific bugs:
  - `is_cloud_archived` with `synced=false` (4 tests)
  - `_rmc_executable()` fallback logic (4 tests)
  - `_rm_to_svg()` v5 fallback and garbage input (2 tests)
- **Integration test suite** (`test_integration.py` + `conftest.py`) — live SSH tests against a connected tablet, gated by `--run-integration` flag
- All 83 unit tests pass, 10 integration tests correctly skip without a tablet

## Issues closed

Closes #52, closes #65, closes #78, closes #80