### PR TITLE
fix: only register write tools supported by active transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,9 +462,9 @@ Or set the environment variable:
 
 ### Safety
 
-- **Upload works in SSH and USB web mode** — cloud mode returns a clear error
-- **mkdir, move, rename, delete require SSH mode** — USB web and cloud return a clear error
-- **Delete is destructive and immediate** — the MCP client is responsible for confirming with the user before invoking
+- **Upload registers in SSH and USB web mode** — cloud mode returns a clear error
+- **mkdir, move, rename, delete are only registered in SSH mode** — they are not exposed at all on USB web or cloud, keeping the tool list scoped to what the active transport actually supports
+- **Delete is destructive and immediate** — the MCP client is responsible for confirming with the user before invoking. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
 - After each write operation (SSH), the tablet UI restarts automatically to reflect changes
 
 ### Examples

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -264,7 +264,10 @@ from remarkable_mcp import (  # noqa: E402
 # Conditionally register write tools when enabled
 from remarkable_mcp import write_tools as _write_tools  # noqa: E402
 
-if _write_tools.write_enabled():
+if _write_tools.write_enabled() and (
+    os.environ.get("REMARKABLE_USE_SSH", "").lower() in ("1", "true", "yes")
+    or os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in ("1", "true", "yes")
+):
     _write_tools.register_write_tools()
 
 

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -432,353 +432,356 @@ def register_write_tools():
                 suggestion=f"Check {transport} connection and try again.",
             )
 
-    @mcp.tool(annotations=MKDIR_ANNOTATIONS)
-    async def remarkable_mkdir(
-        folder_name: str,
-        parent: str = "/",
-    ) -> str:
-        """
-        <usecase>Create a new folder on the reMarkable tablet.</usecase>
-        <instructions>
-        Creates a folder in the tablet's document hierarchy. The folder appears
-        in the tablet UI after xochitl restarts.
+    if _is_ssh_mode():
 
-        Requires SSH mode and --write flag. Not available in USB web mode.
-        </instructions>
-        <parameters>
-        - folder_name: Name of the new folder
-        - parent: Parent folder path (default: root "/")
-        </parameters>
-        <examples>
-        - remarkable_mkdir("Projects")
-        - remarkable_mkdir("2024", parent="/Archive")
-        </examples>
-        """
-        error = _require_ssh_mode()
-        if error:
-            return error
+        @mcp.tool(annotations=MKDIR_ANNOTATIONS)
+        async def remarkable_mkdir(
+            folder_name: str,
+            parent: str = "/",
+        ) -> str:
+            """
+            <usecase>Create a new folder on the reMarkable tablet.</usecase>
+            <instructions>
+            Creates a folder in the tablet's document hierarchy. The folder appears
+            in the tablet UI after xochitl restarts.
 
-        try:
-            ssh_client = _get_ssh_client()
-            collection = ssh_client.get_meta_items()
-            items_by_id = get_items_by_id(collection)
+            Requires SSH mode and --write flag. Not available in USB web mode.
+            </instructions>
+            <parameters>
+            - folder_name: Name of the new folder
+            - parent: Parent folder path (default: root "/")
+            </parameters>
+            <examples>
+            - remarkable_mkdir("Projects")
+            - remarkable_mkdir("2024", parent="/Archive")
+            </examples>
+            """
+            error = _require_ssh_mode()
+            if error:
+                return error
 
-            # Resolve parent
-            parent_id = _resolve_parent_id(parent, items_by_id, collection)
-            if parent_id is None:
-                return make_error(
-                    error_type="folder_not_found",
-                    message=f"Parent folder not found: '{parent}'",
-                    suggestion="Use remarkable_browse('/') to see available folders.",
-                )
+            try:
+                ssh_client = _get_ssh_client()
+                collection = ssh_client.get_meta_items()
+                items_by_id = get_items_by_id(collection)
 
