### PR TITLE
feat: opt-in SSH write tools (upload, mkdir, move, rename, delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,9 +394,76 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 | Offline | ✅ Yes | ❌ No |
 | Subscription | ✅ Not required | ❌ Connect required |
 | Raw files | ✅ PDFs, EPUBs | ❌ Not available |
+| Write tools | ✅ With `--write` flag | ❌ Not available |
 | Setup | Developer mode | One-time code |
 
 📖 **[SSH Setup Guide](docs/ssh-setup.md)**
+
+---
+
+## Write Tools (SSH Only)
+
+Opt-in write tools let you upload, organize, and manage documents directly on your reMarkable tablet via SSH. **Disabled by default** for safety.
+
+### Enabling Write Tools
+
+Add the `--write` flag when running in SSH mode:
+
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--ssh", "--write"]
+    }
+  }
+}
+```
+
+Or set the environment variable:
+```json
+{
+  "env": {
+    "REMARKABLE_ENABLE_WRITE": "1"
+  }
+}
+```
+
+### Available Write Tools
+
+| Tool | Description | Destructive? |
+|------|-------------|:------------:|
+| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file | No |
+| `remarkable_mkdir(folder_name, parent)` | Create a new folder | No |
+| `remarkable_move(document, dest_folder)` | Move a document or folder | No |
+| `remarkable_rename(document, new_name)` | Rename a document or folder | No |
+| `remarkable_delete(document, confirm)` | Delete a document or folder | ⚠️ Yes |
+
+### Safety
+
+- **Write tools require SSH mode** — cloud and USB-web modes return a clear error
+- **Delete requires confirmation** — calling without `confirm=True` returns a dry-run preview
+- After each write operation, the tablet UI restarts automatically to reflect changes
+
+### Examples
+
+```python
+# Upload a PDF
+remarkable_upload("/tmp/paper.pdf", parent_folder="/Research")
+
+# Create a folder
+remarkable_mkdir("2024 Archive", parent="/Archive")
+
+# Move a document
+remarkable_move("Meeting Notes", "/Archive/2024 Archive")
+
+# Rename a document
+remarkable_rename("Untitled", "Q4 Planning Notes")
+
+# Delete (dry-run first, then confirm)
+remarkable_delete("Old Draft")           # Preview what would be deleted
+remarkable_delete("Old Draft", confirm=True)  # Actually delete
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -386,28 +386,37 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 
 ---
 
-## SSH vs Cloud Comparison
+## SSH vs USB Web vs Cloud Comparison
 
-| Feature | SSH Mode | Cloud API |
-|---------|----------|-----------|
-| Speed | ⚡ 10-100x faster | Slower |
-| Offline | ✅ Yes | ❌ No |
-| Subscription | ✅ Not required | ❌ Connect required |
-| Raw files | ✅ PDFs, EPUBs | ❌ Not available |
-| Write tools | ✅ With `--write` flag | ❌ Not available |
-| Setup | Developer mode | One-time code |
+| Feature | SSH Mode | USB Web | Cloud API |
+|---------|----------|---------|-----------|
+| Speed | ⚡ 10-100x faster | ⚡ Fast | Slower |
+| Offline | ✅ Yes | ✅ Yes | ❌ No |
+| Subscription | ✅ Not required | ✅ Not required | ❌ Connect required |
+| Raw files | ✅ PDFs, EPUBs | ✅ PDFs | ❌ Not available |
+| Upload | ✅ With `--write` | ✅ With `--write` | ❌ Not available |
+| mkdir/move/rename/delete | ✅ With `--write` | ❌ | ❌ |
+| Setup | Developer mode | Enable in Settings | One-time code |
 
 📖 **[SSH Setup Guide](docs/ssh-setup.md)**
 
 ---
 
-## Write Tools (SSH Only)
+## Write Tools (SSH & USB Web)
 
-Opt-in write tools let you upload, organize, and manage documents directly on your reMarkable tablet via SSH. **Disabled by default** for safety.
+Opt-in write tools let you upload, organize, and manage documents directly on your reMarkable tablet. **Disabled by default** for safety.
+
+| Feature | SSH Mode | USB Web Mode | Cloud Mode |
+|---------|:--------:|:------------:|:----------:|
+| Upload | ✅ | ✅ | ❌ |
+| Mkdir | ✅ | ❌ | ❌ |
+| Move | ✅ | ❌ | ❌ |
+| Rename | ✅ | ❌ | ❌ |
+| Delete | ✅ | ❌ | ❌ |
 
 ### Enabling Write Tools
 
-Add the `--write` flag when running in SSH mode:
+Add the `--write` flag when running in SSH or USB web mode:
 
 ```json
 {
@@ -415,6 +424,18 @@ Add the `--write` flag when running in SSH mode:
     "remarkable": {
       "command": "uvx",
       "args": ["remarkable-mcp", "--ssh", "--write"]
+    }
+  }
+}
+```
+
+Or with USB web mode (upload only):
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--usb", "--write"]
     }
   }
 }
@@ -434,16 +455,17 @@ Or set the environment variable:
 | Tool | Description | Destructive? |
 |------|-------------|:------------:|
 | `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file | No |
-| `remarkable_mkdir(folder_name, parent)` | Create a new folder | No |
-| `remarkable_move(document, dest_folder)` | Move a document or folder | No |
-| `remarkable_rename(document, new_name)` | Rename a document or folder | No |
-| `remarkable_delete(document, confirm)` | Delete a document or folder | ⚠️ Yes |
+| `remarkable_mkdir(folder_name, parent)` | Create a new folder (SSH only) | No |
+| `remarkable_move(document, dest_folder)` | Move a document or folder (SSH only) | No |
+| `remarkable_rename(document, new_name)` | Rename a document or folder (SSH only) | No |
+| `remarkable_delete(document, confirm)` | Delete a document or folder (SSH only) | ⚠️ Yes |
 
 ### Safety
 
-- **Write tools require SSH mode** — cloud and USB-web modes return a clear error
+- **Upload works in SSH and USB web mode** — cloud mode returns a clear error
+- **mkdir, move, rename, delete require SSH mode** — USB web and cloud return a clear error
 - **Delete requires confirmation** — calling without `confirm=True` returns a dry-run preview
-- After each write operation, the tablet UI restarts automatically to reflect changes
+- After each write operation (SSH), the tablet UI restarts automatically to reflect changes
 
 ### Examples
 
@@ -451,16 +473,16 @@ Or set the environment variable:
 # Upload a PDF
 remarkable_upload("/tmp/paper.pdf", parent_folder="/Research")
 
-# Create a folder
+# Create a folder (SSH only)
 remarkable_mkdir("2024 Archive", parent="/Archive")
 
-# Move a document
+# Move a document (SSH only)
 remarkable_move("Meeting Notes", "/Archive/2024 Archive")
 
-# Rename a document
+# Rename a document (SSH only)
 remarkable_rename("Untitled", "Q4 Planning Notes")
 
-# Delete (dry-run first, then confirm)
+# Delete (dry-run first, then confirm) (SSH only)
 remarkable_delete("Old Draft")           # Preview what would be deleted
 remarkable_delete("Old Draft", confirm=True)  # Actually delete
 ```

--- a/README.md
+++ b/README.md
@@ -452,19 +452,19 @@ Or set the environment variable:
 
 ### Available Write Tools
 
-| Tool | Description | Destructive? |
-|------|-------------|:------------:|
-| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file | No |
-| `remarkable_mkdir(folder_name, parent)` | Create a new folder (SSH only) | No |
-| `remarkable_move(document, dest_folder)` | Move a document or folder (SSH only) | No |
-| `remarkable_rename(document, new_name)` | Rename a document or folder (SSH only) | No |
-| `remarkable_delete(document, confirm)` | Delete a document or folder (SSH only) | ⚠️ Yes |
+| Tool | Description |
+|------|-------------|
+| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file |
+| `remarkable_mkdir(folder_name, parent)` | Create a new folder (SSH only) |
+| `remarkable_move(document, dest_folder)` | Move a document or folder (SSH only) |
+| `remarkable_rename(document, new_name)` | Rename a document or folder (SSH only) |
+| `remarkable_delete(document)` | Delete a document or folder — destructive (SSH only) |
 
 ### Safety
 
 - **Upload works in SSH and USB web mode** — cloud mode returns a clear error
 - **mkdir, move, rename, delete require SSH mode** — USB web and cloud return a clear error
