### PR TITLE
fix: security bumps + retry backoff for cloud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,19 @@ Default is `#FBFBFB` (reMarkable paper color). This affects both the `remarkable
 
 ---
 
+### Retry Configuration
+
+Cloud API requests automatically retry on transient failures (HTTP 429, 500, 502, 503, 504) and network errors with exponential backoff and jitter. You can tune this via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REMARKABLE_RETRY_ATTEMPTS` | `3` | Maximum number of request attempts (minimum 1) |
+| `REMARKABLE_RETRY_DELAY` | `2.0` | Base delay in seconds for exponential backoff |
+
+The retry logic honours the `Retry-After` header from rate-limited responses, capped at 20 seconds. Auth failures (401) are not retried — they trigger automatic token renewal instead.
+
+---
+
 ## Use Cases
 
 ### Research & Writing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "Pillow>=10.0.0",
     "rmc>=0.3.0",
     "requests>=2.28.0",
-    "cairosvg>=2.8.2",
-    "pymupdf>=1.24.0",
+    "cairosvg>=2.9.0",
+    "pymupdf>=1.26.7",
     "ebooklib>=0.18",
     "beautifulsoup4>=4.12.0",
 ]

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -8,12 +8,25 @@ Based on the protocol used by ddvk/rmapi.
 """
 
 import json
+import logging
+import math
+import os
+import random
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import requests
+
+logger = logging.getLogger(__name__)
+
+# Retry configuration
+DEFAULT_RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_DELAY = 2.0
+MAX_RETRY_DELAY = 20.0
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 # API endpoints
 # Note: my.remarkable.com endpoints redirect to doesnotexist.remarkable.com
@@ -25,6 +38,104 @@ USER_TOKEN_URL = f"{AUTH_HOST}/token/json/2/user/new"
 SYNC_HOST = "https://internal.cloud.remarkable.com"
 ROOT_URL = f"{SYNC_HOST}/sync/v4/root"
 FILES_URL = f"{SYNC_HOST}/sync/v3/files"
+
+
+def _get_retry_attempts() -> int:
+    """Get the number of retry attempts from env or default."""
+    try:
+        val = int(os.environ.get("REMARKABLE_RETRY_ATTEMPTS", DEFAULT_RETRY_ATTEMPTS))
+        return max(val, 1)
+    except (ValueError, TypeError):
+        return DEFAULT_RETRY_ATTEMPTS
+
+
+def _get_retry_delay() -> float:
+    """Get the base retry delay from env or default."""
+    try:
+        val = float(os.environ.get("REMARKABLE_RETRY_DELAY", DEFAULT_RETRY_DELAY))
+        return max(val, 0.0)
+    except (ValueError, TypeError):
+        return DEFAULT_RETRY_DELAY
+
+
+def _parse_retry_after(response: requests.Response) -> Optional[float]:
+    """Parse the Retry-After header, returning seconds or None.
+
+    Only the numeric form (seconds) is supported; HTTP-date values
+    and invalid/negative/non-finite values fall back to jittered backoff.
+    """
+    header = response.headers.get("Retry-After")
+    if header is None:
+        return None
+    try:
+        val = float(header)
+    except (ValueError, TypeError):
+        return None
+    if not math.isfinite(val) or val < 0:
+        return None
+    return min(val, MAX_RETRY_DELAY)
+
+
+def _compute_sleep(base_delay: float, attempt: int) -> float:
+    """Compute sleep duration with exponential backoff and full jitter.
+
+    Uses AWS's "full jitter" strategy: sleep uniformly in [0, cap] where
+    cap = min(base * 2**attempt, MAX_RETRY_DELAY). This avoids
+    thundering-herd retries from concurrent clients.
+    """
+    return random.uniform(0, min(base_delay * 2**attempt, MAX_RETRY_DELAY))
+
+
+def _http_request_with_retry(method: str, url: str, **kwargs) -> requests.Response:
+    """
+    Make an HTTP request with exponential backoff and jitter.
+
+    Retries on ConnectionError, Timeout, and retryable HTTP status codes
+    (429, 500, 502, 503, 504). Does NOT retry on 401 or other 4xx errors.
+    """
+    max_attempts = _get_retry_attempts()
+    base_delay = _get_retry_delay()
+    last_exception: Optional[Exception] = None
+
+    for attempt in range(max_attempts):
+        try:
+            response = requests.request(method, url, **kwargs)
+
+            if response.status_code not in RETRYABLE_STATUS_CODES:
+                return response
+
+            if attempt < max_attempts - 1:
+                retry_after = _parse_retry_after(response)
+                sleep_time = (
+                    retry_after if retry_after is not None else _compute_sleep(base_delay, attempt)
+                )
+                logger.warning(
+                    "Retryable HTTP %d from %s (attempt %d/%d), sleeping %.1fs",
+                    response.status_code,
+                    url,
+                    attempt + 1,
+                    max_attempts,
+                    sleep_time,
+                )
+                time.sleep(sleep_time)
+            else:
+                return response
+
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            last_exception = exc
+            if attempt < max_attempts - 1:
+                sleep_time = _compute_sleep(base_delay, attempt)
+                logger.warning(
+                    "%s for %s (attempt %d/%d), sleeping %.1fs",
+                    type(exc).__name__,
+                    url,
+                    attempt + 1,
+                    max_attempts,
+                    sleep_time,
+                )
+                time.sleep(sleep_time)
+
+    raise last_exception  # noqa: TRY302  # exhausted retries, re-raise last connection error
 
 
 @dataclass
@@ -96,7 +207,7 @@ class RemarkableClient:
         headers = {"Authorization": f"Bearer {self.device_token}"}
 
         try:
-            response = requests.post(USER_TOKEN_URL, headers=headers, timeout=30)
+            response = _http_request_with_retry("POST", USER_TOKEN_URL, headers=headers, timeout=30)
             if response.status_code == 200 and response.text:
                 self.user_token = response.text.strip()
                 return self.user_token
@@ -115,13 +226,13 @@ class RemarkableClient:
             self.renew_token()
 
         headers = {"Authorization": f"Bearer {self.user_token}"}
-        response = requests.request(method, url, headers=headers, timeout=60)
+        response = _http_request_with_retry(method, url, headers=headers, timeout=60)
 
         if response.status_code == 401:
             # Token expired, try to renew
             self.renew_token()
             headers = {"Authorization": f"Bearer {self.user_token}"}
-            response = requests.request(method, url, headers=headers, timeout=60)
+            response = _http_request_with_retry(method, url, headers=headers, timeout=60)
 
         return response
 
@@ -306,7 +417,7 @@ def register_device(one_time_code: str) -> Dict[str, str]:
     }
 
     try:
-        response = requests.post(DEVICE_TOKEN_URL, json=body, timeout=30)
+        response = _http_request_with_retry("POST", DEVICE_TOKEN_URL, json=body, timeout=30)
         if response.status_code == 200 and response.text:
             device_token = response.text.strip()
             return {"devicetoken": device_token, "usertoken": ""}

--- a/test_server.py
+++ b/test_server.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from remarkable_mcp.api import (
     get_item_path,
@@ -627,15 +628,16 @@ class TestRemarkableImage:
 class TestRegistration:
     """Test registration functionality."""
 
-    @patch("requests.post")
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
     @patch("pathlib.Path.write_text")
-    def test_register_and_get_token(self, mock_write_text, mock_post):
+    def test_register_and_get_token(self, mock_write_text, mock_request, mock_sleep):
         """Test registration process."""
         # Mock successful API response
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = "test_device_token_12345"
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         token = register_and_get_token("test_code")
 
@@ -647,18 +649,19 @@ class TestRegistration:
         assert "usertoken" in token_data
 
         # Verify API was called
-        mock_post.assert_called_once()
-        call_args = mock_post.call_args
-        assert "webapp-prod.cloud.remarkable.engineering" in call_args[0][0]
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        assert "webapp-prod.cloud.remarkable.engineering" in call_args[0][1]
 
-    @patch("requests.post")
-    def test_register_invalid_code(self, mock_post):
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_register_invalid_code(self, mock_request, mock_sleep):
         """Test registration with invalid/expired code."""
         # Mock 400 response (invalid code)
         mock_response = Mock()
         mock_response.status_code = 400
         mock_response.text = ""
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         with pytest.raises(RuntimeError, match="Registration failed"):
             register_and_get_token("invalid_code")
@@ -1677,3 +1680,146 @@ class TestUSBWebInterface:
                 import remarkable_mcp.api
 
                 importlib.reload(remarkable_mcp.api)
+
+
+# =============================================================================
+# Test Retry Backoff
+# =============================================================================
+
+
+class TestRetryBackoff:
+    """Test retry with exponential backoff for cloud API requests."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_retry_env(self, monkeypatch):
+        """Ensure retry env vars are unset so tests use defaults."""
+        monkeypatch.delenv("REMARKABLE_RETRY_ATTEMPTS", raising=False)
+        monkeypatch.delenv("REMARKABLE_RETRY_DELAY", raising=False)
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_succeeds_after_transient_503(self, mock_request, mock_sleep):
+        """Retry succeeds when a transient 503 clears on the second attempt."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        fail_response = Mock()
+        fail_response.status_code = 503
+        fail_response.headers = {}
+
+        ok_response = Mock()
+        ok_response.status_code = 200
+
+        mock_request.side_effect = [fail_response, ok_response]
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 200
+        assert mock_request.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_exhaustion_raises_last_exception(self, mock_request, mock_sleep):
+        """After exhausting retries on connection errors, the last exception is raised."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        mock_request.side_effect = requests.ConnectionError("refused")
+
+        with pytest.raises(requests.ConnectionError, match="refused"):
+            _http_request_with_retry("GET", "https://example.com/api")
+
+        assert mock_request.call_count == 3  # DEFAULT_RETRY_ATTEMPTS
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_no_retry_on_401(self, mock_request, mock_sleep):
+        """401 is not retried - it is handled by the caller's token renewal."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        response_401 = Mock()
+        response_401.status_code = 401
+
+        mock_request.return_value = response_401
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 401
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_no_retry_on_400(self, mock_request, mock_sleep):
+        """400 is not retried - client errors are not transient."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        response_400 = Mock()
+        response_400.status_code = 400
+
+        mock_request.return_value = response_400
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 400
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_after_header_honoured(self, mock_request, mock_sleep):
+        """Retry-After header value is used as the sleep duration."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        rate_limited = Mock()
+        rate_limited.status_code = 429
+        rate_limited.headers = {"Retry-After": "5"}
+
+        ok_response = Mock()
+        ok_response.status_code = 200
+
+        mock_request.side_effect = [rate_limited, ok_response]
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 200
+        mock_sleep.assert_called_once_with(5.0)
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_after_header_capped_at_max(self, mock_request, mock_sleep):
+        """Retry-After values above MAX_RETRY_DELAY are capped."""
+        from remarkable_mcp.sync import MAX_RETRY_DELAY, _http_request_with_retry
+
+        rate_limited = Mock()
+        rate_limited.status_code = 429
+        rate_limited.headers = {"Retry-After": "999"}
+
+        ok_response = Mock()
+        ok_response.status_code = 200
+
+        mock_request.side_effect = [rate_limited, ok_response]
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 200
+        mock_sleep.assert_called_once_with(MAX_RETRY_DELAY)
+
+    def test_compute_sleep_within_bounds(self):
+        """_compute_sleep always returns a value between 0 and MAX_RETRY_DELAY."""
+        from remarkable_mcp.sync import MAX_RETRY_DELAY, _compute_sleep
+
+        for attempt in range(10):
+            for _ in range(50):
+                val = _compute_sleep(2.0, attempt)
+                assert 0 <= val <= MAX_RETRY_DELAY
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync.requests.request")
+    def test_retry_exhaustion_returns_last_response(self, mock_request, mock_sleep):
+        """When all retries return retryable status, the last response is returned."""
+        from remarkable_mcp.sync import _http_request_with_retry
+
+        response_503 = Mock()
+        response_503.status_code = 503
+        response_503.headers = {}
+
+        mock_request.return_value = response_503
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 503
+        assert mock_request.call_count == 3

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "cairosvg"
-version = "2.8.2"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cairocffi" },
@@ -139,9 +139,9 @@ dependencies = [
     { name = "pillow" },
     { name = "tinycss2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b9/5106168bd43d7cd8b7cc2a2ee465b385f14b63f4c092bb89eee2d48c8e67/cairosvg-2.8.2.tar.gz", hash = "sha256:07cbf4e86317b27a92318a4cac2a4bb37a5e9c1b8a27355d06874b22f85bef9f", size = 8398590, upload-time = "2025-05-15T06:56:32.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/07/e8412a13019b3f737972dea23a2c61ca42becafc16c9338f4ca7a0caa993/cairosvg-2.9.0.tar.gz", hash = "sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5", size = 40877, upload-time = "2026-03-13T15:42:00.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/48/816bd4aaae93dbf9e408c58598bc32f4a8c65f4b86ab560864cb3ee60adb/cairosvg-2.8.2-py3-none-any.whl", hash = "sha256:eab46dad4674f33267a671dce39b64be245911c901c70d65d2b7b0821e852bf5", size = 45773, upload-time = "2025-05-15T06:56:28.552Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl", hash = "sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68", size = 45962, upload-time = "2026-03-14T13:56:33.512Z" },
 ]
 
 [[package]]
@@ -1197,16 +1197,18 @@ crypto = [
 
 [[package]]
 name = "pymupdf"
-version = "1.26.6"
+version = "1.27.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/a6f0e03a117fa2ad79c4b898203bb212b17804f92558a6a339298faca7bb/pymupdf-1.26.6.tar.gz", hash = "sha256:a2b4531cd4ab36d6f1f794bb6d3c33b49bda22f36d58bb1f3e81cbc10183bd2b", size = 84322494, upload-time = "2025-11-05T15:20:46.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/5c/dec354eee5fe4966c715f33818ed4193e0e6c986cf8484de35b6c167fb8e/pymupdf-1.26.6-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e46f320a136ad55e5219e8f0f4061bdf3e4c12b126d2740d5a49f73fae7ea176", size = 23178988, upload-time = "2025-11-05T14:31:19.834Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a0/11adb742d18142bd623556cd3b5d64649816decc5eafd30efc9498657e76/pymupdf-1.26.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:6844cd2396553c0fa06de4869d5d5ecb1260e6fc3b9d85abe8fa35f14dd9d688", size = 22469764, upload-time = "2025-11-05T14:32:34.654Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c8/377cf20e31f58d4c243bfcf2d3cb7466d5b97003b10b9f1161f11eb4a994/pymupdf-1.26.6-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:617ba69e02c44f0da1c0e039ea4a26cf630849fd570e169c71daeb8ac52a81d6", size = 23502227, upload-time = "2025-11-06T11:03:56.934Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/bf/6e02e3d84b32c137c71a0a3dcdba8f2f6e9950619a3bc272245c7c06a051/pymupdf-1.26.6-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7777d0b7124c2ebc94849536b6a1fb85d158df3b9d873935e63036559391534c", size = 24115381, upload-time = "2025-11-05T14:33:54.338Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/9d/30f7fcb3776bfedde66c06297960debe4883b1667294a1ee9426c942e94d/pymupdf-1.26.6-cp310-abi3-win32.whl", hash = "sha256:8f3ef05befc90ca6bb0f12983200a7048d5bff3e1c1edef1bb3de60b32cb5274", size = 17203613, upload-time = "2025-11-05T17:19:47.494Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e8/989f4eaa369c7166dc24f0eaa3023f13788c40ff1b96701f7047421554a8/pymupdf-1.26.6-cp310-abi3-win_amd64.whl", hash = "sha256:ce02ca96ed0d1acfd00331a4d41a34c98584d034155b06fd4ec0f051718de7ba", size = 18405680, upload-time = "2025-11-05T14:34:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
 ]
 
 [[package]]
@@ -1385,12 +1387,12 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "cairosvg", specifier = ">=2.8.2" },
+    { name = "cairosvg", specifier = ">=2.9.0" },
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "google-cloud-vision", marker = "extra == 'ocr'", specifier = ">=3.0.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pillow", specifier = ">=10.0.0" },
-    { name = "pymupdf", specifier = ">=1.24.0" },
+    { name = "pymupdf", specifier = ">=1.26.7" },
     { name = "pytesseract", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

Fixes security vulnerabilities and adds retry with exponential backoff for cloud API requests. Addresses #29.

### Commit 1: Security dependency bumps
- `cairosvg>=2.9.0` (CVE-2026-31899 — recursive use element DoS)
- `pymupdf>=1.26.7` (CVE-2026-3029 — path traversal)

### Commit 2: Retry with exponential backoff
Re-implementation of the approach from PR #75 by @Giancarlo-therapy.

**What's added in `remarkable_mcp/sync.py`:**
- `_http_request_with_retry()` with exponential backoff + full jitter
- Helper functions: `_get_retry_attempts()`, `_get_retry_delay()`, `_parse_retry_after()`, `_compute_sleep()`
- Configurable via `REMARKABLE_RETRY_ATTEMPTS` and `REMARKABLE_RETRY_DELAY` env vars
- Retries on: `ConnectionError`, `Timeout`, HTTP 429/500/502/503/504
- Does NOT retry on 401 (handled by token renewal) or other 4xx
- Honours `Retry-After` header, capped at `MAX_RETRY_DELAY` (20s)
- Wired into `RemarkableClient._request()`, `renew_token()`, and `register_device()`

**Tests (8 new):**
- Retry succeeds after transient 503
- Retry exhaustion raises last exception
- No retry on 401 or 400
- Retry-After header honoured and capped
- `_compute_sleep` stays within bounds
- Retry exhaustion returns last response for HTTP errors

All 91 tests pass.