### PR TITLE
feat: merged PDF + annotation rendering for remarkable_image

### DIFF
--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -908,6 +908,257 @@ def render_page_from_document_zip(
         return render_rm_file_to_png(target_rm_file, background_color=background_color)
 
 
+def document_zip_has_pdf_underlay(zip_path: Path) -> bool:
+    """Check if a reMarkable document zip contains a PDF underlay.
+
+    Args:
+        zip_path: Path to the document zip file
+
+    Returns:
+        True if the zip contains a .pdf file
+    """
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            return any(name.endswith(".pdf") for name in zf.namelist())
+    except Exception:
+        return False
+
+
+def _read_cpages_entries(tmpdir_path: Path) -> List[Dict[str, Any]]:
+    """Read cPages.pages entries from the .content metadata file.
+
+    Args:
+        tmpdir_path: Path to the extracted document directory
+
+    Returns:
+        List of cPages page entries, or empty list if not found
+    """
+    for content_file in tmpdir_path.glob("*.content"):
+        try:
+            data = json.loads(content_file.read_text())
+            if "cPages" in data and "pages" in data["cPages"]:
+                return data["cPages"]["pages"]
+        except Exception:
+            pass
+        break
+    return []
+
+
+def _pdf_page_index_for_cpages_entry(entry: Dict[str, Any]) -> Optional[int]:
+    """Get the 0-based PDF page index from a cPages entry's redir field.
+
+    The redir.value field in a cPages entry maps the reMarkable page to
+    the original PDF page number (0-based).
+
+    Args:
+        entry: A single cPages page entry dict
+
+    Returns:
+        0-based PDF page index, or None if no redirect exists
+    """
+    redir = entry.get("redir", {})
+    if isinstance(redir, dict) and "value" in redir:
+        try:
+            return int(redir["value"])
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def _render_pdf_page_to_png(
+    pdf_bytes: bytes, page_index: int, width: int, height: int
+) -> Optional[bytes]:
+    """Rasterize a single PDF page to PNG bytes using PyMuPDF (fitz).
+
+    Args:
+        pdf_bytes: Raw PDF file bytes
+        page_index: 0-based page index
+        width: Target output width in pixels
+        height: Target output height in pixels
+
+    Returns:
+        PNG image bytes, or None on failure
+    """
+    try:
+        import fitz
+
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+        if page_index < 0 or page_index >= len(doc):
+            doc.close()
+            return None
+
+        pdf_page = doc[page_index]
+        # Scale to fill the target dimensions
+        mat = fitz.Matrix(width / pdf_page.rect.width, height / pdf_page.rect.height)
+        pix = pdf_page.get_pixmap(matrix=mat, alpha=False)
+        png_data = pix.tobytes("png")
+        doc.close()
+        return png_data
+    except Exception:
+        return None
+
+
+def render_merged_page_from_document_zip(
+    zip_path: Path,
+    page: int = 1,
+    background_color: Optional[str] = None,
+    canvas_width: Optional[int] = None,
+    canvas_height: Optional[int] = None,
+) -> tuple[Optional[bytes], Optional[str]]:
+    """Render a page with the PDF underlay composited with the annotation layer.
+
+    Extracts the zip, determines which PDF page corresponds to the requested
+    reMarkable page, rasterizes the PDF page, renders the annotation layer,
+    and alpha-composites them into a single image.
+
+    Credit: Re-implementation inspired by PR #79 from @ColinSha.
+
+    Args:
+        zip_path: Path to the document zip file
+        page: Page number (1-indexed)
+        background_color: Background color for annotation layer
+        canvas_width: Output canvas width (default: derived from PDF page)
+        canvas_height: Output canvas height (default: derived from PDF page)
+
+    Returns:
+        Tuple of (png_bytes, note) where note is an informational message
+        or None. Returns (None, error_note) on failure.
+    """
+    from PIL import Image as PILImage
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        try:
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                zf.extractall(tmpdir_path)
+        except Exception:
+            # Fall back to annotation-only
+            png = render_page_from_document_zip(zip_path, page, background_color)
+            return png, "Could not extract zip; returned annotation-only render."
+
+        # Find the PDF file in the extracted directory
+        pdf_files = list(tmpdir_path.glob("**/*.pdf"))
+        if not pdf_files:
+            png = render_page_from_document_zip(zip_path, page, background_color)
+            return png, "No PDF underlay found; returned annotation-only render."
+
+        pdf_bytes = pdf_files[0].read_bytes()
+
+        # Read cPages to find PDF page mapping
+        cpages = _read_cpages_entries(tmpdir_path)
+        rm_files = _get_ordered_rm_files(tmpdir_path)
+
+        if page < 1 or page > len(rm_files):
+            return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
+
+        # Determine which PDF page this reMarkable page maps to
+        pdf_page_index: Optional[int] = None
+        if cpages and page <= len(cpages):
+            pdf_page_index = _pdf_page_index_for_cpages_entry(cpages[page - 1])
+
+        if pdf_page_index is None:
+            # No redirect — this page may be a user-added blank page
+            png = render_page_from_document_zip(zip_path, page, background_color)
+            return png, "Page has no PDF underlay (user-added page); annotation-only render."
+
+        # Get PDF page dimensions to set annotation viewBox correctly
+        try:
+            import fitz
+
+            doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+            if pdf_page_index >= len(doc):
+                doc.close()
+                png = render_page_from_document_zip(zip_path, page, background_color)
+                return png, "PDF page index out of range; annotation-only render."
+
+            pdf_page = doc[pdf_page_index]
+            pdf_w_pt = pdf_page.rect.width  # PDF width in points
+            pdf_h_pt = pdf_page.rect.height  # PDF height in points
+            doc.close()
+        except Exception:
+            png = render_page_from_document_zip(zip_path, page, background_color)
+            return png, "Could not read PDF dimensions; annotation-only render."
+
+        # Determine output canvas size
+        out_w = canvas_width or int(pdf_w_pt * 2)  # 2x for decent resolution
+        out_h = canvas_height or int(pdf_h_pt * 2)
+
+        # 1. Rasterize the PDF page
+        pdf_png = _render_pdf_page_to_png(pdf_bytes, pdf_page_index, out_w, out_h)
+        if pdf_png is None:
+            png = render_page_from_document_zip(zip_path, page, background_color)
+            return png, "PDF rasterization failed; annotation-only render."
+
+        # 2. Render annotation layer to SVG, then to PNG with transparent background
+        target_rm_file = rm_files[page - 1]
+        ann_svg_path = None
+        ann_png_bytes = None
+
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
+                ann_svg_path = Path(tmp_svg.name)
+
+            if _rm_to_svg(target_rm_file, ann_svg_path):
+                # Read the SVG and adjust viewBox to match PDF page bounds
+                svg_content = ann_svg_path.read_text()
+
+                # rmc outputs strokes in PDF points (after its SCALE = 72/226).
+                # Set viewBox to match PDF page bounds so annotations align.
+                import re
+
+                svg_content = re.sub(
+                    r'viewBox="[^"]*"',
+                    f'viewBox="{-pdf_w_pt / 2:.1f} 0 {pdf_w_pt:.1f} {pdf_h_pt:.1f}"',
+                    svg_content,
+                )
+                # Also set explicit width/height to match output canvas
+                svg_content = re.sub(r'width="[^"]*"', f'width="{out_w}"', svg_content)
+                svg_content = re.sub(r'height="[^"]*"', f'height="{out_h}"', svg_content)
+
+                # Render SVG to PNG with transparent background
+                import io
+
+                import cairosvg
+
+                ann_png_data = cairosvg.svg2png(
+                    bytestring=svg_content.encode("utf-8"),
+                    output_width=out_w,
+                    output_height=out_h,
+                )
+                ann_png_bytes = ann_png_data
+        except Exception:
+            pass  # Annotation rendering failed; we'll just return the PDF
+        finally:
+            if ann_svg_path:
+                ann_svg_path.unlink(missing_ok=True)
+
+        # 3. Composite: PDF base + annotation overlay
+        try:
+            import io
+
+            pdf_img = PILImage.open(io.BytesIO(pdf_png)).convert("RGBA")
+
+            if ann_png_bytes:
+                ann_img = PILImage.open(io.BytesIO(ann_png_bytes)).convert("RGBA")
+                # Resize annotation to match PDF if needed
+                if ann_img.size != pdf_img.size:
+                    ann_img = ann_img.resize(pdf_img.size, PILImage.LANCZOS)
+                composite = PILImage.alpha_composite(pdf_img, ann_img)
+            else:
+                composite = pdf_img
+
+            # Convert to RGB for PNG output (no alpha needed in final)
+            composite = composite.convert("RGB")
+            buf = io.BytesIO()
+            composite.save(buf, format="PNG")
+            return buf.getvalue(), None
+        except Exception:
+            # Last resort: return annotation-only
+            png = render_page_from_document_zip(zip_path, page, background_color)
+            return png, "Compositing failed; annotation-only render."
+
+
 def get_document_page_count(zip_path: Path) -> int:
     """
     Get the number of pages in a reMarkable document zip.

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -3,6 +3,7 @@ Text extraction helpers for reMarkable documents.
 """
 
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -13,6 +14,8 @@ import zipfile
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def _rmc_executable() -> str:
@@ -1025,6 +1028,10 @@ def render_merged_page_from_document_zip(
         Tuple of (png_bytes, note) where note is an informational message
         or None. Returns (None, error_note) on failure.
     """
+    import io
+    import re
+
+    import fitz
     from PIL import Image as PILImage
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -1038,7 +1045,9 @@ def render_merged_page_from_document_zip(
             png = render_page_from_document_zip(zip_path, page, background_color)
             return png, "Could not extract zip; returned annotation-only render."
 
-        # Find the PDF file in the extracted directory
+        # Find the PDF file in the extracted directory. If multiple are present
+        # (rare), prefer the one whose stem matches the .content document id so
+        # selection is deterministic.
         pdf_files = list(tmpdir_path.glob("**/*.pdf"))
         if not pdf_files:
             rm_files = _get_ordered_rm_files(tmpdir_path)
@@ -1047,7 +1056,10 @@ def render_merged_page_from_document_zip(
             png = render_rm_file_to_png(rm_files[page - 1], background_color=background_color)
             return png, "No PDF underlay found; returned annotation-only render."
 
-        pdf_bytes = pdf_files[0].read_bytes()
+        content_stems = {p.stem for p in tmpdir_path.glob("*.content")}
+        matching = [p for p in pdf_files if p.stem in content_stems]
+        pdf_path = matching[0] if matching else sorted(pdf_files)[0]
+        pdf_bytes = pdf_path.read_bytes()
 
         # Read cPages to find PDF page mapping
         cpages = _read_cpages_entries(tmpdir_path)
@@ -1070,8 +1082,6 @@ def render_merged_page_from_document_zip(
 
         # Get PDF page dimensions to set annotation viewBox correctly
         try:
-            import fitz
-
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")
             try:
                 if pdf_page_index >= len(doc):
@@ -1106,12 +1116,17 @@ def render_merged_page_from_document_zip(
                 ann_svg_path = Path(tmp_svg.name)
 
             if _rm_to_svg(target_rm_file, ann_svg_path):
-                # Read the SVG and adjust viewBox to match PDF page bounds
+                # Read the SVG and adjust viewBox to match PDF page bounds.
+                #
+                # rmc emits stroke coordinates in PDF points (after its internal
+                # SCALE = 72/226), with the origin at the top of the page and
+                # x=0 in the horizontal center (so x ranges roughly from
+                # -W_pt/2 to +W_pt/2). Setting the viewBox to
+                # (-W_pt/2, 0, W_pt, H_pt) maps that coordinate system to the
+                # PDF page bounds so annotations align. This is specific to
+                # rmc's v6 renderer; if the upstream coordinate convention
+                # changes this alignment will need to be revisited.
                 svg_content = ann_svg_path.read_text()
-
-                # rmc outputs strokes in PDF points (after its SCALE = 72/226).
-                # Set viewBox to match PDF page bounds so annotations align.
-                import re
 
                 svg_content = re.sub(
                     r'viewBox="[^"]*"',
@@ -1123,8 +1138,6 @@ def render_merged_page_from_document_zip(
                 svg_content = re.sub(r'height="[^"]*"', f'height="{out_h}"', svg_content)
 
                 # Render SVG to PNG with transparent background
-                import io
-
                 import cairosvg
 
                 ann_png_data = cairosvg.svg2png(
@@ -1133,16 +1146,19 @@ def render_merged_page_from_document_zip(
                     output_height=out_h,
                 )
                 ann_png_bytes = ann_png_data
-        except Exception:
-            pass  # Annotation rendering failed; we'll just return the PDF
+        except Exception as exc:
+            # Annotation rendering failed; we'll just return the PDF, but
+            # record the failure so callers can surface it as a note.
+            logger.debug("Annotation overlay rendering failed: %s", exc)
+            ann_render_error = exc
+        else:
+            ann_render_error = None
         finally:
             if ann_svg_path:
                 ann_svg_path.unlink(missing_ok=True)
 
         # 3. Composite: PDF base + annotation overlay
         try:
-            import io
-
             pdf_img = PILImage.open(io.BytesIO(pdf_png)).convert("RGBA")
 
             if ann_png_bytes:
@@ -1151,14 +1167,20 @@ def render_merged_page_from_document_zip(
                 if ann_img.size != pdf_img.size:
                     ann_img = ann_img.resize(pdf_img.size, PILImage.LANCZOS)
                 composite = PILImage.alpha_composite(pdf_img, ann_img)
+                merged_note = None
             else:
                 composite = pdf_img
+                merged_note = (
+                    "Annotation overlay failed to render; returned PDF page without annotations."
+                    if ann_render_error is not None
+                    else None
+                )
 
             # Convert to RGB for PNG output (no alpha needed in final)
             composite = composite.convert("RGB")
             buf = io.BytesIO()
             composite.save(buf, format="PNG")
-            return buf.getvalue(), None
+            return buf.getvalue(), merged_note
         except Exception:
             # Last resort: return annotation-only from already-extracted .rm file
             png = render_rm_file_to_png(target_rm_file, background_color=background_color)

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -933,14 +933,15 @@ def _read_cpages_entries(tmpdir_path: Path) -> List[Dict[str, Any]]:
     Returns:
         List of cPages page entries, or empty list if not found
     """
-    for content_file in tmpdir_path.glob("*.content"):
-        try:
-            data = json.loads(content_file.read_text())
-            if "cPages" in data and "pages" in data["cPages"]:
-                return data["cPages"]["pages"]
-        except Exception:
-            pass
-        break
+    content_file = next(tmpdir_path.glob("*.content"), None)
+    if content_file is None:
+        return []
+    try:
+        data = json.loads(content_file.read_text())
+        if "cPages" in data and "pages" in data["cPages"]:
+            return data["cPages"]["pages"]
+    except Exception:
+        pass
     return []
 
 
@@ -983,17 +984,17 @@ def _render_pdf_page_to_png(
         import fitz
 
         doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-        if page_index < 0 or page_index >= len(doc):
-            doc.close()
-            return None
+        try:
+            if page_index < 0 or page_index >= len(doc):
+                return None
 
-        pdf_page = doc[page_index]
-        # Scale to fill the target dimensions
-        mat = fitz.Matrix(width / pdf_page.rect.width, height / pdf_page.rect.height)
-        pix = pdf_page.get_pixmap(matrix=mat, alpha=False)
-        png_data = pix.tobytes("png")
-        doc.close()
-        return png_data
+            pdf_page = doc[page_index]
+            # Scale to fill the target dimensions
+            mat = fitz.Matrix(width / pdf_page.rect.width, height / pdf_page.rect.height)
+            pix = pdf_page.get_pixmap(matrix=mat, alpha=False)
+            return pix.tobytes("png")
+        finally:
+            doc.close()
     except Exception:
         return None
 
@@ -1040,7 +1041,10 @@ def render_merged_page_from_document_zip(
         # Find the PDF file in the extracted directory
         pdf_files = list(tmpdir_path.glob("**/*.pdf"))
         if not pdf_files:
-            png = render_page_from_document_zip(zip_path, page, background_color)
+            rm_files = _get_ordered_rm_files(tmpdir_path)
+            if page < 1 or page > len(rm_files):
+                return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
+            png = render_rm_file_to_png(rm_files[page - 1], background_color=background_color)
             return png, "No PDF underlay found; returned annotation-only render."
 
         pdf_bytes = pdf_files[0].read_bytes()
@@ -1052,6 +1056,8 @@ def render_merged_page_from_document_zip(
         if page < 1 or page > len(rm_files):
             return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
 
+        target_rm_file = rm_files[page - 1]
+
         # Determine which PDF page this reMarkable page maps to
         pdf_page_index: Optional[int] = None
         if cpages and page <= len(cpages):
@@ -1059,7 +1065,7 @@ def render_merged_page_from_document_zip(
 
         if pdf_page_index is None:
             # No redirect — this page may be a user-added blank page
-            png = render_page_from_document_zip(zip_path, page, background_color)
+            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
             return png, "Page has no PDF underlay (user-added page); annotation-only render."
 
         # Get PDF page dimensions to set annotation viewBox correctly
@@ -1067,17 +1073,18 @@ def render_merged_page_from_document_zip(
             import fitz
 
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-            if pdf_page_index >= len(doc):
-                doc.close()
-                png = render_page_from_document_zip(zip_path, page, background_color)
-                return png, "PDF page index out of range; annotation-only render."
+            try:
+                if pdf_page_index >= len(doc):
+                    png = render_rm_file_to_png(target_rm_file, background_color=background_color)
+                    return png, "PDF page index out of range; annotation-only render."
 
-            pdf_page = doc[pdf_page_index]
-            pdf_w_pt = pdf_page.rect.width  # PDF width in points
-            pdf_h_pt = pdf_page.rect.height  # PDF height in points
-            doc.close()
+                pdf_page = doc[pdf_page_index]
+                pdf_w_pt = pdf_page.rect.width  # PDF width in points
+                pdf_h_pt = pdf_page.rect.height  # PDF height in points
+            finally:
+                doc.close()
         except Exception:
-            png = render_page_from_document_zip(zip_path, page, background_color)
+            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
             return png, "Could not read PDF dimensions; annotation-only render."
 
         # Determine output canvas size
@@ -1087,11 +1094,10 @@ def render_merged_page_from_document_zip(
         # 1. Rasterize the PDF page
         pdf_png = _render_pdf_page_to_png(pdf_bytes, pdf_page_index, out_w, out_h)
         if pdf_png is None:
-            png = render_page_from_document_zip(zip_path, page, background_color)
+            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
             return png, "PDF rasterization failed; annotation-only render."
 
         # 2. Render annotation layer to SVG, then to PNG with transparent background
-        target_rm_file = rm_files[page - 1]
         ann_svg_path = None
         ann_png_bytes = None
 
@@ -1154,8 +1160,8 @@ def render_merged_page_from_document_zip(
             composite.save(buf, format="PNG")
             return buf.getvalue(), None
         except Exception:
-            # Last resort: return annotation-only
-            png = render_page_from_document_zip(zip_path, page, background_color)
+            # Last resort: return annotation-only from already-extracted .rm file
+            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
             return png, "Compositing failed; annotation-only render."
 
 

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -330,6 +330,8 @@ class SSHClient:
         Download a document's content as a zip file.
 
         Creates a zip archive with the same structure as the cloud API.
+        Includes the document folder contents, .content metadata, and
+        any associated PDF/EPUB file for merged rendering support.
         """
         doc_path = f"{XOCHITL_PATH}/{doc.id}"
 
@@ -348,6 +350,15 @@ class SSHClient:
             file_list.append(content_file)
         except Exception:
             pass
+
+        # Include the associated PDF or EPUB file for merged rendering
+        for ext in ("pdf", "epub"):
+            raw_file = f"{XOCHITL_PATH}/{doc.id}.{ext}"
+            try:
+                self._ssh_command(f"test -f '{raw_file}' && echo exists")
+                file_list.append(raw_file)
+            except Exception:
+                pass
 
         # Create zip archive
         zip_buffer = io.BytesIO()

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -32,7 +32,6 @@ from remarkable_mcp.api import (
 )
 from remarkable_mcp.extract import (
     cache_page_ocr,
-    document_zip_has_pdf_underlay,
     extract_text_from_document_zip,
     extract_text_from_epub,
     extract_text_from_pdf,
@@ -1566,16 +1565,11 @@ async def remarkable_image(
                     return [info, embedded]
             else:
                 # PNG format
-                if render_merged and document_zip_has_pdf_underlay(tmp_path):
+                if render_merged:
                     png_data, merged_note = render_merged_page_from_document_zip(
                         tmp_path, page, background_color=background
                     )
                     is_merged = png_data is not None and merged_note is None
-                elif render_merged:
-                    merged_note = "No PDF underlay; returned annotation-only render."
-                    png_data = render_page_from_document_zip(
-                        tmp_path, page, background_color=background
-                    )
                 else:
                     png_data = render_page_from_document_zip(
                         tmp_path, page, background_color=background

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1650,6 +1650,8 @@ async def remarkable_image(
                         hint = f"Page {page}/{total_pages}. No text detected via OCR."
                     if merged_note:
                         hint = f"{merged_note} {hint}"
+                    elif is_merged:
+                        hint = f"Rendered with PDF + annotation compositing. {hint}"
 
                     response_data = {
                         "data_uri": data_uri,

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -32,6 +32,7 @@ from remarkable_mcp.api import (
 )
 from remarkable_mcp.extract import (
     cache_page_ocr,
+    document_zip_has_pdf_underlay,
     extract_text_from_document_zip,
     extract_text_from_epub,
     extract_text_from_pdf,
@@ -40,6 +41,7 @@ from remarkable_mcp.extract import (
     get_cached_ocr_result,
     get_cached_page_ocr,
     get_document_page_count,
+    render_merged_page_from_document_zip,
     render_page_from_document_zip,
     render_page_from_document_zip_svg,
 )
@@ -1350,6 +1352,7 @@ async def remarkable_image(
     output_format: str = "png",
     compatibility: bool = False,
     include_ocr: bool = False,
+    render_merged: bool = False,
     ctx: Optional[Context] = None,
 ):
     """
@@ -1360,6 +1363,13 @@ async def remarkable_image(
     - Getting visual context that text extraction might miss
     - Implementing designs based on hand-drawn wireframes
     - SVG format for scalable vector graphics that can be edited
+
+    ## Merged PDF + Annotation Rendering
+
+    Set render_merged=True to composite the PDF page with the annotation layer into
+    a single image. This is ideal for annotated PDFs where the annotation-only render
+    is hard to interpret without the printed page context. Only works with PNG format
+    and documents that have a PDF underlay.
 
     ## Response Formats
 
@@ -1377,7 +1387,8 @@ async def remarkable_image(
     the client's own LLM will be used for OCR (no API keys needed).
 
     Note: This works best with notebooks and handwritten content. For PDFs/EPUBs,
-    the annotations layer is rendered (not the underlying PDF content).
+    the annotations layer is rendered (not the underlying PDF content) unless
+    render_merged=True is set.
     </instructions>
     <parameters>
     - document: Document name or path (use remarkable_browse to find documents)
@@ -1390,6 +1401,8 @@ async def remarkable_image(
       Use this if your client doesn't support embedded resources in tool responses.
     - include_ocr: Enable OCR text extraction from the image (default: False).
       When REMARKABLE_OCR_BACKEND=sampling, uses the client's LLM via MCP sampling.
+    - render_merged: Composite PDF page + annotation layer into one image (default: False).
+      Only works with PNG format and documents that have a PDF underlay.
     </parameters>
     <examples>
     - remarkable_image("UI Mockup")  # Get first page as embedded PNG resource
@@ -1399,6 +1412,7 @@ async def remarkable_image(
     - remarkable_image("Diagram", output_format="svg")  # Get as embedded SVG resource
     - remarkable_image("Notes", compatibility=True)  # Return resource URI for retry
     - remarkable_image("Notes", include_ocr=True)  # Get image with OCR text extraction
+    - remarkable_image("Annotated PDF", render_merged=True)  # PDF + annotations composited
     </examples>
     """
     try:
@@ -1491,7 +1505,16 @@ async def remarkable_image(
             uri_path = doc_path.lstrip("/")
 
             # Render the page based on format
+            merged_note = None
+            is_merged = False
+
             if format_lower == "svg":
+                if render_merged:
+                    merged_note = (
+                        "render_merged is only supported with PNG format; "
+                        "returning annotation-only SVG."
+                    )
+
                 svg_content = render_page_from_document_zip_svg(
                     tmp_path, page, background_color=background
                 )
@@ -1514,16 +1537,17 @@ async def remarkable_image(
                         f"Page {page}/{total_pages} as SVG. "
                         f"Use compatibility=False for embedded resource format."
                     )
-                    return make_response(
-                        {
-                            "svg": svg_content,
-                            "mime_type": "image/svg+xml",
-                            "page": page,
-                            "total_pages": total_pages,
-                            "resource_uri": resource_uri,
-                        },
-                        hint,
-                    )
+                    if merged_note:
+                        hint = f"{merged_note} {hint}"
+                    response_data = {
+                        "svg": svg_content,
+                        "mime_type": "image/svg+xml",
+                        "page": page,
+                        "total_pages": total_pages,
+                        "resource_uri": resource_uri,
+                        "merged": False,
+                    }
+                    return make_response(response_data, hint)
                 else:
                     # Return SVG as embedded TextResourceContents with info hint
                     text_resource = TextResourceContents(
@@ -1532,17 +1556,30 @@ async def remarkable_image(
                         text=svg_content,
                     )
                     embedded = EmbeddedResource(type="resource", resource=text_resource)
-                    info = TextContent(
-                        type="text",
-                        text=f"Page {page}/{total_pages} of '{target_doc.VissibleName}' as SVG. "
-                        f"Resource URI: {resource_uri}",
+                    info_text = (
+                        f"Page {page}/{total_pages} of '{target_doc.VissibleName}' as SVG. "
+                        f"Resource URI: {resource_uri}"
                     )
+                    if merged_note:
+                        info_text = f"{merged_note}\n{info_text}"
+                    info = TextContent(type="text", text=info_text)
                     return [info, embedded]
             else:
                 # PNG format
-                png_data = render_page_from_document_zip(
-                    tmp_path, page, background_color=background
-                )
+                if render_merged and document_zip_has_pdf_underlay(tmp_path):
+                    png_data, merged_note = render_merged_page_from_document_zip(
+                        tmp_path, page, background_color=background
+                    )
+                    is_merged = png_data is not None and merged_note is None
+                elif render_merged:
+                    merged_note = "No PDF underlay; returned annotation-only render."
+                    png_data = render_page_from_document_zip(
+                        tmp_path, page, background_color=background
+                    )
+                else:
+                    png_data = render_page_from_document_zip(
+                        tmp_path, page, background_color=background
+                    )
 
                 if png_data is None:
                     return make_error(
@@ -1589,7 +1626,8 @@ async def remarkable_image(
                         finally:
                             ocr_tmp_path.unlink(missing_ok=True)
 
-                resource_uri = f"remarkableimg:///{uri_path}.page-{page}.png"
+                uri_suffix = ".merged.png" if is_merged else ".png"
+                resource_uri = f"remarkableimg:///{uri_path}.page-{page}{uri_suffix}"
                 png_base64 = base64.b64encode(png_data).decode("utf-8")
 
                 # Build OCR info for response if OCR was requested
@@ -1616,6 +1654,8 @@ async def remarkable_image(
                         )
                     elif include_ocr:
                         hint = f"Page {page}/{total_pages}. No text detected via OCR."
+                    if merged_note:
+                        hint = f"{merged_note} {hint}"
 
                     response_data = {
                         "data_uri": data_uri,
@@ -1624,6 +1664,7 @@ async def remarkable_image(
                         "page": page,
                         "total_pages": total_pages,
                         "resource_uri": resource_uri,
+                        "merged": is_merged,
                         **ocr_info,
                     }
                     return make_response(response_data, hint)
@@ -1638,6 +1679,10 @@ async def remarkable_image(
 
                     info_text = f"Page {page}/{total_pages} of '{target_doc.VissibleName}' as PNG. "
                     info_text += f"Resource URI: {resource_uri}"
+                    if is_merged:
+                        info_text += "\nRendered with PDF + annotation compositing."
+                    if merged_note:
+                        info_text += f"\nNote: {merged_note}"
                     if include_ocr and ocr_text:
                         info_text += f"\n\nOCR Text (via {ocr_backend_used}):\n{ocr_text}"
                     elif include_ocr:

--- a/test_server.py
+++ b/test_server.py
@@ -723,6 +723,52 @@ class TestMergedRendering:
         assert data.get("merged") is False
         assert "render_merged is only supported with PNG" in data.get("_hint", "")
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    @patch("remarkable_mcp.tools.render_merged_page_from_document_zip")
+    @patch("remarkable_mcp.tools.get_document_page_count")
+    async def test_render_merged_success_path(
+        self,
+        mock_page_count,
+        mock_render_merged,
+        mock_get_rmapi,
+        mock_document,
+    ):
+        """Test render_merged success path: returns merged PNG with .merged.png URI."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = b"fake zip"
+        mock_page_count.return_value = 5
+        # Simulate successful merged render (no fallback note)
+        composited_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 200
+        mock_render_merged.return_value = (composited_png, None)
+
+        with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
+            mock_tmp = Mock()
+            mock_tmp.__enter__ = Mock(return_value=mock_tmp)
+            mock_tmp.__exit__ = Mock(return_value=False)
+            mock_tmp.name = "/tmp/test.zip"
+            mock_tmpfile.return_value = mock_tmp
+            with patch("pathlib.Path.unlink"):
+                result = await mcp.call_tool(
+                    "remarkable_image",
+                    {
+                        "document": "Test Document",
+                        "render_merged": True,
+                        "compatibility": True,
+                    },
+                )
+
+        data = json.loads(result[0].text)
+        assert data.get("merged") is True
+        assert data.get("resource_uri", "").endswith(".merged.png")
+        hint = data.get("_hint", "")
+        assert "PDF" in hint and "annotation" in hint.lower()
+        # The merged renderer should have been called once for this page
+        assert mock_render_merged.called
+
 
 # =============================================================================
 # Test Registration

--- a/test_server.py
+++ b/test_server.py
@@ -641,14 +641,12 @@ class TestMergedRendering:
 
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.get_rmapi")
-    @patch("remarkable_mcp.tools.document_zip_has_pdf_underlay")
-    @patch("remarkable_mcp.tools.render_page_from_document_zip")
+    @patch("remarkable_mcp.tools.render_merged_page_from_document_zip")
     @patch("remarkable_mcp.tools.get_document_page_count")
     async def test_render_merged_fallback_no_pdf(
         self,
         mock_page_count,
-        mock_render,
-        mock_has_pdf,
+        mock_render_merged,
         mock_get_rmapi,
         mock_document,
     ):
@@ -658,10 +656,13 @@ class TestMergedRendering:
         mock_document.is_folder = False
         mock_client.get_meta_items.return_value = [mock_document]
         mock_client.download.return_value = b"fake zip"
-        mock_has_pdf.return_value = False
         mock_page_count.return_value = 3
-        # Return fake PNG data
-        mock_render.return_value = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        # Simulate merged function returning annotation-only with a note (no PDF)
+        fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        mock_render_merged.return_value = (
+            fake_png,
+            "No PDF underlay found; returned annotation-only render.",
+        )
 
         with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
             mock_tmp = Mock()

--- a/test_server.py
+++ b/test_server.py
@@ -620,6 +620,110 @@ class TestRemarkableImage:
 
 
 # =============================================================================
+# Test Merged Rendering
+# =============================================================================
+
+
+class TestMergedRendering:
+    """Test render_merged parameter for remarkable_image."""
+
+    @pytest.mark.asyncio
+    async def test_render_merged_parameter_in_schema(self):
+        """Test that remarkable_image tool has the render_merged parameter in its schema."""
+        tools = await mcp.list_tools()
+        image_tool = next(t for t in tools if t.name == "remarkable_image")
+
+        # Check that render_merged parameter exists in the input schema
+        assert "render_merged" in image_tool.inputSchema.get("properties", {})
+        merged_schema = image_tool.inputSchema["properties"]["render_merged"]
+        assert merged_schema.get("type") == "boolean"
+        assert merged_schema.get("default") is False
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    @patch("remarkable_mcp.tools.document_zip_has_pdf_underlay")
+    @patch("remarkable_mcp.tools.render_page_from_document_zip")
+    @patch("remarkable_mcp.tools.get_document_page_count")
+    async def test_render_merged_fallback_no_pdf(
+        self,
+        mock_page_count,
+        mock_render,
+        mock_has_pdf,
+        mock_get_rmapi,
+        mock_document,
+    ):
+        """Test render_merged falls back when document has no PDF underlay."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = b"fake zip"
+        mock_has_pdf.return_value = False
+        mock_page_count.return_value = 3
+        # Return fake PNG data
+        mock_render.return_value = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+
+        with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
+            mock_tmp = Mock()
+            mock_tmp.__enter__ = Mock(return_value=mock_tmp)
+            mock_tmp.__exit__ = Mock(return_value=False)
+            mock_tmp.name = "/tmp/test.zip"
+            mock_tmpfile.return_value = mock_tmp
+            with patch("pathlib.Path.unlink"):
+                result = await mcp.call_tool(
+                    "remarkable_image",
+                    {
+                        "document": "Test Document",
+                        "render_merged": True,
+                        "compatibility": True,
+                    },
+                )
+
+        data = json.loads(result[0].text)
+        # Should fall back to annotation-only since no PDF underlay
+        assert data.get("merged") is False
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_render_merged_svg_ignored(self, mock_get_rmapi, mock_document):
+        """Test that SVG format ignores render_merged gracefully."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = b"fake zip"
+
+        with (
+            patch("tempfile.NamedTemporaryFile") as mock_tmpfile,
+            patch("remarkable_mcp.tools.get_document_page_count", return_value=2),
+            patch(
+                "remarkable_mcp.tools.render_page_from_document_zip_svg",
+                return_value='<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+            ),
+        ):
+            mock_tmp = Mock()
+            mock_tmp.__enter__ = Mock(return_value=mock_tmp)
+            mock_tmp.__exit__ = Mock(return_value=False)
+            mock_tmp.name = "/tmp/test.zip"
+            mock_tmpfile.return_value = mock_tmp
+            with patch("pathlib.Path.unlink"):
+                result = await mcp.call_tool(
+                    "remarkable_image",
+                    {
+                        "document": "Test Document",
+                        "output_format": "svg",
+                        "render_merged": True,
+                        "compatibility": True,
+                    },
+                )
+
+        data = json.loads(result[0].text)
+        # SVG should return successfully but merged=False
+        assert data.get("merged") is False
+        assert "render_merged is only supported with PNG" in data.get("_hint", "")
+
+
+# =============================================================================
 # Test Registration
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Adds a `render_merged` parameter to `remarkable_image` that composites the PDF page with the reMarkable annotation layer into a single image. This makes annotated PDFs viewable as the user sees them on the device, rather than showing just the annotation layer in isolation.

Re-implementation inspired by PR #79 from @ColinSha.

## Changes

### `remarkable_mcp/extract.py`
- `document_zip_has_pdf_underlay(zip_path)` — checks if a document zip contains a PDF file
- `_read_cpages_entries(tmpdir_path)` — reads cPages.pages from .content metadata
- `_pdf_page_index_for_cpages_entry(entry)` — extracts 0-based PDF page index from redir.value
- `_render_pdf_page_to_png(pdf_bytes, page_index, width, height)` — rasterizes a PDF page using PyMuPDF (fitz)
- `render_merged_page_from_document_zip(zip_path, page, ...)` — main entry point that:
  - Extracts the zip and reads cPages to find PDF page mapping
  - Rasterizes the PDF page to PNG
  - Renders the .rm annotation layer to PNG with matching viewBox
  - Alpha-composites annotations on top of PDF
  - Graceful fallback to annotation-only on any failure

### `remarkable_mcp/tools.py`
- Added `render_merged: bool = False` parameter to `remarkable_image`
- When `render_merged=True` and format is PNG with PDF underlay: calls merged renderer
- When no PDF underlay: falls back to annotation-only with a note
- When format is SVG: ignores `render_merged` gracefully with a note
- Added `.merged.png` URI suffix and `"merged": true/false` to response data
- Updated docstring and examples

### `test_server.py`
- `TestMergedRendering` class with 3 tests:
  - Schema verification for `render_merged` parameter
  - Fallback behavior when document has no PDF underlay
  - SVG format gracefully ignores `render_merged`

## Testing

All 86 tests pass. Ruff check and format clean.