-- **Delete requires confirmation** — calling without `confirm=True` returns a dry-run preview
+- **Delete is destructive and immediate** — the MCP client is responsible for confirming with the user before invoking
 - After each write operation (SSH), the tablet UI restarts automatically to reflect changes
 
 ### Examples
@@ -482,9 +482,8 @@ remarkable_move("Meeting Notes", "/Archive/2024 Archive")
 # Rename a document (SSH only)
 remarkable_rename("Untitled", "Q4 Planning Notes")
 
-# Delete (dry-run first, then confirm) (SSH only)
-remarkable_delete("Old Draft")           # Preview what would be deleted
-remarkable_delete("Old Draft", confirm=True)  # Actually delete
+# Delete (destructive — confirm with user first) (SSH only)
+remarkable_delete("Old Draft")
 ```
 
 ---

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -74,6 +74,11 @@ Security Note:
         action="store_true",
         help="Use USB web interface (connect via USB cable, enable in Storage Settings)",
     )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Enable write tools (upload, mkdir, move, rename, delete). SSH mode only.",
+    )
 
     args = parser.parse_args()
 
@@ -111,17 +116,29 @@ Security Note:
     elif args.usb:
         # USB web mode - set environment variable and run server
         os.environ["REMARKABLE_USE_USB_WEB"] = "1"
+        if args.write:
+            print(
+                "⚠️  --write flag ignored: write tools are only available in SSH mode.",
+                file=sys.stderr,
+            )
         from remarkable_mcp.server import run
 
         run()
     elif args.ssh:
         # SSH mode - set environment variable and run server
         os.environ["REMARKABLE_USE_SSH"] = "1"
+        if args.write:
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         from remarkable_mcp.server import run
 
         run()
     else:
         # MCP server mode - only now import the full server
+        if args.write:
+            print(
+                "⚠️  --write flag ignored: write tools are only available in SSH mode.",
+                file=sys.stderr,
+            )
         from remarkable_mcp.server import run
 
         run()

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -77,7 +77,7 @@ Security Note:
     parser.add_argument(
         "--write",
         action="store_true",
-        help="Enable write tools (upload, mkdir, move, rename, delete). SSH mode only.",
+        help="Enable write tools (upload, mkdir, move, rename, delete). SSH and USB web mode.",
     )
 
     args = parser.parse_args()
@@ -117,10 +117,7 @@ Security Note:
         # USB web mode - set environment variable and run server
         os.environ["REMARKABLE_USE_USB_WEB"] = "1"
         if args.write:
-            print(
-                "⚠️  --write flag ignored: write tools are only available in SSH mode.",
-                file=sys.stderr,
-            )
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         from remarkable_mcp.server import run
 
         run()
@@ -136,7 +133,7 @@ Security Note:
         # MCP server mode - only now import the full server
         if args.write:
             print(
-                "⚠️  --write flag ignored: write tools are only available in SSH mode.",
+                "⚠️  --write flag ignored: write tools require SSH or USB web mode.",
                 file=sys.stderr,
             )
         from remarkable_mcp.server import run

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -60,6 +60,11 @@ def _build_instructions() -> str:
     """Build server instructions based on current configuration."""
     # Check environment
     ssh_mode = os.environ.get("REMARKABLE_USE_SSH", "").lower() in ("1", "true", "yes")
+    usb_web_mode = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     has_google_vision = bool(os.environ.get("GOOGLE_VISION_API_KEY"))
     ocr_backend = os.environ.get("REMARKABLE_OCR_BACKEND", "auto").lower()
 
@@ -67,7 +72,7 @@ def _build_instructions() -> str:
         "1",
         "true",
         "yes",
-    )
+    ) and (ssh_mode or usb_web_mode)
 
     read_only_note = "" if write_mode else " All operations are read-only."
 
@@ -121,13 +126,7 @@ Documents are registered as resources for direct access:
 """
     )
 
-    # Add SSH-specific instructions
-    usb_web_mode = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-
+    # Add transport-specific instructions
     if ssh_mode:
         instructions += """
 ## SSH Mode (Active)

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -122,6 +122,12 @@ Documents are registered as resources for direct access:
     )
 
     # Add SSH-specific instructions
+    usb_web_mode = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
     if ssh_mode:
         instructions += """
 ## SSH Mode (Active)
@@ -136,13 +142,7 @@ You're connected directly to the tablet via SSH. This enables:
 - `"raw"` - Only original PDF/EPUB text (no annotations)
 - `"annotations"` - Only typed text, highlights, and OCR content
 """
-        # Add write tools instructions if enabled
-        write_enabled = os.environ.get("REMARKABLE_ENABLE_WRITE", "").lower() in (
-            "1",
-            "true",
-            "yes",
-        )
-        if write_enabled:
+        if write_mode:
             instructions += """
 ## Write Tools (Active)
 
@@ -158,6 +158,17 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - **Delete is destructive**: always call without `confirm` first to preview
 - After each write operation, the tablet UI restarts automatically
 - Use `remarkable_browse()` to verify changes after write operations
+"""
+    elif usb_web_mode:
+        if write_mode:
+            instructions += """
+## Write Tools (Active — USB Web)
+
+Upload is available via the USB web interface:
+
+- `remarkable_upload(file_path)` - Upload a PDF/EPUB file
+
+Note: mkdir, move, rename, and delete require SSH mode.
 """
     else:
         instructions += """

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -63,10 +63,18 @@ def _build_instructions() -> str:
     has_google_vision = bool(os.environ.get("GOOGLE_VISION_API_KEY"))
     ocr_backend = os.environ.get("REMARKABLE_OCR_BACKEND", "auto").lower()
 
-    instructions = """# reMarkable MCP Server
+    write_mode = os.environ.get("REMARKABLE_ENABLE_WRITE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
-Access documents from your reMarkable tablet. All operations are read-only.
+    read_only_note = "" if write_mode else " All operations are read-only."
 
+    instructions = (
+        "# reMarkable MCP Server\n\n"
+        f"Access documents from your reMarkable tablet.{read_only_note}\n"
+        """
 ## Available Tools
 
 - `remarkable_browse(path, query)` - Browse folders or search for documents
@@ -111,6 +119,7 @@ Documents are registered as resources for direct access:
 - `remarkableimg:///{path}.page-{N}.png` - Get PNG image of page N (notebooks only)
 - Use resources when you need complete document content without pagination
 """
+    )
 
     # Add SSH-specific instructions
     if ssh_mode:
@@ -126,6 +135,29 @@ You're connected directly to the tablet via SSH. This enables:
 - `"text"` (default) - Full content: raw PDF/EPUB text + annotations
 - `"raw"` - Only original PDF/EPUB text (no annotations)
 - `"annotations"` - Only typed text, highlights, and OCR content
+"""
+        # Add write tools instructions if enabled
+        write_enabled = os.environ.get("REMARKABLE_ENABLE_WRITE", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if write_enabled:
+            instructions += """
+## Write Tools (Active)
+
+Write operations are enabled. These tools modify your tablet's filesystem:
+
+- `remarkable_upload(file_path, parent_folder, document_name)` - Upload a PDF/EPUB
+- `remarkable_mkdir(folder_name, parent)` - Create a folder
+- `remarkable_move(document, dest_folder)` - Move a document/folder
+- `remarkable_rename(document, new_name)` - Rename a document/folder
+- `remarkable_delete(document, confirm)` - Delete (requires confirm=True)
+
+### Safety
+- **Delete is destructive**: always call without `confirm` first to preview
+- After each write operation, the tablet UI restarts automatically
+- Use `remarkable_browse()` to verify changes after write operations
 """
     else:
         instructions += """
@@ -218,6 +250,12 @@ from remarkable_mcp import (  # noqa: E402
     resources,  # noqa: F401
     tools,  # noqa: F401
 )
+
+# Conditionally register write tools when enabled
+from remarkable_mcp import write_tools as _write_tools  # noqa: E402
+
+if _write_tools.write_enabled():
+    _write_tools.register_write_tools()
 
 
 def run():

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -151,10 +151,10 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - `remarkable_mkdir(folder_name, parent)` - Create a folder
 - `remarkable_move(document, dest_folder)` - Move a document/folder
 - `remarkable_rename(document, new_name)` - Rename a document/folder
-- `remarkable_delete(document, confirm)` - Delete (requires confirm=True)
+- `remarkable_delete(document)` - Delete a document/folder (destructive)
 
 ### Safety
-- **Delete is destructive**: always call without `confirm` first to preview
+- **Delete is destructive** and immediate — the MCP client should confirm with the user first
 - After each write operation, the tablet UI restarts automatically
 - Use `remarkable_browse()` to verify changes after write operations
 """

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1,14 +1,16 @@
 """
-Write tools for reMarkable tablet via SSH.
+Write tools for reMarkable tablet via SSH or USB web interface.
 
 These tools are opt-in — disabled by default. Enable via:
-- CLI flag: remarkable-mcp --ssh --write
+- CLI flag: remarkable-mcp --ssh --write  (or --usb --write)
 - Environment variable: REMARKABLE_ENABLE_WRITE=1
 
-Only available in SSH mode. Cloud/USB-web modes return a clear error.
+Available in SSH mode and USB web mode. Cloud mode returns a clear error.
+- SSH mode: full write support (upload, mkdir, move, rename, delete)
+- USB web mode: upload only (via POST /upload endpoint)
 
 Inspired by PR #70 from @McSchnizzle. Implemented purely via SSH filesystem
-operations — no external Go binary required.
+operations and USB web HTTP endpoints — no external Go binary required.
 """
 
 import json
@@ -82,8 +84,36 @@ def write_enabled() -> bool:
     )
 
 
