### PR TITLE
fix: await async helper in remarkable_search per-document path

### DIFF
--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1105,7 +1105,7 @@ def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
 
 
 @mcp.tool(annotations=SEARCH_ANNOTATIONS)
-def remarkable_search(
+async def remarkable_search(
     query: str,
     grep: Optional[str] = None,
     limit: int = 5,
@@ -1177,7 +1177,7 @@ def remarkable_search(
                 doc_result["tags"] = doc["tags"]
 
             try:
-                read_result = remarkable_read(
+                read_result = await remarkable_read(
                     document=doc["path"],
                     page=1,
                     grep=grep,

--- a/test_server.py
+++ b/test_server.py
@@ -459,6 +459,74 @@ class TestRemarkableRecent:
 
 
 # =============================================================================
+# Test remarkable_search Tool
+# =============================================================================
+
+
+class TestRemarkableSearch:
+    """Test remarkable_search tool."""
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_search_awaits_remarkable_read(self, mock_get_rmapi):
+        """Regression test: remarkable_search must await the async remarkable_read.
+
+        Previously remarkable_search was a sync function calling the async
+        remarkable_read without awaiting it, resulting in per-document errors:
+            'the JSON object must be str, bytes or bytearray, not coroutine'
+        because json.loads() was called on a coroutine object.
+        """
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+
+        doc = Mock()
+        doc.VissibleName = "mcp notes"
+        doc.ID = "doc-mcp-1"
+        doc.Parent = ""
+        doc.ModifiedClient = "2024-01-15T10:30:00Z"
+        doc.is_folder = False
+        doc.is_cloud_archived = False
+        doc.tags = []
+
+        mock_client.get_meta_items.return_value = [doc]
+
+        # Minimal zip so remarkable_read can succeed end-to-end
+        import io
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr("doc-mcp-1.content", '{"fileType": "notebook"}')
+        mock_client.download.return_value = zip_buffer.getvalue()
+
+        result = await mcp.call_tool("remarkable_search", {"query": "mcp", "limit": 2})
+        data = json.loads(result[0][0].text)
+
+        # Top-level call must succeed (not surface a coroutine TypeError)
+        assert "_error" not in data, f"Unexpected top-level error: {data.get('_error')}"
+        assert "documents" in data
+        assert data["count"] >= 1
+
+        # No per-document result should contain the coroutine error
+        for doc_result in data["documents"]:
+            err = doc_result.get("error", "")
+            assert "coroutine" not in err, f"Per-document coroutine error leaked through: {err}"
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_search_no_documents_found(self, mock_get_rmapi):
+        """Test search returns clean error when no documents match."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_client.get_meta_items.return_value = []
+
+        result = await mcp.call_tool("remarkable_search", {"query": "nonexistent-xyz"})
+        data = json.loads(result[0][0].text)
+
+        assert "_error" in data
+        assert data["_error"]["type"] == "no_documents_found"
+
+
+# =============================================================================
 # Test remarkable_read Tool
 # =============================================================================
 

--- a/test_server.py
+++ b/test_server.py
@@ -466,6 +466,11 @@ class TestRemarkableRecent:
 class TestRemarkableSearch:
     """Test remarkable_search tool."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_root_path(self, monkeypatch):
+        # Ensure tests are independent of any ambient REMARKABLE_ROOT_PATH
+        monkeypatch.delenv("REMARKABLE_ROOT_PATH", raising=False)
+
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.get_rmapi")
     async def test_search_awaits_remarkable_read(self, mock_get_rmapi):


### PR DESCRIPTION
## Bug

`remarkable_search` was declared as a sync function but called the async `remarkable_read` without awaiting it. The returned coroutine was then passed to `json.loads(...)`, producing per-document errors visible to MCP clients:

```
the JSON object must be str, bytes or bytearray, not coroutine
```

Surface symptom from v0.9.0 (VS Code MCP stdio):
```
remarkable_search("mcp", limit=2)
→ per-document: "the JSON object must be str, bytes or bytearray, not coroutine"
```

Plain `remarkable_browse`, `remarkable_search` without enrichment, and direct `remarkable_read` calls were unaffected — only the cross-document search helper was broken.

## Fix

- Make `remarkable_search` `async` and `await remarkable_read(...)` in the per-document loop (`remarkable_mcp/tools.py`).

## Test

- Add `TestRemarkableSearch::test_search_awaits_remarkable_read` regression test in `test_server.py` that drives the full path via `mcp.call_tool("remarkable_search", ...)` with a mocked `get_rmapi` and a minimal in-memory zip. Verified it fails on the pre-fix code with the exact `not coroutine` message, and passes with the fix.
- Add `test_search_no_documents_found` for the empty-result path.

## Verification

```
uv run ruff check .          # All checks passed!
uv run ruff format --check . # 19 files already formatted
uv run pytest test_server.py # 106 passed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>