-            # Generate UUID
-            doc_uuid = str(uuid.uuid4())
-            timestamp_ms = str(int(time.time() * 1000))
-
-            # Create metadata for folder
-            metadata = {
-                "visibleName": folder_name,
-                "type": "CollectionType",
-                "parent": parent_id,
-                "deleted": False,
-                "pinned": False,
-                "lastModified": timestamp_ms,
-                "metadatamodified": True,
-                "modified": True,
-                "synced": False,
-                "version": 0,
-            }
-            _write_metadata(ssh_client, doc_uuid, metadata)
-
-            # Restart xochitl
-            _restart_xochitl(ssh_client)
-
-            # Clear cache
-            ssh_client._documents = []
-            ssh_client._documents_by_id = {}
-
-            return make_response(
-                {
-                    "created": True,
-                    "folder_name": folder_name,
-                    "uuid": doc_uuid,
-                    "parent": parent,
-                },
-                "Folder created. Use remarkable_browse() to verify.",
-            )
-
-        except Exception as e:
-            return make_error(
-                error_type="mkdir_failed",
-                message=f"Failed to create folder: {e}",
-                suggestion="Check SSH connection and try again.",
-            )
-
-    @mcp.tool(annotations=MOVE_ANNOTATIONS)
-    async def remarkable_move(
-        document: str,
-        dest_folder: str,
-    ) -> str:
-        """
-        <usecase>Move a document or folder to a different location.</usecase>
-        <instructions>
-        Moves a document or folder by updating its parent reference in the metadata.
-        Find the document name with remarkable_browse() first.
-
-        Requires SSH mode and --write flag. Not available in USB web mode.
-        </instructions>
-        <parameters>
-        - document: Name or path of the document/folder to move
-        - dest_folder: Destination folder path (use "/" for root)
-        </parameters>
-        <examples>
-        - remarkable_move("Meeting Notes", "/Archive")
-        - remarkable_move("Old Project", "/Archive/2023")
-        </examples>
-        """
-        error = _require_ssh_mode()
-        if error:
-            return error
-
-        try:
-            ssh_client = _get_ssh_client()
-            collection = ssh_client.get_meta_items()
-            items_by_id = get_items_by_id(collection)
-
-            # Find the document
-            target = _resolve_document(document, collection, items_by_id)
-            if not target:
-                from remarkable_mcp.extract import find_similar_documents
-
-                similar = find_similar_documents(document, collection)
-                return make_error(
-                    error_type="document_not_found",
-                    message=f"Document not found: '{document}'",
-                    suggestion="Use remarkable_browse() to find the correct name.",
-                    did_you_mean=similar if similar else None,
-                )
-
-            # Find the destination folder
-            dest_id = _resolve_parent_id(dest_folder, items_by_id, collection)
-            if dest_id is None:
-                return make_error(
-                    error_type="folder_not_found",
-                    message=f"Destination folder not found: '{dest_folder}'",
-                    suggestion="Use remarkable_browse('/') to see available folders.",
-                )
-
-            # Prevent moving a folder into itself or a descendant
-            if target.is_folder:
-                if dest_id == target.ID:
+                # Resolve parent
+                parent_id = _resolve_parent_id(parent, items_by_id, collection)
+                if parent_id is None:
                     return make_error(
-                        error_type="invalid_move",
-                        message="Cannot move a folder into itself",
-                        suggestion="Choose a different destination folder.",
+                        error_type="folder_not_found",
+                        message=f"Parent folder not found: '{parent}'",
+                        suggestion="Use remarkable_browse('/') to see available folders.",
                     )