+def _require_write_transport() -> Optional[str]:
+    """Return an error string if not in a write-capable mode, or None if OK."""
+    ssh_enabled = os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    usb_web_enabled = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if not ssh_enabled and not usb_web_enabled:
+        return make_error(
+            error_type="write_transport_required",
+            message="Write operations require SSH or USB web mode",
+            suggestion=(
+                "Write tools work with SSH or USB web access to your tablet. "
+                "Run with: remarkable-mcp --ssh --write  (or --usb --write)\n"
+                "See: https://github.com/SamMorrowDrums/remarkable-mcp/blob/main/docs/ssh-setup.md"
+            ),
+        )
+    return None
+
+
 def _require_ssh_mode() -> Optional[str]:
-    """Return an error string if not in SSH mode, or None if OK."""
+    """Return an error string if not in SSH mode, or None if OK.
+
+    Used for operations that only work via SSH (mkdir, move, rename, delete).
+    """
     ssh_enabled = os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
         "1",
         "true",
@@ -92,14 +122,33 @@ def _require_ssh_mode() -> Optional[str]:
     if not ssh_enabled:
         return make_error(
             error_type="ssh_required",
-            message="Write operations require SSH mode",
+            message="This operation requires SSH mode",
             suggestion=(
-                "Write tools only work with direct SSH access to your tablet. "
+                "mkdir, move, rename, and delete only work with SSH access. "
+                "Upload works with both SSH and USB web mode.\n"
                 "Run with: remarkable-mcp --ssh --write\n"
                 "See: https://github.com/SamMorrowDrums/remarkable-mcp/blob/main/docs/ssh-setup.md"
             ),
         )
     return None
+
+
+def _is_ssh_mode() -> bool:
+    """Check if SSH transport is active."""
+    return os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _is_usb_web_mode() -> bool:
+    """Check if USB web transport is active."""
+    return os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 def _get_ssh_client():
@@ -157,6 +206,36 @@ def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str)
 def _restart_xochitl(ssh_client: SSHClient) -> None:
     """Restart the xochitl UI service on the tablet."""
     ssh_client._ssh_command("systemctl restart xochitl", timeout=15)
+
+
+def _upload_via_usb_web(local_path: str) -> dict:
+    """Upload a file to the tablet via USB web interface POST /upload.
+
+    Returns dict with upload result info.
+    """
+    import requests
+
+    from remarkable_mcp.usb_web import DEFAULT_USB_HOST
+
+    host = os.environ.get("REMARKABLE_USB_HOST", DEFAULT_USB_HOST).rstrip("/")
+    url = f"{host}/upload"
+
+    with open(local_path, "rb") as f:
+        filename = os.path.basename(local_path)
+        files = {"file": (filename, f)}
+        try:
+            response = requests.post(url, files=files, timeout=120)
+            response.raise_for_status()
+            return {"status": response.status_code, "ok": True}
+        except requests.Timeout:
+            raise RuntimeError("USB web upload timed out. Check USB connection.")
+        except requests.ConnectionError:
+            raise RuntimeError(
+                f"Cannot connect to USB web interface at {host}. "
+                "Make sure USB cable is connected and web interface is enabled."
+            )
+        except requests.HTTPError as e:
+            raise RuntimeError(f"USB web upload failed: {e}")
 
 
 def _resolve_parent_id(parent_path: str, items_by_id: dict, collection: list) -> Optional[str]:
@@ -228,16 +307,21 @@ def register_write_tools():
         """
         <usecase>Upload a PDF or EPUB file to the reMarkable tablet.</usecase>
         <instructions>
-        Uploads a local file to the tablet via SSH. Only PDF and EPUB formats
-        are supported. The file is transferred directly to the tablet's filesystem
-        and the UI is restarted to pick up the change.
+        Uploads a local file to the tablet. Only PDF and EPUB formats
+        are supported.
 
-        Requires SSH mode and --write flag.
+        Works in both SSH and USB web mode:
+        - SSH: file is transferred via SSH, metadata is created, xochitl restarts
+        - USB web: file is uploaded via POST /upload HTTP endpoint
+
+        Requires --write flag.
         </instructions>
         <parameters>
         - file_path: Absolute path to the local PDF or EPUB file
-        - parent_folder: Destination folder path on tablet (default: root "/")
-        - document_name: Display name on tablet (default: filename without extension)
+        - parent_folder: Destination folder path on tablet (default: root "/").
+          Note: parent_folder is only supported in SSH mode.
+        - document_name: Display name on tablet (default: filename without
+          extension). Note: document_name is only supported in SSH mode.
         </parameters>
         <examples>
         - remarkable_upload("/tmp/paper.pdf")
@@ -245,7 +329,7 @@ def register_write_tools():
         - remarkable_upload("/tmp/report.pdf", document_name="Q4 Report")
         </examples>
         """
-        error = _require_ssh_mode()
+        error = _require_write_transport()
         if error:
             return error
 
@@ -266,6 +350,33 @@ def register_write_tools():
                     suggestion="Only PDF and EPUB files can be uploaded to reMarkable.",
                 )
 
+            # USB web mode: simple HTTP upload
+            if _is_usb_web_mode():
+                _upload_via_usb_web(file_path)
+
+                name = document_name or os.path.splitext(os.path.basename(file_path))[0]
+
+                # Clear cached documents
+                client = get_rmapi()
+                client._documents = []
+                client._documents_by_id = {}
+
+                result = {
+                    "uploaded": True,
+                    "name": name,
+                    "format": ext,
+                    "transport": "usb-web",
+                }
+                if parent_folder != "/":
+                    result["note"] = (
+                        "USB web upload places files at root. Use SSH mode for folder placement."
+                    )
+                return make_response(
+                    result,
+                    "Document uploaded via USB web interface. Use remarkable_browse() to verify.",
+                )
+
+            # SSH mode: full upload with metadata
             ssh_client = _get_ssh_client()
             collection = ssh_client.get_meta_items()
             items_by_id = get_items_by_id(collection)
@@ -329,15 +440,17 @@ def register_write_tools():
                     "format": ext,
                     "parent_folder": parent_folder,
                     "remote_path": remote_file,
+                    "transport": "ssh",
                 },
                 "Document uploaded successfully. Use remarkable_browse() to verify it appears.",
             )
 
         except Exception as e:
+            transport = "USB web" if _is_usb_web_mode() else "SSH"
             return make_error(
                 error_type="upload_failed",
                 message=f"Upload failed: {e}",
-                suggestion="Check SSH connection and try again.",
+                suggestion=f"Check {transport} connection and try again.",
             )
 
     @mcp.tool(annotations=MKDIR_ANNOTATIONS)
@@ -351,7 +464,7 @@ def register_write_tools():
         Creates a folder in the tablet's document hierarchy. The folder appears
         in the tablet UI after xochitl restarts.
 
-        Requires SSH mode and --write flag.
+        Requires SSH mode and --write flag. Not available in USB web mode.
         </instructions>
         <parameters>
         - folder_name: Name of the new folder
@@ -434,7 +547,7 @@ def register_write_tools():
         Moves a document or folder by updating its parent reference in the metadata.
         Find the document name with remarkable_browse() first.
 
-        Requires SSH mode and --write flag.
+        Requires SSH mode and --write flag. Not available in USB web mode.
         </instructions>
         <parameters>
         - document: Name or path of the document/folder to move
@@ -523,7 +636,7 @@ def register_write_tools():
         Changes the display name of a document or folder by updating its metadata.
         Find the document name with remarkable_browse() first.
 
-        Requires SSH mode and --write flag.
+        Requires SSH mode and --write flag. Not available in USB web mode.
         </instructions>
         <parameters>
         - document: Current name or path of the document/folder
@@ -605,7 +718,7 @@ def register_write_tools():
         Safety: requires confirm=True to actually delete. Without it, returns
         a dry-run preview showing what would be deleted.
 
-        Requires SSH mode and --write flag.
+        Requires SSH mode and --write flag. Not available in USB web mode.
         </instructions>
         <parameters>
         - document: Name or path of the document/folder to delete

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -193,14 +193,26 @@ def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str)
         ssh_args = ["sshpass", "-p", ssh_client.password] + ssh_args
 
     with open(local_path, "rb") as f:
-        result = subprocess.run(
-            ssh_args,
-            stdin=f,
-            capture_output=True,
-            timeout=120,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"Upload failed: {result.stderr.decode()}")
+        try:
+            result = subprocess.run(
+                ssh_args,
+                stdin=f,
+                capture_output=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"Upload failed: {result.stderr.decode()}")
+        except FileNotFoundError as e:
+            if ssh_client.password and "sshpass" in str(e):
+                raise RuntimeError(
+                    "sshpass not found. Install it with: "
+                    "apt install sshpass (Debian/Ubuntu), "
+                    "brew install hudochenkov/sshpass/sshpass (macOS), "
+                    "or set up SSH key authentication instead."
+                )
+            raise RuntimeError("SSH client not found. Install openssh-client.")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("SSH upload timed out after 120s")
 
 
 def _restart_xochitl(ssh_client: SSHClient) -> None:
@@ -588,6 +600,28 @@ def register_write_tools():
                     message=f"Destination folder not found: '{dest_folder}'",
                     suggestion="Use remarkable_browse('/') to see available folders.",
                 )
+
+            # Prevent moving a folder into itself or a descendant
+            if target.is_folder:
+                if dest_id == target.ID:
+                    return make_error(
+                        error_type="invalid_move",
+                        message="Cannot move a folder into itself",
+                        suggestion="Choose a different destination folder.",
+                    )
+                # Walk up from dest to check for cycles
+                check_id = dest_id
+                while check_id and check_id in items_by_id:
+                    if check_id == target.ID:
+                        return make_error(
+                            error_type="invalid_move",
+                            message="Cannot move a folder into one of its subfolders",
+                            suggestion=(
+                                "Choose a destination that is not inside the folder being moved."
+                            ),
+                        )
+                    parent_item = items_by_id[check_id]
+                    check_id = parent_item.Parent if hasattr(parent_item, "Parent") else ""
 
             # Read existing metadata
             meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1,0 +1,692 @@