-                # Walk up from dest to check for cycles
-                check_id = dest_id
-                while check_id and check_id in items_by_id:
-                    if check_id == target.ID:
+
+                # Generate UUID
+                doc_uuid = str(uuid.uuid4())
+                timestamp_ms = str(int(time.time() * 1000))
+
+                # Create metadata for folder
+                metadata = {
+                    "visibleName": folder_name,
+                    "type": "CollectionType",
+                    "parent": parent_id,
+                    "deleted": False,
+                    "pinned": False,
+                    "lastModified": timestamp_ms,
+                    "metadatamodified": True,
+                    "modified": True,
+                    "synced": False,
+                    "version": 0,
+                }
+                _write_metadata(ssh_client, doc_uuid, metadata)
+
+                # Restart xochitl
+                _restart_xochitl(ssh_client)
+
+                # Clear cache
+                ssh_client._documents = []
+                ssh_client._documents_by_id = {}
+
+                return make_response(
+                    {
+                        "created": True,
+                        "folder_name": folder_name,
+                        "uuid": doc_uuid,
+                        "parent": parent,
+                    },
+                    "Folder created. Use remarkable_browse() to verify.",
+                )
+
+            except Exception as e:
+                return make_error(
+                    error_type="mkdir_failed",
+                    message=f"Failed to create folder: {e}",
+                    suggestion="Check SSH connection and try again.",
+                )
+
+        @mcp.tool(annotations=MOVE_ANNOTATIONS)
+        async def remarkable_move(
+            document: str,
+            dest_folder: str,
+        ) -> str:
+            """
+            <usecase>Move a document or folder to a different location.</usecase>
+            <instructions>
+            Moves a document or folder by updating its parent reference in the metadata.
+            Find the document name with remarkable_browse() first.
+
+            Requires SSH mode and --write flag. Not available in USB web mode.
+            </instructions>
+            <parameters>
+            - document: Name or path of the document/folder to move
+            - dest_folder: Destination folder path (use "/" for root)
+            </parameters>
+            <examples>
+            - remarkable_move("Meeting Notes", "/Archive")
+            - remarkable_move("Old Project", "/Archive/2023")
+            </examples>
+            """
+            error = _require_ssh_mode()
+            if error:
+                return error
+
+            try:
+                ssh_client = _get_ssh_client()
+                collection = ssh_client.get_meta_items()
+                items_by_id = get_items_by_id(collection)
+
+                # Find the document
+                target = _resolve_document(document, collection, items_by_id)
+                if not target:
+                    from remarkable_mcp.extract import find_similar_documents
+
+                    similar = find_similar_documents(document, collection)
+                    return make_error(
+                        error_type="document_not_found",
+                        message=f"Document not found: '{document}'",
+                        suggestion="Use remarkable_browse() to find the correct name.",
+                        did_you_mean=similar if similar else None,
+                    )
+
+                # Find the destination folder
+                dest_id = _resolve_parent_id(dest_folder, items_by_id, collection)
+                if dest_id is None:
+                    return make_error(
+                        error_type="folder_not_found",
+                        message=f"Destination folder not found: '{dest_folder}'",
+                        suggestion="Use remarkable_browse('/') to see available folders.",
+                    )
+
+                # Prevent moving a folder into itself or a descendant
+                if target.is_folder:
+                    if dest_id == target.ID:
                         return make_error(
                             error_type="invalid_move",
-                            message="Cannot move a folder into one of its subfolders",
-                            suggestion=(
-                                "Choose a destination that is not inside the folder being moved."
-                            ),
+                            message="Cannot move a folder into itself",
+                            suggestion="Choose a different destination folder.",
                         )
-                    parent_item = items_by_id[check_id]
-                    check_id = parent_item.Parent if hasattr(parent_item, "Parent") else ""
+                    # Walk up from dest to check for cycles
+                    check_id = dest_id
+                    while check_id and check_id in items_by_id:
+                        if check_id == target.ID:
+                            return make_error(
+                                error_type="invalid_move",
+                                message="Cannot move a folder into one of its subfolders",
+                                suggestion=(
+                                    "Choose a destination that is not inside the folder "
+                                    "being moved."
+                                ),
+                            )
+                        parent_item = items_by_id[check_id]
+                        check_id = parent_item.Parent if hasattr(parent_item, "Parent") else ""
 