+"""
+Write tools for reMarkable tablet via SSH.
+
+These tools are opt-in — disabled by default. Enable via:
+- CLI flag: remarkable-mcp --ssh --write
+- Environment variable: REMARKABLE_ENABLE_WRITE=1
+
+Only available in SSH mode. Cloud/USB-web modes return a clear error.
+
+Inspired by PR #70 from @McSchnizzle. Implemented purely via SSH filesystem
+operations — no external Go binary required.
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+from typing import Optional
+
+from mcp.types import ToolAnnotations
+
+from remarkable_mcp.api import (
+    get_item_path,
+    get_items_by_id,
+    get_rmapi,
+)
+from remarkable_mcp.responses import make_error, make_response
+from remarkable_mcp.server import mcp
+from remarkable_mcp.ssh import XOCHITL_PATH, SSHClient
+
+logger = logging.getLogger(__name__)
+
+# Tool annotations for write operations
+UPLOAD_ANNOTATIONS = ToolAnnotations(
+    title="Upload Document to reMarkable",
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+MKDIR_ANNOTATIONS = ToolAnnotations(
+    title="Create Folder on reMarkable",
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+MOVE_ANNOTATIONS = ToolAnnotations(
+    title="Move reMarkable Document",
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+RENAME_ANNOTATIONS = ToolAnnotations(
+    title="Rename reMarkable Document",
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+DELETE_ANNOTATIONS = ToolAnnotations(
+    title="Delete reMarkable Document",
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+
+def write_enabled() -> bool:
+    """Check if write tools are enabled via environment variable."""
+    return os.environ.get("REMARKABLE_ENABLE_WRITE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _require_ssh_mode() -> Optional[str]:
+    """Return an error string if not in SSH mode, or None if OK."""
+    ssh_enabled = os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if not ssh_enabled:
+        return make_error(
+            error_type="ssh_required",
+            message="Write operations require SSH mode",
+            suggestion=(
+                "Write tools only work with direct SSH access to your tablet. "
+                "Run with: remarkable-mcp --ssh --write\n"
+                "See: https://github.com/SamMorrowDrums/remarkable-mcp/blob/main/docs/ssh-setup.md"
+            ),
+        )
+    return None
+
+
+def _get_ssh_client():
+    """Get the current API client (expected to be SSHClient in SSH mode)."""
+    return get_rmapi()
+
+
+def _write_metadata(ssh_client: SSHClient, doc_uuid: str, metadata: dict) -> None:
+    """Write a metadata JSON file to the tablet."""
+    content = json.dumps(metadata, indent=2)
+    remote_path = f"{XOCHITL_PATH}/{doc_uuid}.metadata"
+    ssh_client._ssh_command(f"cat > '{remote_path}' << 'REMARKABLE_EOF'\n{content}\nREMARKABLE_EOF")
+
+
+def _write_content_file(ssh_client: SSHClient, doc_uuid: str, content_data: dict) -> None:
+    """Write a .content JSON file to the tablet."""
+    content = json.dumps(content_data, indent=2)
+    remote_path = f"{XOCHITL_PATH}/{doc_uuid}.content"
+    ssh_client._ssh_command(f"cat > '{remote_path}' << 'REMARKABLE_EOF'\n{content}\nREMARKABLE_EOF")
+
+
+def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str) -> None:
+    """Upload a local file to the tablet via SSH stdin pipe."""
+    import subprocess
+
+    ssh_args = [
+        "ssh",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-p",
+        str(ssh_client.port),
+        f"{ssh_client.user}@{ssh_client.host}",
+        f"cat > '{remote_path}'",
+    ]
+
+    if not ssh_client.password:
+        ssh_args.insert(1, "-o")
+        ssh_args.insert(2, "BatchMode=yes")
+    else:
+        ssh_args = ["sshpass", "-p", ssh_client.password] + ssh_args
+
+    with open(local_path, "rb") as f:
+        result = subprocess.run(
+            ssh_args,
+            stdin=f,
+            capture_output=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Upload failed: {result.stderr.decode()}")
+
+
+def _restart_xochitl(ssh_client: SSHClient) -> None:
+    """Restart the xochitl UI service on the tablet."""
+    ssh_client._ssh_command("systemctl restart xochitl", timeout=15)
+
+
+def _resolve_parent_id(parent_path: str, items_by_id: dict, collection: list) -> Optional[str]:
+    """Resolve a folder path to its UUID.
+
+    Args:
+        parent_path: Path like "/" or "/Folder/Subfolder"
+        items_by_id: Dict mapping item IDs to items
+        collection: Full list of items
+
+    Returns:
+        The UUID of the folder, "" for root, or None if not found
+    """
+    if not parent_path or parent_path == "/":
+        return ""
+
+    # Normalize
+    parent_path = parent_path.strip("/")
+
+    for item in collection:
+        if not item.is_folder:
+            continue
+        item_path = get_item_path(item, items_by_id).strip("/")
+        if item_path.lower() == parent_path.lower():
+            return item.ID
+
+    return None
+
+
+def _resolve_document(
+    name_or_path: str, collection: list, items_by_id: dict, folders_only: bool = False
+) -> Optional[object]:
+    """Find a document or folder by name or path.
+
+    Args:
+        name_or_path: Document name or full path
+        collection: Full list of items
+        items_by_id: Dict mapping item IDs to items
+        folders_only: If True, only match folders
+
+    Returns:
+        The matching item, or None
+    """
+    target = name_or_path.lower().strip("/")
+
+    for item in collection:
+        if folders_only and not item.is_folder:
+            continue
+        # Match by name
+        if item.VissibleName.lower() == target:
+            return item
+        # Match by path
+        item_path = get_item_path(item, items_by_id).strip("/")
+        if item_path.lower() == target:
+            return item
+
+    return None
+
+
+def register_write_tools():
+    """Register all write tools with the MCP server."""
+
+    @mcp.tool(annotations=UPLOAD_ANNOTATIONS)
+    async def remarkable_upload(
+        file_path: str,
+        parent_folder: str = "/",
+        document_name: Optional[str] = None,
+    ) -> str:
+        """
+        <usecase>Upload a PDF or EPUB file to the reMarkable tablet.</usecase>
+        <instructions>
+        Uploads a local file to the tablet via SSH. Only PDF and EPUB formats
+        are supported. The file is transferred directly to the tablet's filesystem
+        and the UI is restarted to pick up the change.
+
+        Requires SSH mode and --write flag.
+        </instructions>
+        <parameters>
+        - file_path: Absolute path to the local PDF or EPUB file
+        - parent_folder: Destination folder path on tablet (default: root "/")
+        - document_name: Display name on tablet (default: filename without extension)
+        </parameters>
+        <examples>
+        - remarkable_upload("/tmp/paper.pdf")
+        - remarkable_upload("/tmp/book.epub", parent_folder="/Books")
+        - remarkable_upload("/tmp/report.pdf", document_name="Q4 Report")
+        </examples>
+        """
+        error = _require_ssh_mode()
+        if error:
+            return error
+
+        try:
+            # Validate file
+            if not os.path.isfile(file_path):
+                return make_error(
+                    error_type="file_not_found",
+                    message=f"File not found: '{file_path}'",
+                    suggestion="Provide an absolute path to an existing PDF or EPUB file.",
+                )
+
+            ext = os.path.splitext(file_path)[1].lower().lstrip(".")
+            if ext not in ("pdf", "epub"):
+                return make_error(
+                    error_type="unsupported_format",
+                    message=f"Unsupported file format: '.{ext}'",
+                    suggestion="Only PDF and EPUB files can be uploaded to reMarkable.",
+                )
+
+            ssh_client = _get_ssh_client()
+            collection = ssh_client.get_meta_items()
+            items_by_id = get_items_by_id(collection)
+
+            # Resolve parent folder
+            parent_id = _resolve_parent_id(parent_folder, items_by_id, collection)
+            if parent_id is None:
+                folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+                return make_error(
+                    error_type="folder_not_found",
+                    message=f"Folder not found: '{parent_folder}'",
+                    suggestion="Use remarkable_browse('/') to see available folders.",
+                    did_you_mean=folders[:5] if folders else None,
+                )
+
+            # Generate UUID and set name
+            doc_uuid = str(uuid.uuid4())
+            name = document_name or os.path.splitext(os.path.basename(file_path))[0]
+            timestamp_ms = str(int(time.time() * 1000))
+
+            # Upload the file
+            remote_file = f"{XOCHITL_PATH}/{doc_uuid}.{ext}"
+            _upload_file_bytes(ssh_client, file_path, remote_file)
+
+            # Create metadata
+            metadata = {
+                "visibleName": name,
+                "type": "DocumentType",
+                "parent": parent_id,
+                "deleted": False,
+                "pinned": False,
+                "lastModified": timestamp_ms,
+                "metadatamodified": True,
+                "modified": True,
+                "synced": False,
+                "version": 0,
+            }
+            _write_metadata(ssh_client, doc_uuid, metadata)
+
+            # Create content file
+            content_data = {
+                "fileType": ext,
+            }
+            _write_content_file(ssh_client, doc_uuid, content_data)
+
+            # Create the document directory (required by xochitl)
+            ssh_client._ssh_command(f"mkdir -p '{XOCHITL_PATH}/{doc_uuid}'")
+
+            # Restart xochitl to pick up changes
+            _restart_xochitl(ssh_client)
+
+            # Clear cached documents so next read picks up the new doc
+            ssh_client._documents = []
+            ssh_client._documents_by_id = {}
+
+            return make_response(
+                {
+                    "uploaded": True,
+                    "name": name,
+                    "uuid": doc_uuid,
+                    "format": ext,
+                    "parent_folder": parent_folder,
+                    "remote_path": remote_file,
+                },
+                "Document uploaded successfully. Use remarkable_browse() to verify it appears.",
+            )
+
+        except Exception as e:
+            return make_error(
+                error_type="upload_failed",
+                message=f"Upload failed: {e}",
+                suggestion="Check SSH connection and try again.",
+            )
+
+    @mcp.tool(annotations=MKDIR_ANNOTATIONS)
+    async def remarkable_mkdir(
+        folder_name: str,
+        parent: str = "/",
+    ) -> str:
+        """
+        <usecase>Create a new folder on the reMarkable tablet.</usecase>
+        <instructions>
+        Creates a folder in the tablet's document hierarchy. The folder appears
+        in the tablet UI after xochitl restarts.
+
+        Requires SSH mode and --write flag.
+        </instructions>
+        <parameters>
+        - folder_name: Name of the new folder
+        - parent: Parent folder path (default: root "/")
+        </parameters>
+        <examples>
+        - remarkable_mkdir("Projects")
+        - remarkable_mkdir("2024", parent="/Archive")
+        </examples>
+        """
+        error = _require_ssh_mode()
+        if error:
+            return error
+
+        try:
+            ssh_client = _get_ssh_client()
+            collection = ssh_client.get_meta_items()
+            items_by_id = get_items_by_id(collection)
+
+            # Resolve parent
+            parent_id = _resolve_parent_id(parent, items_by_id, collection)
+            if parent_id is None:
+                return make_error(
+                    error_type="folder_not_found",
+                    message=f"Parent folder not found: '{parent}'",
+                    suggestion="Use remarkable_browse('/') to see available folders.",
+                )
+
+            # Generate UUID
+            doc_uuid = str(uuid.uuid4())
+            timestamp_ms = str(int(time.time() * 1000))
+
+            # Create metadata for folder
+            metadata = {
+                "visibleName": folder_name,
+                "type": "CollectionType",
+                "parent": parent_id,
+                "deleted": False,
+                "pinned": False,
+                "lastModified": timestamp_ms,
+                "metadatamodified": True,
+                "modified": True,
+                "synced": False,
+                "version": 0,
+            }
+            _write_metadata(ssh_client, doc_uuid, metadata)
+
+            # Restart xochitl
+            _restart_xochitl(ssh_client)
+
+            # Clear cache
+            ssh_client._documents = []
+            ssh_client._documents_by_id = {}
+
+            return make_response(
+                {
+                    "created": True,
+                    "folder_name": folder_name,
+                    "uuid": doc_uuid,
+                    "parent": parent,
+                },
+                "Folder created. Use remarkable_browse() to verify.",
+            )
+
+        except Exception as e:
+            return make_error(
+                error_type="mkdir_failed",
+                message=f"Failed to create folder: {e}",
+                suggestion="Check SSH connection and try again.",
+            )
+
+    @mcp.tool(annotations=MOVE_ANNOTATIONS)
+    async def remarkable_move(
+        document: str,
+        dest_folder: str,
+    ) -> str:
+        """
+        <usecase>Move a document or folder to a different location.</usecase>
+        <instructions>
+        Moves a document or folder by updating its parent reference in the metadata.
+        Find the document name with remarkable_browse() first.
+
+        Requires SSH mode and --write flag.
+        </instructions>
+        <parameters>
+        - document: Name or path of the document/folder to move
+        - dest_folder: Destination folder path (use "/" for root)
+        </parameters>
+        <examples>
+        - remarkable_move("Meeting Notes", "/Archive")
+        - remarkable_move("Old Project", "/Archive/2023")
+        </examples>
+        """
+        error = _require_ssh_mode()
+        if error:
+            return error
+
+        try:
+            ssh_client = _get_ssh_client()
+            collection = ssh_client.get_meta_items()
+            items_by_id = get_items_by_id(collection)
+
+            # Find the document
+            target = _resolve_document(document, collection, items_by_id)
+            if not target:
+                from remarkable_mcp.extract import find_similar_documents
+
+                similar = find_similar_documents(document, collection)
+                return make_error(
+                    error_type="document_not_found",
+                    message=f"Document not found: '{document}'",
+                    suggestion="Use remarkable_browse() to find the correct name.",
+                    did_you_mean=similar if similar else None,
+                )
+
+            # Find the destination folder
+            dest_id = _resolve_parent_id(dest_folder, items_by_id, collection)
+            if dest_id is None:
+                return make_error(
+                    error_type="folder_not_found",
+                    message=f"Destination folder not found: '{dest_folder}'",
+                    suggestion="Use remarkable_browse('/') to see available folders.",
+                )
+
+            # Read existing metadata
+            meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+            metadata = json.loads(meta_content.decode("utf-8"))
+
+            old_path = get_item_path(target, items_by_id)
+
+            # Update parent
+            metadata["parent"] = dest_id
+            metadata["lastModified"] = str(int(time.time() * 1000))
+            metadata["metadatamodified"] = True
+            _write_metadata(ssh_client, target.ID, metadata)
+
+            # Restart xochitl
+            _restart_xochitl(ssh_client)
+
+            # Clear cache
+            ssh_client._documents = []
+            ssh_client._documents_by_id = {}
+
+            return make_response(
+                {
+                    "moved": True,
+                    "name": target.VissibleName,
+                    "from": old_path,
+                    "to": dest_folder,
+                },
+                "Document moved. Use remarkable_browse() to verify.",
+            )
+
+        except Exception as e:
+            return make_error(
+                error_type="move_failed",
+                message=f"Failed to move document: {e}",
+                suggestion="Check SSH connection and try again.",
+            )
+
+    @mcp.tool(annotations=RENAME_ANNOTATIONS)
+    async def remarkable_rename(
+        document: str,
+        new_name: str,
+    ) -> str:
+        """
+        <usecase>Rename a document or folder on the reMarkable tablet.</usecase>
+        <instructions>
+        Changes the display name of a document or folder by updating its metadata.
+        Find the document name with remarkable_browse() first.
+
+        Requires SSH mode and --write flag.
+        </instructions>
+        <parameters>
+        - document: Current name or path of the document/folder
+        - new_name: New display name
+        </parameters>
+        <examples>
+        - remarkable_rename("Untitled", "Meeting Notes 2024-01-15")
+        - remarkable_rename("/Work/Draft", "Final Report")
+        </examples>
+        """
+        error = _require_ssh_mode()
+        if error:
+            return error
+
+        try:
+            ssh_client = _get_ssh_client()
+            collection = ssh_client.get_meta_items()
+            items_by_id = get_items_by_id(collection)
+
+            # Find the document
+            target = _resolve_document(document, collection, items_by_id)
+            if not target:
+                from remarkable_mcp.extract import find_similar_documents
+
+                similar = find_similar_documents(document, collection)
+                return make_error(
+                    error_type="document_not_found",
+                    message=f"Document not found: '{document}'",
+                    suggestion="Use remarkable_browse() to find the correct name.",
+                    did_you_mean=similar if similar else None,
+                )
+
+            # Read existing metadata
+            meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+            metadata = json.loads(meta_content.decode("utf-8"))
+
+            old_name = metadata.get("visibleName", target.VissibleName)
+
+            # Update name
+            metadata["visibleName"] = new_name
+            metadata["lastModified"] = str(int(time.time() * 1000))
+            metadata["metadatamodified"] = True
+            _write_metadata(ssh_client, target.ID, metadata)
+
+            # Restart xochitl
+            _restart_xochitl(ssh_client)
+
+            # Clear cache
+            ssh_client._documents = []
+            ssh_client._documents_by_id = {}
+
+            return make_response(
+                {
+                    "renamed": True,
+                    "old_name": old_name,
+                    "new_name": new_name,
+                },
+                "Document renamed. Use remarkable_browse() to verify.",
+            )
+
+        except Exception as e:
+            return make_error(
+                error_type="rename_failed",
+                message=f"Failed to rename document: {e}",
+                suggestion="Check SSH connection and try again.",
+            )
+
+    @mcp.tool(annotations=DELETE_ANNOTATIONS)
+    async def remarkable_delete(
+        document: str,
+        confirm: bool = False,
+    ) -> str:
+        """
+        <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
+        <instructions>
+        DESTRUCTIVE operation — marks a document as deleted in its metadata.
+        The document won't appear in the tablet UI after restart.
+
+        Safety: requires confirm=True to actually delete. Without it, returns
+        a dry-run preview showing what would be deleted.
+
+        Requires SSH mode and --write flag.
+        </instructions>
+        <parameters>
+        - document: Name or path of the document/folder to delete
+        - confirm: Must be True to actually delete (default: False for dry-run)
+        </parameters>
+        <examples>
+        - remarkable_delete("Old Notes")  # Dry-run preview
+        - remarkable_delete("Old Notes", confirm=True)  # Actually delete
+        </examples>
+        """
+        error = _require_ssh_mode()
+        if error:
+            return error
+
+        try:
+            ssh_client = _get_ssh_client()
+            collection = ssh_client.get_meta_items()
+            items_by_id = get_items_by_id(collection)
+
+            # Find the document
+            target = _resolve_document(document, collection, items_by_id)
+            if not target:
+                from remarkable_mcp.extract import find_similar_documents
+
+                similar = find_similar_documents(document, collection)
+                return make_error(
+                    error_type="document_not_found",
+                    message=f"Document not found: '{document}'",
+                    suggestion="Use remarkable_browse() to find the correct name.",
+                    did_you_mean=similar if similar else None,
+                )
+
+            doc_path = get_item_path(target, items_by_id)
+
+            if not confirm:
+                # Dry-run: show what would be deleted
+                return make_response(
+                    {
+                        "dry_run": True,
+                        "would_delete": {
+                            "name": target.VissibleName,
+                            "path": doc_path,
+                            "type": "folder" if target.is_folder else "document",
+                            "uuid": target.ID,
+                        },
+                        "confirm_required": True,
+                    },
+                    "This is a dry-run preview. To actually delete, call "
+                    f'remarkable_delete("{document}", confirm=True).',
+                )
+
+            # Read existing metadata
+            meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+            metadata = json.loads(meta_content.decode("utf-8"))
+
+            # Mark as deleted
+            metadata["deleted"] = True
+            metadata["lastModified"] = str(int(time.time() * 1000))
+            metadata["metadatamodified"] = True
+            _write_metadata(ssh_client, target.ID, metadata)
+
+            # Restart xochitl
+            _restart_xochitl(ssh_client)
+
+            # Clear cache
+            ssh_client._documents = []
+            ssh_client._documents_by_id = {}
+
+            return make_response(
+                {
+                    "deleted": True,
+                    "name": target.VissibleName,
+                    "path": doc_path,
+                    "type": "folder" if target.is_folder else "document",
+                },
+                "Document deleted. It will no longer appear on the tablet.",
+            )
+
+        except Exception as e:
+            return make_error(
+                error_type="delete_failed",
+                message=f"Failed to delete document: {e}",
+                suggestion="Check SSH connection and try again.",
+            )

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -34,45 +34,12 @@ from remarkable_mcp.ssh import XOCHITL_PATH, SSHClient
 logger = logging.getLogger(__name__)
 
 # Tool annotations for write operations
-UPLOAD_ANNOTATIONS = ToolAnnotations(
-    title="Upload Document to reMarkable",
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=False,
-)
-
-MKDIR_ANNOTATIONS = ToolAnnotations(
-    title="Create Folder on reMarkable",
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=False,
-)
-
-MOVE_ANNOTATIONS = ToolAnnotations(
-    title="Move reMarkable Document",
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=False,
-)
-
-RENAME_ANNOTATIONS = ToolAnnotations(
-    title="Rename reMarkable Document",
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=False,
-)
-
-DELETE_ANNOTATIONS = ToolAnnotations(
-    title="Delete reMarkable Document",
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=False,
-)
+WRITE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False)
+UPLOAD_ANNOTATIONS = WRITE_ANNOTATIONS
+MKDIR_ANNOTATIONS = WRITE_ANNOTATIONS
+MOVE_ANNOTATIONS = WRITE_ANNOTATIONS
+RENAME_ANNOTATIONS = WRITE_ANNOTATIONS
+DELETE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
 
 
 def write_enabled() -> bool:
@@ -739,28 +706,23 @@ def register_write_tools():
             )
 
     @mcp.tool(annotations=DELETE_ANNOTATIONS)
-    async def remarkable_delete(
-        document: str,
-        confirm: bool = False,
-    ) -> str:
+    async def remarkable_delete(document: str) -> str:
         """
         <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
         <instructions>
         DESTRUCTIVE operation — marks a document as deleted in its metadata.
         The document won't appear in the tablet UI after restart.
 
-        Safety: requires confirm=True to actually delete. Without it, returns
-        a dry-run preview showing what would be deleted.
-
         Requires SSH mode and --write flag. Not available in USB web mode.
+        The MCP client is responsible for any user confirmation; this tool
+        performs the delete immediately.
         </instructions>
         <parameters>
         - document: Name or path of the document/folder to delete
-        - confirm: Must be True to actually delete (default: False for dry-run)
         </parameters>
         <examples>
-        - remarkable_delete("Old Notes")  # Dry-run preview
-        - remarkable_delete("Old Notes", confirm=True)  # Actually delete
+        - remarkable_delete("Old Notes")
+        - remarkable_delete("/Books/Archive/Old Draft")
         </examples>
         """
         error = _require_ssh_mode()
@@ -786,23 +748,6 @@ def register_write_tools():
                 )
 
             doc_path = get_item_path(target, items_by_id)
-
-            if not confirm:
-                # Dry-run: show what would be deleted
-                return make_response(
-                    {
-                        "dry_run": True,
-                        "would_delete": {
-                            "name": target.VissibleName,
-                            "path": doc_path,
-                            "type": "folder" if target.is_folder else "document",
-                            "uuid": target.ID,
-                        },
-                        "confirm_required": True,
-                    },
-                    "This is a dry-run preview. To actually delete, call "
-                    f'remarkable_delete("{document}", confirm=True).',
-                )
 
             # Read existing metadata
             meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")

--- a/test_server.py
+++ b/test_server.py
@@ -2215,3 +2215,84 @@ class TestWriteTools:
                 "remarkable_delete",
             ]:
                 mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_upload_error_in_cloud_mode(self):
+        """Test that upload returns error in cloud mode (no SSH or USB web)."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        register_write_tools()
+
+        try:
+            # Ensure neither SSH nor USB web mode is set
+            old_ssh = os.environ.pop("REMARKABLE_USE_SSH", None)
+            old_usb = os.environ.pop("REMARKABLE_USE_USB_WEB", None)
+            try:
+                import importlib
+
+                import remarkable_mcp.api
+
+                importlib.reload(remarkable_mcp.api)
+
+                result = await mcp.call_tool(
+                    "remarkable_upload",
+                    {"file_path": "/tmp/test.pdf"},
+                )
+                data = json.loads(result[0][0].text)
+                assert "_error" in data
+                assert data["_error"]["type"] == "write_transport_required"
+                assert "SSH or USB web" in data["_error"]["message"]
+            finally:
+                if old_ssh is not None:
+                    os.environ["REMARKABLE_USE_SSH"] = old_ssh
+                if old_usb is not None:
+                    os.environ["REMARKABLE_USE_USB_WEB"] = old_usb
+                importlib.reload(remarkable_mcp.api)
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_mkdir_error_in_usb_web_mode(self):
+        """Test that mkdir returns SSH-required error in USB web mode."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        register_write_tools()
+
+        try:
+            old_ssh = os.environ.pop("REMARKABLE_USE_SSH", None)
+            os.environ["REMARKABLE_USE_USB_WEB"] = "1"
+            try:
+                import importlib
+
+                import remarkable_mcp.api
+
+                importlib.reload(remarkable_mcp.api)
+
+                result = await mcp.call_tool(
+                    "remarkable_mkdir",
+                    {"folder_name": "Test"},
+                )
+                data = json.loads(result[0][0].text)
+                assert "_error" in data
+                assert data["_error"]["type"] == "ssh_required"
+            finally:
+                if old_ssh is not None:
+                    os.environ["REMARKABLE_USE_SSH"] = old_ssh
+                os.environ.pop("REMARKABLE_USE_USB_WEB", None)
+                importlib.reload(remarkable_mcp.api)
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)

--- a/test_server.py
+++ b/test_server.py
@@ -1838,6 +1838,7 @@ class TestUSBWebInterface:
 # Test Retry Backoff
 # =============================================================================
 
+
 class TestRetryBackoff:
     """Test retry with exponential backoff for cloud API requests."""
 
@@ -2075,8 +2076,8 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_delete_dry_run(self):
-        """Test that delete without confirm returns preview."""
+    async def test_delete_marks_document_deleted(self):
+        """Test that delete marks the document's metadata as deleted."""
         from remarkable_mcp.write_tools import register_write_tools
 
         register_write_tools()