-            # Read existing metadata
-            meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-            metadata = json.loads(meta_content.decode("utf-8"))
+                # Read existing metadata
+                meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+                metadata = json.loads(meta_content.decode("utf-8"))
 
-            old_path = get_item_path(target, items_by_id)
+                old_path = get_item_path(target, items_by_id)
 
-            # Update parent
-            metadata["parent"] = dest_id
-            metadata["lastModified"] = str(int(time.time() * 1000))
-            metadata["metadatamodified"] = True
-            _write_metadata(ssh_client, target.ID, metadata)
+                # Update parent
+                metadata["parent"] = dest_id
+                metadata["lastModified"] = str(int(time.time() * 1000))
+                metadata["metadatamodified"] = True
+                _write_metadata(ssh_client, target.ID, metadata)
 
-            # Restart xochitl
-            _restart_xochitl(ssh_client)
+                # Restart xochitl
+                _restart_xochitl(ssh_client)
 
-            # Clear cache
-            ssh_client._documents = []
-            ssh_client._documents_by_id = {}
+                # Clear cache
+                ssh_client._documents = []
+                ssh_client._documents_by_id = {}
 
-            return make_response(
-                {
-                    "moved": True,
-                    "name": target.VissibleName,
-                    "from": old_path,
-                    "to": dest_folder,
-                },
-                "Document moved. Use remarkable_browse() to verify.",
-            )
-
-        except Exception as e:
-            return make_error(
-                error_type="move_failed",
-                message=f"Failed to move document: {e}",
-                suggestion="Check SSH connection and try again.",
-            )
-
-    @mcp.tool(annotations=RENAME_ANNOTATIONS)
-    async def remarkable_rename(
-        document: str,
-        new_name: str,
-    ) -> str:
-        """
-        <usecase>Rename a document or folder on the reMarkable tablet.</usecase>
-        <instructions>
-        Changes the display name of a document or folder by updating its metadata.
-        Find the document name with remarkable_browse() first.
-
-        Requires SSH mode and --write flag. Not available in USB web mode.
-        </instructions>
-        <parameters>
-        - document: Current name or path of the document/folder
-        - new_name: New display name
-        </parameters>
-        <examples>
-        - remarkable_rename("Untitled", "Meeting Notes 2024-01-15")
-        - remarkable_rename("/Work/Draft", "Final Report")
-        </examples>
-        """
-        error = _require_ssh_mode()
-        if error:
-            return error
-
-        try:
-            ssh_client = _get_ssh_client()
-            collection = ssh_client.get_meta_items()
-            items_by_id = get_items_by_id(collection)
-
-            # Find the document
-            target = _resolve_document(document, collection, items_by_id)
-            if not target:
-                from remarkable_mcp.extract import find_similar_documents
-
-                similar = find_similar_documents(document, collection)
-                return make_error(
-                    error_type="document_not_found",
-                    message=f"Document not found: '{document}'",
-                    suggestion="Use remarkable_browse() to find the correct name.",
-                    did_you_mean=similar if similar else None,
+                return make_response(
+                    {
+                        "moved": True,
+                        "name": target.VissibleName,
+                        "from": old_path,
+                        "to": dest_folder,
+                    },
+                    "Document moved. Use remarkable_browse() to verify.",
                 )
 
-            # Read existing metadata
-            meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-            metadata = json.loads(meta_content.decode("utf-8"))
-
-            old_name = metadata.get("visibleName", target.VissibleName)
-
-            # Update name
-            metadata["visibleName"] = new_name
-            metadata["lastModified"] = str(int(time.time() * 1000))
-            metadata["metadatamodified"] = True
-            _write_metadata(ssh_client, target.ID, metadata)
-
-            # Restart xochitl
-            _restart_xochitl(ssh_client)
-
-            # Clear cache
-            ssh_client._documents = []
-            ssh_client._documents_by_id = {}
-
-            return make_response(
-                {
-                    "renamed": True,
-                    "old_name": old_name,
-                    "new_name": new_name,
-                },
-                "Document renamed. Use remarkable_browse() to verify.",
-            )
-
-        except Exception as e:
-            return make_error(
-                error_type="rename_failed",
-                message=f"Failed to rename document: {e}",
-                suggestion="Check SSH connection and try again.",
-            )
-
-    @mcp.tool(annotations=DELETE_ANNOTATIONS)
-    async def remarkable_delete(document: str) -> str:
-        """
-        <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
-        <instructions>
-        DESTRUCTIVE operation — marks a document as deleted in its metadata.
-        The document won't appear in the tablet UI after restart.
-
-        Requires SSH mode and --write flag. Not available in USB web mode.
-        The MCP client is responsible for any user confirmation; this tool
-        performs the delete immediately.
-        </instructions>
-        <parameters>
-        - document: Name or path of the document/folder to delete
-        </parameters>
-        <examples>
-        - remarkable_delete("Old Notes")
-        - remarkable_delete("/Books/Archive/Old Draft")
-        </examples>
-        """
-        error = _require_ssh_mode()
-        if error:
-            return error
-
-        try:
-            ssh_client = _get_ssh_client()
-            collection = ssh_client.get_meta_items()
-            items_by_id = get_items_by_id(collection)
-
-            # Find the document
-            target = _resolve_document(document, collection, items_by_id)
-            if not target:
-                from remarkable_mcp.extract import find_similar_documents
-
-                similar = find_similar_documents(document, collection)
+            except Exception as e:
                 return make_error(
-                    error_type="document_not_found",
-                    message=f"Document not found: '{document}'",
-                    suggestion="Use remarkable_browse() to find the correct name.",
-                    did_you_mean=similar if similar else None,
+                    error_type="move_failed",
+                    message=f"Failed to move document: {e}",
+                    suggestion="Check SSH connection and try again.",
                 )
 
-            doc_path = get_item_path(target, items_by_id)
+        @mcp.tool(annotations=RENAME_ANNOTATIONS)
+        async def remarkable_rename(
+            document: str,
+            new_name: str,
+        ) -> str:
+            """
+            <usecase>Rename a document or folder on the reMarkable tablet.</usecase>
+            <instructions>
+            Changes the display name of a document or folder by updating its metadata.
+            Find the document name with remarkable_browse() first.
 
-            # Read existing metadata
-            meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-            metadata = json.loads(meta_content.decode("utf-8"))
+            Requires SSH mode and --write flag. Not available in USB web mode.
+            </instructions>
+            <parameters>
+            - document: Current name or path of the document/folder
+            - new_name: New display name
+            </parameters>
+            <examples>
+            - remarkable_rename("Untitled", "Meeting Notes 2024-01-15")
+            - remarkable_rename("/Work/Draft", "Final Report")
+            </examples>
+            """
+            error = _require_ssh_mode()
+            if error:
+                return error
 
-            # Mark as deleted
-            metadata["deleted"] = True
-            metadata["lastModified"] = str(int(time.time() * 1000))
-            metadata["metadatamodified"] = True
-            _write_metadata(ssh_client, target.ID, metadata)
+            try:
+                ssh_client = _get_ssh_client()
+                collection = ssh_client.get_meta_items()
+                items_by_id = get_items_by_id(collection)
 
-            # Restart xochitl
-            _restart_xochitl(ssh_client)
+                # Find the document
+                target = _resolve_document(document, collection, items_by_id)
+                if not target:
+                    from remarkable_mcp.extract import find_similar_documents
 
-            # Clear cache
-            ssh_client._documents = []
-            ssh_client._documents_by_id = {}
+                    similar = find_similar_documents(document, collection)
+                    return make_error(
+                        error_type="document_not_found",
+                        message=f"Document not found: '{document}'",
+                        suggestion="Use remarkable_browse() to find the correct name.",
+                        did_you_mean=similar if similar else None,
+                    )
 
-            return make_response(
-                {
-                    "deleted": True,
-                    "name": target.VissibleName,
-                    "path": doc_path,
-                    "type": "folder" if target.is_folder else "document",
-                },
-                "Document deleted. It will no longer appear on the tablet.",
-            )
+                # Read existing metadata
+                meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+                metadata = json.loads(meta_content.decode("utf-8"))
 
-        except Exception as e:
-            return make_error(
-                error_type="delete_failed",
-                message=f"Failed to delete document: {e}",
-                suggestion="Check SSH connection and try again.",
-            )
+                old_name = metadata.get("visibleName", target.VissibleName)
+
+                # Update name
+                metadata["visibleName"] = new_name
+                metadata["lastModified"] = str(int(time.time() * 1000))
+                metadata["metadatamodified"] = True
+                _write_metadata(ssh_client, target.ID, metadata)
+
+                # Restart xochitl
+                _restart_xochitl(ssh_client)
+
+                # Clear cache
+                ssh_client._documents = []
+                ssh_client._documents_by_id = {}
+
+                return make_response(
+                    {
+                        "renamed": True,
+                        "old_name": old_name,
+                        "new_name": new_name,
+                    },
+                    "Document renamed. Use remarkable_browse() to verify.",
+                )
+
+            except Exception as e:
+                return make_error(
+                    error_type="rename_failed",
+                    message=f"Failed to rename document: {e}",
+                    suggestion="Check SSH connection and try again.",
+                )
+
+        @mcp.tool(annotations=DELETE_ANNOTATIONS)
+        async def remarkable_delete(document: str) -> str:
+            """
+            <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
+            <instructions>
+            DESTRUCTIVE operation — marks a document as deleted in its metadata.
+            The document won't appear in the tablet UI after restart.
+
+            Requires SSH mode and --write flag. Not available in USB web mode.
+            The MCP client is responsible for any user confirmation; this tool
+            performs the delete immediately.
+            </instructions>
+            <parameters>
+            - document: Name or path of the document/folder to delete
+            </parameters>
+            <examples>
+            - remarkable_delete("Old Notes")
+            - remarkable_delete("/Books/Archive/Old Draft")
+            </examples>
+            """
+            error = _require_ssh_mode()
+            if error:
+                return error
+
+            try:
+                ssh_client = _get_ssh_client()
+                collection = ssh_client.get_meta_items()
+                items_by_id = get_items_by_id(collection)
+
+                # Find the document
+                target = _resolve_document(document, collection, items_by_id)
+                if not target:
+                    from remarkable_mcp.extract import find_similar_documents
+
+                    similar = find_similar_documents(document, collection)
+                    return make_error(
+                        error_type="document_not_found",
+                        message=f"Document not found: '{document}'",
+                        suggestion="Use remarkable_browse() to find the correct name.",
+                        did_you_mean=similar if similar else None,
+                    )
+
+                doc_path = get_item_path(target, items_by_id)
+
+                # Read existing metadata
+                meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+                metadata = json.loads(meta_content.decode("utf-8"))
+
+                # Mark as deleted
+                metadata["deleted"] = True
+                metadata["lastModified"] = str(int(time.time() * 1000))
+                metadata["metadatamodified"] = True
+                _write_metadata(ssh_client, target.ID, metadata)
+
+                # Restart xochitl
+                _restart_xochitl(ssh_client)
+
+                # Clear cache
+                ssh_client._documents = []
+                ssh_client._documents_by_id = {}
+
+                return make_response(
+                    {
+                        "deleted": True,
+                        "name": target.VissibleName,
+                        "path": doc_path,
+                        "type": "folder" if target.is_folder else "document",
+                    },
+                    "Document deleted. It will no longer appear on the tablet.",
+                )
+
+            except Exception as e:
+                return make_error(
+                    error_type="delete_failed",
+                    message=f"Failed to delete document: {e}",
+                    suggestion="Check SSH connection and try again.",
+                )

--- a/test_server.py
+++ b/test_server.py
@@ -2044,11 +2044,11 @@ class TestWriteTools:
 
     @pytest.mark.asyncio
     async def test_write_tools_registered_when_enabled(self):
-        """Test that write tools ARE registered with REMARKABLE_ENABLE_WRITE=1."""
+        """Test that write tools ARE registered with REMARKABLE_ENABLE_WRITE=1 in SSH mode."""
         from remarkable_mcp.write_tools import register_write_tools
 
-        # Register the tools
-        register_write_tools()
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
 
         try:
             tools = await mcp.list_tools()
@@ -2080,7 +2080,8 @@ class TestWriteTools:
         """Test that delete marks the document's metadata as deleted."""
         from remarkable_mcp.write_tools import register_write_tools
 
-        register_write_tools()
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
 
         try:
             mock_doc = Mock()
@@ -2150,52 +2151,40 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_write_tools_error_in_cloud_mode(self):
-        """Test that write tools return error in cloud mode."""
+    async def test_mkdir_not_registered_in_cloud_mode(self):
+        """SSH-only write tools must not be exposed when there's no SSH transport."""
         from remarkable_mcp.write_tools import register_write_tools
 
-        register_write_tools()
-
-        try:
-            # Ensure NOT in SSH mode
-            old_ssh = os.environ.pop("REMARKABLE_USE_SSH", None)
+        # Cloud mode: neither SSH nor USB web
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env.pop("REMARKABLE_USE_USB_WEB", None)
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
             try:
-                import importlib
-
-                import remarkable_mcp.api
-
-                importlib.reload(remarkable_mcp.api)
-
-                result = await mcp.call_tool(
-                    "remarkable_mkdir",
-                    {
-                        "folder_name": "Test",
-                    },
-                )
-                data = json.loads(result[0][0].text)
-                assert "_error" in data
-                assert data["_error"]["type"] == "ssh_required"
-                assert "SSH mode" in data["_error"]["message"]
+                tools = await mcp.list_tools()
+                names = {t.name for t in tools}
+                # Upload is transport-checked at call time and may still register
+                assert "remarkable_mkdir" not in names
+                assert "remarkable_move" not in names
+                assert "remarkable_rename" not in names
+                assert "remarkable_delete" not in names
             finally:
-                if old_ssh is not None:
-                    os.environ["REMARKABLE_USE_SSH"] = old_ssh
-                importlib.reload(remarkable_mcp.api)
-        finally:
-            for name in [
-                "remarkable_upload",
-                "remarkable_mkdir",
-                "remarkable_move",
-                "remarkable_rename",
-                "remarkable_delete",
-            ]:
-                mcp._tool_manager._tools.pop(name, None)
+                for name in [
+                    "remarkable_upload",
+                    "remarkable_mkdir",
+                    "remarkable_move",
+                    "remarkable_rename",
+                    "remarkable_delete",
+                ]:
+                    mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
     async def test_all_write_tools_have_xml_docstrings(self):
         """Test that all write tools have XML-structured documentation."""
         from remarkable_mcp.write_tools import register_write_tools
 
-        register_write_tools()
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
 
         try:
             tools = await mcp.list_tools()
@@ -2268,40 +2257,28 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_mkdir_error_in_usb_web_mode(self):
-        """Test that mkdir returns SSH-required error in USB web mode."""
+    async def test_mkdir_not_registered_in_usb_web_mode(self):
+        """SSH-only write tools must not be exposed in USB web mode (upload-only)."""
         from remarkable_mcp.write_tools import register_write_tools
 
-        register_write_tools()
-
-        try:
-            old_ssh = os.environ.pop("REMARKABLE_USE_SSH", None)
-            os.environ["REMARKABLE_USE_USB_WEB"] = "1"
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env["REMARKABLE_USE_USB_WEB"] = "1"
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
             try:
-                import importlib
-
-                import remarkable_mcp.api
-
-                importlib.reload(remarkable_mcp.api)
-
-                result = await mcp.call_tool(
-                    "remarkable_mkdir",
-                    {"folder_name": "Test"},
-                )
-                data = json.loads(result[0][0].text)
-                assert "_error" in data
-                assert data["_error"]["type"] == "ssh_required"
+                tools = await mcp.list_tools()
+                names = {t.name for t in tools}
+                assert "remarkable_upload" in names  # upload works on USB web
+                assert "remarkable_mkdir" not in names
+                assert "remarkable_move" not in names
+                assert "remarkable_rename" not in names
+                assert "remarkable_delete" not in names
             finally:
-                if old_ssh is not None:
-                    os.environ["REMARKABLE_USE_SSH"] = old_ssh
-                os.environ.pop("REMARKABLE_USE_USB_WEB", None)
-                importlib.reload(remarkable_mcp.api)
-        finally:
-            for name in [
-                "remarkable_upload",
-                "remarkable_mkdir",
-                "remarkable_move",
-                "remarkable_rename",
-                "remarkable_delete",
-            ]:
-                mcp._tool_manager._tools.pop(name, None)
+                for name in [
+                    "remarkable_upload",
+                    "remarkable_mkdir",
+                    "remarkable_move",
+                    "remarkable_rename",
+                    "remarkable_delete",
+                ]:
+                    mcp._tool_manager._tools.pop(name, None)


### PR DESCRIPTION
## Summary

When `--usb --write` was used, all 5 write tools were exposed in the MCP tool list, but `mkdir`/`move`/`rename`/`delete` were SSH-only and would return an `ssh_required` error at call time. That's confusing for clients and wastes the model's tool budget on tools that can never succeed on the active transport. Same issue with `REMARKABLE_ENABLE_WRITE=1` set in cloud mode (the env-var bypass of the CLI warning) — upload would register but cannot work.

This PR scopes write-tool registration to what each transport can actually do.

## Behavior matrix (verified end-to-end)

| Mode | Tools registered |
|---|---|
| SSH (no `--write`) | 6 read |
| **SSH + `--write`** | 6 read + 5 write (upload, mkdir, move, rename, delete) |
| USB (no `--write`) | 6 read |
| **USB + `--write`** | 6 read + 1 write (upload only) |
| Cloud (no `--write`) | 6 read |
| Cloud + `--write` env-var | 6 read (write requires SSH/USB web) |

## Changes

- **`remarkable_mcp/server.py`** — gate `register_write_tools()` on both `write_enabled()` and a write-capable transport, matching the existing `write_mode` logic used for instruction text.
- **`remarkable_mcp/write_tools.py`** — in `register_write_tools()`, only register the SSH-only tools (`mkdir`/`move`/`rename`/`delete`) when `_is_ssh_mode()`. `upload` still registers in any write-capable transport and continues to check transport at call time.
- **`test_server.py`** — replaced the two "returns `ssh_required` error" tests with "tool is not registered" assertions (`test_mkdir_not_registered_in_cloud_mode`, `test_mkdir_not_registered_in_usb_web_mode`), and set `REMARKABLE_USE_SSH=1` in the tests that need the full set registered (`test_write_tools_registered_when_enabled`, `test_delete_marks_document_deleted`, `test_all_write_tools_have_xml_docstrings`).
- **`README.md`** — clarify that SSH-only write tools are not exposed on USB web/cloud and call out `ToolAnnotations(readOnlyHint=False, destructiveHint=True)` as the harness-level write gate.

## Verification

- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest test_server.py` ✅ **104/104**
- End-to-end stdio subprocess across all 6 mode combinations shows the table above is correct.