@@ -2091,6 +2092,8 @@ class TestWriteTools:
 
             with (
                 patch("remarkable_mcp.write_tools.get_rmapi") as mock_get_rmapi,
+                patch("remarkable_mcp.write_tools._write_metadata") as mock_write_meta,
+                patch("remarkable_mcp.write_tools._restart_xochitl"),
                 patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
             ):
                 import importlib
@@ -2114,6 +2117,9 @@ class TestWriteTools:
                         ]
                     )
                     mock_client.get_meta_items.return_value = [mock_doc]
+                    mock_client._scp_download.return_value = (
+                        b'{"visibleName": "Test Doc", "deleted": false}'
+                    )
                     mock_get_rmapi.return_value = mock_client
 
                     result = await mcp.call_tool(
@@ -2123,9 +2129,12 @@ class TestWriteTools:
                         },
                     )
                     data = json.loads(result[0][0].text)
-                    assert data["dry_run"] is True
-                    assert data["confirm_required"] is True
-                    assert data["would_delete"]["name"] == "Test Doc"
+                    assert data["deleted"] is True
+                    assert data["name"] == "Test Doc"
+                    # Verify metadata was written with deleted=True
+                    mock_write_meta.assert_called_once()
+                    written_metadata = mock_write_meta.call_args[0][2]
+                    assert written_metadata["deleted"] is True
                 finally:
                     if "REMARKABLE_USE_SSH" in os.environ:
                         del os.environ["REMARKABLE_USE_SSH"]

--- a/test_server.py
+++ b/test_server.py
@@ -6,6 +6,7 @@ Tests the 4 intent-based tools using FastMCP's testing capabilities.
 """
 
 import json
+import os
 import shutil
 import tempfile
 import zipfile
@@ -1837,7 +1838,6 @@ class TestUSBWebInterface:
 # Test Retry Backoff
 # =============================================================================
 
-
 class TestRetryBackoff:
     """Test retry with exponential backoff for cloud API requests."""
 
@@ -1974,3 +1974,244 @@ class TestRetryBackoff:
         result = _http_request_with_retry("GET", "https://example.com/api")
         assert result.status_code == 503
         assert mock_request.call_count == 3
+
+
+# =============================================================================
+# Test Write Tools
+# =============================================================================
+
+
+class TestWriteTools:
+    """Test write tools opt-in behavior and safety checks."""
+
+    def test_write_enabled_default_off(self):
+        """Test that write_enabled() returns False by default."""
+        from remarkable_mcp.write_tools import write_enabled
+
+        # Ensure env var is not set
+        old = os.environ.pop("REMARKABLE_ENABLE_WRITE", None)
+        try:
+            assert write_enabled() is False
+        finally:
+            if old is not None:
+                os.environ["REMARKABLE_ENABLE_WRITE"] = old
+
+    def test_write_enabled_with_env_var(self):
+        """Test that write_enabled() returns True with env var."""
+        from remarkable_mcp.write_tools import write_enabled
+
+        old = os.environ.get("REMARKABLE_ENABLE_WRITE")
+        try:
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+            assert write_enabled() is True
+
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "true"
+            assert write_enabled() is True
+
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "yes"
+            assert write_enabled() is True
+
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "0"
+            assert write_enabled() is False
+
+            os.environ["REMARKABLE_ENABLE_WRITE"] = ""
+            assert write_enabled() is False
+        finally:
+            if old is not None:
+                os.environ["REMARKABLE_ENABLE_WRITE"] = old
+            else:
+                os.environ.pop("REMARKABLE_ENABLE_WRITE", None)
+
+    @pytest.mark.asyncio
+    async def test_write_tools_not_registered_by_default(self):
+        """Test that write tools are NOT registered without --write flag."""
+        tools = await mcp.list_tools()
+        tool_names = [tool.name for tool in tools]
+
+        write_tool_names = [
+            "remarkable_upload",
+            "remarkable_mkdir",
+            "remarkable_move",
+            "remarkable_rename",
+            "remarkable_delete",
+        ]
+
+        for tool_name in write_tool_names:
+            assert tool_name not in tool_names, (
+                f"Write tool {tool_name} should not be registered without --write flag"
+            )
+
+    @pytest.mark.asyncio
+    async def test_write_tools_registered_when_enabled(self):
+        """Test that write tools ARE registered with REMARKABLE_ENABLE_WRITE=1."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        # Register the tools
+        register_write_tools()
+
+        try:
+            tools = await mcp.list_tools()
+            tool_names = [tool.name for tool in tools]
+
+            write_tool_names = [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]
+
+            for tool_name in write_tool_names:
+                assert tool_name in tool_names, f"Write tool {tool_name} should be registered"
+        finally:
+            # Clean up: remove registered tools to not affect other tests
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_delete_dry_run(self):
+        """Test that delete without confirm returns preview."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        register_write_tools()
+
+        try:
+            mock_doc = Mock()
+            mock_doc.VissibleName = "Test Doc"
+            mock_doc.ID = "doc-123"
+            mock_doc.Parent = ""
+            mock_doc.is_folder = False
+            mock_doc.is_cloud_archived = False
+
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi") as mock_get_rmapi,
+                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            ):
+                import importlib
+
+                import remarkable_mcp.api
+
+                importlib.reload(remarkable_mcp.api)
+
+                try:
+                    mock_client = Mock(
+                        spec=[
+                            "get_meta_items",
+                            "_scp_download",
+                            "_ssh_command",
+                            "_documents",
+                            "_documents_by_id",
+                            "host",
+                            "user",
+                            "port",
+                            "password",
+                        ]
+                    )
+                    mock_client.get_meta_items.return_value = [mock_doc]
+                    mock_get_rmapi.return_value = mock_client
+
+                    result = await mcp.call_tool(
+                        "remarkable_delete",
+                        {
+                            "document": "Test Doc",
+                        },
+                    )
+                    data = json.loads(result[0][0].text)
+                    assert data["dry_run"] is True
+                    assert data["confirm_required"] is True
+                    assert data["would_delete"]["name"] == "Test Doc"
+                finally:
+                    if "REMARKABLE_USE_SSH" in os.environ:
+                        del os.environ["REMARKABLE_USE_SSH"]
+                    importlib.reload(remarkable_mcp.api)
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_write_tools_error_in_cloud_mode(self):
+        """Test that write tools return error in cloud mode."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        register_write_tools()
+
+        try:
+            # Ensure NOT in SSH mode
+            old_ssh = os.environ.pop("REMARKABLE_USE_SSH", None)
+            try:
+                import importlib
+
+                import remarkable_mcp.api
+
+                importlib.reload(remarkable_mcp.api)
+
+                result = await mcp.call_tool(
+                    "remarkable_mkdir",
+                    {
+                        "folder_name": "Test",
+                    },
+                )
+                data = json.loads(result[0][0].text)
+                assert "_error" in data
+                assert data["_error"]["type"] == "ssh_required"
+                assert "SSH mode" in data["_error"]["message"]
+            finally:
+                if old_ssh is not None:
+                    os.environ["REMARKABLE_USE_SSH"] = old_ssh
+                importlib.reload(remarkable_mcp.api)
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_all_write_tools_have_xml_docstrings(self):
+        """Test that all write tools have XML-structured documentation."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        register_write_tools()
+
+        try:
+            tools = await mcp.list_tools()
+            write_tools = [
+                t
+                for t in tools
+                if t.name
+                in (
+                    "remarkable_upload",
+                    "remarkable_mkdir",
+                    "remarkable_move",
+                    "remarkable_rename",
+                    "remarkable_delete",
+                )
+            ]
+
+            for tool in write_tools:
+                desc = tool.description
+                assert "<usecase>" in desc, f"Write tool {tool.name} missing <usecase> tag"
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)


### PR DESCRIPTION
## Summary

Add 5 opt-in write tools that operate via SSH filesystem operations and USB web HTTP endpoints — no external Go binary required. Inspired by PR #70 from @McSchnizzle.

## Write Tools

| Tool | Description | SSH | USB Web | Cloud |
|------|-------------|:---:|:-------:|:-----:|
| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file | ✅ | ✅ | ❌ |
| `remarkable_mkdir(folder_name, parent)` | Create a new folder | ✅ | ❌ | ❌ |
| `remarkable_move(document, dest_folder)` | Move a document or folder | ✅ | ❌ | ❌ |
| `remarkable_rename(document, new_name)` | Rename a document or folder | ✅ | ❌ | ❌ |
| `remarkable_delete(document)` | Delete a document or folder | ✅ | ❌ | ❌ |

## Two Transport Modes

- **SSH mode**: Full write support — upload via SCP, mkdir/move/rename/delete via filesystem metadata
- **USB web mode**: Upload only via `POST /upload` HTTP endpoint (zero external dependencies)
- **Cloud mode**: Returns clear error explaining write requires SSH or USB web

## Safety Design

- **Off by default** — Enable with `--write` CLI flag or `REMARKABLE_ENABLE_WRITE=1` env var
- All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete), so an agent harness can optionally block writes at the MCP layer.
- After each SSH write operation, xochitl is restarted to reflect changes on the tablet
- Unsupported operations return clear errors explaining which mode is needed

## How to Enable

```bash
# SSH mode (full write support)
uvx remarkable-mcp --ssh --write

# USB web mode (upload only)
uvx remarkable-mcp --usb --write
```

## Files Changed

- **`remarkable_mcp/write_tools.py`** (new) — 5 write tools + helpers for SSH and USB web upload
- **`remarkable_mcp/server.py`** — Conditional registration, transport-aware instructions
- **`remarkable_mcp/cli.py`** — Added `--write` flag (works with `--ssh` and `--usb`)
- **`test_server.py`** — Tests for opt-in, safety, cloud/USB error paths, XML docs
- **`README.md`** — Updated comparison table + "Write Tools" section documenting both transports

## Verification

- All tests pass; lint clean.
- End-to-end verified over MCP stdio against a live tablet: upload + delete lifecycle round-trip.

Co-authored-by: McSchnizzle <103280888+McSchnizzle@users.noreply.github.com>
