### PR TITLE
fix: prevent event-loop blocking under concurrent tool calls

### DIFF
--- a/remarkable_mcp/concurrency.py
+++ b/remarkable_mcp/concurrency.py
@@ -1,0 +1,38 @@
+"""Concurrency helpers for offloading blocking work from the asyncio event loop.
+
+FastMCP awaits ``async def`` tool handlers directly on the asyncio event loop
+without dispatching them to a thread pool, and it also calls plain ``def``
+handlers inline. Any blocking I/O performed inside a tool handler — SSH
+subprocess calls, ``requests`` HTTP requests, ``pymupdf``/``cairosvg``
+rendering, ``pytesseract`` OCR, ``zipfile`` extraction — therefore blocks the
+entire event loop. While that handler is running, no other ``call_tool``
+request can make progress, which serializes concurrent requests and can make
+the server appear to hang under parallel tool calls.
+
+The fix is to push every blocking call onto a worker thread via
+:func:`asyncio.to_thread`. :func:`run_blocking` is a thin wrapper for the
+common case (call a single blocking function with args), so tool handlers can
+write ``await run_blocking(ssh_client.get_meta_items)`` instead of repeating
+``await asyncio.to_thread(...)`` everywhere.
+
+Tools whose entire body is blocking (no inner ``await``) can alternatively
+wrap their body in a nested ``def _impl()`` and ``return await
+asyncio.to_thread(_impl)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def run_blocking(func: Callable[..., T], *args: Any, **kwargs: Any) -> Awaitable[T]:
+    """Run ``func(*args, **kwargs)`` in a worker thread.
+
+    Returns the awaitable produced by :func:`asyncio.to_thread`. Use this to
+    offload blocking I/O from an ``async def`` MCP tool handler so other
+    concurrent tool calls can make progress on the event loop.
+    """
+    return asyncio.to_thread(func, *args, **kwargs)

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -30,6 +30,7 @@ from remarkable_mcp.api import (
     get_items_by_parent,
     get_rmapi,
 )
+from remarkable_mcp.concurrency import run_blocking
 from remarkable_mcp.extract import (
     cache_page_ocr,
     extract_text_from_document_zip,
@@ -297,7 +298,7 @@ async def remarkable_read(
     """
     try:
         client = get_rmapi()
-        collection = client.get_meta_items()
+        collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
         # Validate parameters
@@ -346,7 +347,7 @@ async def remarkable_read(
             )
 
         doc_path = get_item_path(target_doc, items_by_id)
-        file_type = get_file_type(client, target_doc)
+        file_type = await run_blocking(get_file_type, client, target_doc)
 
         # Collect content based on content_type
         text_parts = []
@@ -354,7 +355,7 @@ async def remarkable_read(
 
         # Get raw PDF/EPUB content if requested or for "text" mode
         if content_type in ("text", "raw") and file_type in ("pdf", "epub"):
-            raw_data = download_raw_file(client, target_doc, file_type)
+            raw_data = await run_blocking(download_raw_file, client, target_doc, file_type)
             if raw_data:
                 raw_available = True
                 with tempfile.NamedTemporaryFile(suffix=f".{file_type}", delete=False) as tmp:
@@ -362,9 +363,9 @@ async def remarkable_read(
                     tmp_path = Path(tmp.name)
                 try:
                     if file_type == "pdf":
-                        raw_text = extract_text_from_pdf(tmp_path)
+                        raw_text = await run_blocking(extract_text_from_pdf, tmp_path)
                     else:
-                        raw_text = extract_text_from_epub(tmp_path)
+                        raw_text = await run_blocking(extract_text_from_epub, tmp_path)
                     if raw_text:
                         text_parts.append(raw_text)
                 finally:
@@ -397,16 +398,18 @@ async def remarkable_read(
             # For sampling OCR: use per-page caching and only OCR requested page
             if use_sampling:
                 # Check per-page cache first
-                cached_text = get_cached_page_ocr(target_doc.ID, page, "sampling")
+                cached_text = await run_blocking(
+                    get_cached_page_ocr, target_doc.ID, page, "sampling"
+                )
                 if cached_text is not None:
                     # We have cached OCR for this page
                     # Still need to get total page count
-                    raw_doc = client.download(target_doc)
+                    raw_doc = await run_blocking(client.download, target_doc)
                     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp.write(raw_doc)
                         tmp_path = Path(tmp.name)
                     try:
-                        total_notebook_pages = get_document_page_count(tmp_path)
+                        total_notebook_pages = await run_blocking(get_document_page_count, tmp_path)
                     finally:
                         tmp_path.unlink(missing_ok=True)
 
@@ -416,13 +419,13 @@ async def remarkable_read(
                     ocr_backend_used = "sampling"
                 else:
                     # No cache - render and OCR just the requested page
-                    raw_doc = client.download(target_doc)
+                    raw_doc = await run_blocking(client.download, target_doc)
                     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp.write(raw_doc)
                         tmp_path = Path(tmp.name)
 
                     try:
-                        total_notebook_pages = get_document_page_count(tmp_path)
+                        total_notebook_pages = await run_blocking(get_document_page_count, tmp_path)
 
                         if page > total_notebook_pages:
                             return make_error(
@@ -434,13 +437,19 @@ async def remarkable_read(
                             )
 
                         # Render just the requested page
-                        png_data = render_page_from_document_zip(tmp_path, page)
+                        png_data = await run_blocking(render_page_from_document_zip, tmp_path, page)
                         if png_data:
                             # OCR the single page
                             ocr_text = await ocr_via_sampling(ctx, png_data)
                             if ocr_text:
                                 # Cache the result
-                                cache_page_ocr(target_doc.ID, page, "sampling", ocr_text)
+                                await run_blocking(
+                                    cache_page_ocr,
+                                    target_doc.ID,
+                                    page,
+                                    "sampling",
+                                    ocr_text,
+                                )
                                 # Build notebook_pages list
                                 notebook_pages = [""] * total_notebook_pages
                                 notebook_pages[page - 1] = ocr_text
@@ -450,7 +459,12 @@ async def remarkable_read(
 
             # For non-sampling: check full document cache or extract all
             if not use_sampling and is_notebook and include_ocr:
-                cached = get_cached_ocr_result(target_doc.ID, include_ocr=True, ocr_backend=None)
+                cached = await run_blocking(
+                    get_cached_ocr_result,
+                    target_doc.ID,
+                    include_ocr=True,
+                    ocr_backend=None,
+                )
                 if cached and cached.get("handwritten_text"):
                     notebook_pages = cached["handwritten_text"]
                     ocr_backend_used = cached.get("ocr_backend")
@@ -458,14 +472,17 @@ async def remarkable_read(
 
             # If not cached (non-sampling), perform extraction
             if not notebook_pages and is_notebook:
-                raw_doc = client.download(target_doc)
+                raw_doc = await run_blocking(client.download, target_doc)
                 with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                     tmp.write(raw_doc)
                     tmp_path = Path(tmp.name)
 
                 try:
-                    content = extract_text_from_document_zip(
-                        tmp_path, include_ocr=include_ocr, doc_id=target_doc.ID
+                    content = await run_blocking(
+                        extract_text_from_document_zip,
+                        tmp_path,
+                        include_ocr=include_ocr,
+                        doc_id=target_doc.ID,
                     )
                     if content.get("handwritten_text"):
                         notebook_pages = content["handwritten_text"]
@@ -477,13 +494,16 @@ async def remarkable_read(
             if not (is_notebook and notebook_pages):
                 if content is None:
                     # Need to extract if we haven't already
-                    raw_doc = client.download(target_doc)
+                    raw_doc = await run_blocking(client.download, target_doc)
                     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp.write(raw_doc)
                         tmp_path = Path(tmp.name)
                     try:
-                        content = extract_text_from_document_zip(
-                            tmp_path, include_ocr=include_ocr, doc_id=target_doc.ID
+                        content = await run_blocking(
+                            extract_text_from_document_zip,
+                            tmp_path,
+                            include_ocr=include_ocr,
+                            doc_id=target_doc.ID,
                         )
                     finally:
                         tmp_path.unlink(missing_ok=True)
@@ -748,7 +768,7 @@ async def remarkable_read(
 
 
 @mcp.tool(annotations=BROWSE_ANNOTATIONS)
-def remarkable_browse(
+async def remarkable_browse(
     path: str = "/", query: Optional[str] = None, tags: Optional[List[str]] = None
 ) -> str:
     """
@@ -784,7 +804,7 @@ def remarkable_browse(
     """
     try:
         client = get_rmapi()
-        collection = client.get_meta_items()
+        collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
         items_by_parent = get_items_by_parent(collection)
 
@@ -989,7 +1009,7 @@ def remarkable_browse(
 
 
 @mcp.tool(annotations=RECENT_ANNOTATIONS)
-def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
+async def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
     """
     <usecase>Get your most recently modified documents.</usecase>
     <instructions>
@@ -1012,7 +1032,7 @@ def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
     """
     try:
         client = get_rmapi()
-        collection = client.get_meta_items()
+        collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
         # Clamp limit - lower max when previews enabled (expensive operation)
@@ -1052,21 +1072,24 @@ def remarkable_recent(limit: int = 10, include_preview: bool = False) -> str:
 
             if include_preview:
                 # Download and extract preview (skip notebooks - they need slow OCR)
-                file_type = get_file_type(client, doc)
+                file_type = await run_blocking(get_file_type, client, doc)
                 if file_type == "notebook":
                     # Notebooks need OCR for preview, skip for performance
                     doc_info["preview_skipped"] = "notebook (use remarkable_read with include_ocr)"
                 else:
                     # PDFs and EPUBs have extractable text - fast to preview
                     try:
-                        raw_doc = client.download(doc)
+                        raw_doc = await run_blocking(client.download, doc)
                         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                             tmp.write(raw_doc)
                             tmp_path = Path(tmp.name)
 
                         try:
-                            content = extract_text_from_document_zip(
-                                tmp_path, include_ocr=False, doc_id=doc.ID
+                            content = await run_blocking(
+                                extract_text_from_document_zip,
+                                tmp_path,
+                                include_ocr=False,
+                                doc_id=doc.ID,
                             )
                             preview_text = "\n".join(content["typed_text"])[:200]
                             if preview_text:
@@ -1148,7 +1171,7 @@ async def remarkable_search(
         limit = min(max(1, limit), 5)
 
         # First, find matching documents
-        browse_result = remarkable_browse(query=query, tags=tags)
+        browse_result = await remarkable_browse(query=query, tags=tags)
         browse_data = json.loads(browse_result)
 
         if "_error" in browse_data:
@@ -1234,7 +1257,7 @@ async def remarkable_search(
 
 
 @mcp.tool(annotations=STATUS_ANNOTATIONS)
-def remarkable_status() -> str:
+async def remarkable_status() -> str:
     """
     <usecase>Check connection status and authentication with reMarkable Cloud.</usecase>
     <instructions>
@@ -1274,7 +1297,7 @@ def remarkable_status() -> str:
 
     try:
         client = get_rmapi()
-        collection = client.get_meta_items()
+        collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
         root = _get_root_path()
@@ -1417,10 +1440,10 @@ async def remarkable_image(
     try:
         # Resolve background color: use provided value or get from env/default
         if background is None:
-            background = get_background_color()
+            background = await run_blocking(get_background_color)
 
         client = get_rmapi()
-        collection = client.get_meta_items()
+        collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
         root = _get_root_path()
@@ -1464,7 +1487,7 @@ async def remarkable_image(
             )
 
         # Download the document
-        raw_doc = client.download(target_doc)
+        raw_doc = await run_blocking(client.download, target_doc)
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
             tmp.write(raw_doc)
             tmp_path = Path(tmp.name)
@@ -1480,7 +1503,7 @@ async def remarkable_image(
                 )
 
             # Get total page count
-            total_pages = get_document_page_count(tmp_path)
+            total_pages = await run_blocking(get_document_page_count, tmp_path)
 
             if total_pages == 0:
                 return make_error(
@@ -1514,8 +1537,11 @@ async def remarkable_image(
                         "returning annotation-only SVG."
                     )
 
-                svg_content = render_page_from_document_zip_svg(
-                    tmp_path, page, background_color=background
+                svg_content = await run_blocking(
+                    render_page_from_document_zip_svg,
+                    tmp_path,
+                    page,
+                    background_color=background,
                 )
 
                 if svg_content is None:
@@ -1566,13 +1592,19 @@ async def remarkable_image(
             else:
                 # PNG format
                 if render_merged:
-                    png_data, merged_note = render_merged_page_from_document_zip(
-                        tmp_path, page, background_color=background
+                    png_data, merged_note = await run_blocking(
+                        render_merged_page_from_document_zip,
+                        tmp_path,
+                        page,
+                        background_color=background,
                     )
                     is_merged = png_data is not None and merged_note is None
                 else:
-                    png_data = render_page_from_document_zip(
-                        tmp_path, page, background_color=background
+                    png_data = await run_blocking(
+                        render_page_from_document_zip,
+                        tmp_path,
+                        page,
+                        background_color=background,
                     )
 
                 if png_data is None:
@@ -1609,12 +1641,12 @@ async def remarkable_image(
                             if backend in ("sampling", "google") or (
                                 backend == "auto" and os.environ.get("GOOGLE_VISION_API_KEY")
                             ):
-                                ocr_text = _ocr_png_google_vision(ocr_tmp_path)
+                                ocr_text = await run_blocking(_ocr_png_google_vision, ocr_tmp_path)
                                 if ocr_text:
                                     ocr_backend_used = "google"
                             # Fall through to Tesseract if Google not available or returned None
                             if ocr_text is None:
-                                ocr_text = _ocr_png_tesseract(ocr_tmp_path)
+                                ocr_text = await run_blocking(_ocr_png_tesseract, ocr_tmp_path)
                                 if ocr_text:
                                     ocr_backend_used = "tesseract"
                         finally:

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -13,6 +13,7 @@ Inspired by PR #70 from @McSchnizzle. Implemented purely via SSH filesystem
 operations and USB web HTTP endpoints — no external Go binary required.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -308,129 +309,135 @@ def register_write_tools():
         - remarkable_upload("/tmp/report.pdf", document_name="Q4 Report")
         </examples>
         """
-        error = _require_write_transport()
-        if error:
-            return error
 
-        try:
-            # Validate file
-            if not os.path.isfile(file_path):
-                return make_error(
-                    error_type="file_not_found",
-                    message=f"File not found: '{file_path}'",
-                    suggestion="Provide an absolute path to an existing PDF or EPUB file.",
-                )
+        def _impl() -> str:
+            error = _require_write_transport()
+            if error:
+                return error
 
-            ext = os.path.splitext(file_path)[1].lower().lstrip(".")
-            if ext not in ("pdf", "epub"):
-                return make_error(
-                    error_type="unsupported_format",
-                    message=f"Unsupported file format: '.{ext}'",
-                    suggestion="Only PDF and EPUB files can be uploaded to reMarkable.",
-                )
-
-            # USB web mode: simple HTTP upload
-            if _is_usb_web_mode():
-                _upload_via_usb_web(file_path)
-
-                name = document_name or os.path.splitext(os.path.basename(file_path))[0]
-
-                # Clear cached documents
-                client = get_rmapi()
-                client._documents = []
-                client._documents_by_id = {}
-
-                result = {
-                    "uploaded": True,
-                    "name": name,
-                    "format": ext,
-                    "transport": "usb-web",
-                }
-                if parent_folder != "/":
-                    result["note"] = (
-                        "USB web upload places files at root. Use SSH mode for folder placement."
+            try:
+                # Validate file
+                if not os.path.isfile(file_path):
+                    return make_error(
+                        error_type="file_not_found",
+                        message=f"File not found: '{file_path}'",
+                        suggestion="Provide an absolute path to an existing PDF or EPUB file.",
                     )
+
+                ext = os.path.splitext(file_path)[1].lower().lstrip(".")
+                if ext not in ("pdf", "epub"):
+                    return make_error(
+                        error_type="unsupported_format",
+                        message=f"Unsupported file format: '.{ext}'",
+                        suggestion="Only PDF and EPUB files can be uploaded to reMarkable.",
+                    )
+
+                # USB web mode: simple HTTP upload
+                if _is_usb_web_mode():
+                    _upload_via_usb_web(file_path)
+
+                    name = document_name or os.path.splitext(os.path.basename(file_path))[0]
+
+                    # Clear cached documents
+                    client = get_rmapi()
+                    client._documents = []
+                    client._documents_by_id = {}
+
+                    result = {
+                        "uploaded": True,
+                        "name": name,
+                        "format": ext,
+                        "transport": "usb-web",
+                    }
+                    if parent_folder != "/":
+                        result["note"] = (
+                            "USB web upload places files at root. "
+                            "Use SSH mode for folder placement."
+                        )
+                    return make_response(
+                        result,
+                        "Document uploaded via USB web interface. "
+                        "Use remarkable_browse() to verify.",
+                    )
+
+                # SSH mode: full upload with metadata
+                ssh_client = _get_ssh_client()
+                collection = ssh_client.get_meta_items()
+                items_by_id = get_items_by_id(collection)
+
+                # Resolve parent folder
+                parent_id = _resolve_parent_id(parent_folder, items_by_id, collection)
+                if parent_id is None:
+                    folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+                    return make_error(
+                        error_type="folder_not_found",
+                        message=f"Folder not found: '{parent_folder}'",
+                        suggestion="Use remarkable_browse('/') to see available folders.",
+                        did_you_mean=folders[:5] if folders else None,
+                    )
+
+                # Generate UUID and set name
+                doc_uuid = str(uuid.uuid4())
+                name = document_name or os.path.splitext(os.path.basename(file_path))[0]
+                timestamp_ms = str(int(time.time() * 1000))
+
+                # Upload the file
+                remote_file = f"{XOCHITL_PATH}/{doc_uuid}.{ext}"
+                _upload_file_bytes(ssh_client, file_path, remote_file)
+
+                # Create metadata
+                metadata = {
+                    "visibleName": name,
+                    "type": "DocumentType",
+                    "parent": parent_id,
+                    "deleted": False,
+                    "pinned": False,
+                    "lastModified": timestamp_ms,
+                    "metadatamodified": True,
+                    "modified": True,
+                    "synced": False,
+                    "version": 0,
+                }
+                _write_metadata(ssh_client, doc_uuid, metadata)
+
+                # Create content file
+                content_data = {
+                    "fileType": ext,
+                }
+                _write_content_file(ssh_client, doc_uuid, content_data)
+
+                # Create the document directory (required by xochitl)
+                ssh_client._ssh_command(f"mkdir -p '{XOCHITL_PATH}/{doc_uuid}'")
+
+                # Restart xochitl to pick up changes
+                _restart_xochitl(ssh_client)
+
+                # Clear cached documents so next read picks up the new doc
+                ssh_client._documents = []
+                ssh_client._documents_by_id = {}
+
                 return make_response(
-                    result,
-                    "Document uploaded via USB web interface. Use remarkable_browse() to verify.",
+                    {
+                        "uploaded": True,
+                        "name": name,
+                        "uuid": doc_uuid,
+                        "format": ext,
+                        "parent_folder": parent_folder,
+                        "remote_path": remote_file,
+                        "transport": "ssh",
+                    },
+                    "Document uploaded successfully. Use remarkable_browse() to verify it appears.",
                 )
 
-            # SSH mode: full upload with metadata
-            ssh_client = _get_ssh_client()
-            collection = ssh_client.get_meta_items()
-            items_by_id = get_items_by_id(collection)
-
-            # Resolve parent folder
-            parent_id = _resolve_parent_id(parent_folder, items_by_id, collection)
-            if parent_id is None:
-                folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+            except Exception as e:
+                transport = "USB web" if _is_usb_web_mode() else "SSH"
                 return make_error(
-                    error_type="folder_not_found",
-                    message=f"Folder not found: '{parent_folder}'",
-                    suggestion="Use remarkable_browse('/') to see available folders.",
-                    did_you_mean=folders[:5] if folders else None,
+                    error_type="upload_failed",
+                    message=f"Upload failed: {e}",
+                    suggestion=f"Check {transport} connection and try again.",
                 )
 
-            # Generate UUID and set name
-            doc_uuid = str(uuid.uuid4())
-            name = document_name or os.path.splitext(os.path.basename(file_path))[0]
-            timestamp_ms = str(int(time.time() * 1000))
-
-            # Upload the file
-            remote_file = f"{XOCHITL_PATH}/{doc_uuid}.{ext}"
-            _upload_file_bytes(ssh_client, file_path, remote_file)
-
-            # Create metadata
-            metadata = {
-                "visibleName": name,
-                "type": "DocumentType",
-                "parent": parent_id,
-                "deleted": False,
-                "pinned": False,
-                "lastModified": timestamp_ms,
-                "metadatamodified": True,
-                "modified": True,
-                "synced": False,
-                "version": 0,
-            }
-            _write_metadata(ssh_client, doc_uuid, metadata)
-
-            # Create content file
-            content_data = {
-                "fileType": ext,
-            }
-            _write_content_file(ssh_client, doc_uuid, content_data)
-
-            # Create the document directory (required by xochitl)
-            ssh_client._ssh_command(f"mkdir -p '{XOCHITL_PATH}/{doc_uuid}'")
-
-            # Restart xochitl to pick up changes
-            _restart_xochitl(ssh_client)
-
-            # Clear cached documents so next read picks up the new doc
-            ssh_client._documents = []
-            ssh_client._documents_by_id = {}
-
-            return make_response(
-                {
-                    "uploaded": True,
-                    "name": name,
-                    "uuid": doc_uuid,
-                    "format": ext,
-                    "parent_folder": parent_folder,
-                    "remote_path": remote_file,
-                    "transport": "ssh",
-                },
-                "Document uploaded successfully. Use remarkable_browse() to verify it appears.",
-            )
-
-        except Exception as e:
-            transport = "USB web" if _is_usb_web_mode() else "SSH"
-            return make_error(
-                error_type="upload_failed",
-                message=f"Upload failed: {e}",
-                suggestion=f"Check {transport} connection and try again.",
-            )
+        return await asyncio.to_thread(_impl)
 
     if _is_ssh_mode():
 
@@ -456,66 +463,70 @@ def register_write_tools():
             - remarkable_mkdir("2024", parent="/Archive")
             </examples>
             """
-            error = _require_ssh_mode()
-            if error:
-                return error
 
-            try:
-                ssh_client = _get_ssh_client()
-                collection = ssh_client.get_meta_items()
-                items_by_id = get_items_by_id(collection)
+            def _impl() -> str:
+                error = _require_ssh_mode()
+                if error:
+                    return error
 
-                # Resolve parent
-                parent_id = _resolve_parent_id(parent, items_by_id, collection)
-                if parent_id is None:
-                    return make_error(
-                        error_type="folder_not_found",
-                        message=f"Parent folder not found: '{parent}'",
-                        suggestion="Use remarkable_browse('/') to see available folders.",
+                try:
+                    ssh_client = _get_ssh_client()
+                    collection = ssh_client.get_meta_items()
+                    items_by_id = get_items_by_id(collection)
+
+                    # Resolve parent
+                    parent_id = _resolve_parent_id(parent, items_by_id, collection)
+                    if parent_id is None:
+                        return make_error(
+                            error_type="folder_not_found",
+                            message=f"Parent folder not found: '{parent}'",
+                            suggestion="Use remarkable_browse('/') to see available folders.",
+                        )
+
+                    # Generate UUID
+                    doc_uuid = str(uuid.uuid4())
+                    timestamp_ms = str(int(time.time() * 1000))
+
+                    # Create metadata for folder
+                    metadata = {
+                        "visibleName": folder_name,
+                        "type": "CollectionType",
+                        "parent": parent_id,
+                        "deleted": False,
+                        "pinned": False,
+                        "lastModified": timestamp_ms,
+                        "metadatamodified": True,
+                        "modified": True,
+                        "synced": False,
+                        "version": 0,
+                    }
+                    _write_metadata(ssh_client, doc_uuid, metadata)
+
+                    # Restart xochitl
+                    _restart_xochitl(ssh_client)
+
+                    # Clear cache
+                    ssh_client._documents = []
+                    ssh_client._documents_by_id = {}
+
+                    return make_response(
+                        {
+                            "created": True,
+                            "folder_name": folder_name,
+                            "uuid": doc_uuid,
+                            "parent": parent,
+                        },
+                        "Folder created. Use remarkable_browse() to verify.",
                     )
 
-                # Generate UUID
-                doc_uuid = str(uuid.uuid4())
-                timestamp_ms = str(int(time.time() * 1000))
+                except Exception as e:
+                    return make_error(
+                        error_type="mkdir_failed",
+                        message=f"Failed to create folder: {e}",
+                        suggestion="Check SSH connection and try again.",
+                    )
 
-                # Create metadata for folder
-                metadata = {
-                    "visibleName": folder_name,
-                    "type": "CollectionType",
-                    "parent": parent_id,
-                    "deleted": False,
-                    "pinned": False,
-                    "lastModified": timestamp_ms,
-                    "metadatamodified": True,
-                    "modified": True,
-                    "synced": False,
-                    "version": 0,
-                }
-                _write_metadata(ssh_client, doc_uuid, metadata)
-
-                # Restart xochitl
-                _restart_xochitl(ssh_client)
-
-                # Clear cache
-                ssh_client._documents = []
-                ssh_client._documents_by_id = {}
-
-                return make_response(
-                    {
-                        "created": True,
-                        "folder_name": folder_name,
-                        "uuid": doc_uuid,
-                        "parent": parent,
-                    },
-                    "Folder created. Use remarkable_browse() to verify.",
-                )
-
-            except Exception as e:
-                return make_error(
-                    error_type="mkdir_failed",
-                    message=f"Failed to create folder: {e}",
-                    suggestion="Check SSH connection and try again.",
-                )
+            return await asyncio.to_thread(_impl)
 
         @mcp.tool(annotations=MOVE_ANNOTATIONS)
         async def remarkable_move(
@@ -539,95 +550,99 @@ def register_write_tools():
             - remarkable_move("Old Project", "/Archive/2023")
             </examples>
             """
-            error = _require_ssh_mode()
-            if error:
-                return error
 
-            try:
-                ssh_client = _get_ssh_client()
-                collection = ssh_client.get_meta_items()
-                items_by_id = get_items_by_id(collection)
+            def _impl() -> str:
+                error = _require_ssh_mode()
+                if error:
+                    return error
 
-                # Find the document
-                target = _resolve_document(document, collection, items_by_id)
-                if not target:
-                    from remarkable_mcp.extract import find_similar_documents
+                try:
+                    ssh_client = _get_ssh_client()
+                    collection = ssh_client.get_meta_items()
+                    items_by_id = get_items_by_id(collection)
 
-                    similar = find_similar_documents(document, collection)
-                    return make_error(
-                        error_type="document_not_found",
-                        message=f"Document not found: '{document}'",
-                        suggestion="Use remarkable_browse() to find the correct name.",
-                        did_you_mean=similar if similar else None,
-                    )
+                    # Find the document
+                    target = _resolve_document(document, collection, items_by_id)
+                    if not target:
+                        from remarkable_mcp.extract import find_similar_documents
 
-                # Find the destination folder
-                dest_id = _resolve_parent_id(dest_folder, items_by_id, collection)
-                if dest_id is None:
-                    return make_error(
-                        error_type="folder_not_found",
-                        message=f"Destination folder not found: '{dest_folder}'",
-                        suggestion="Use remarkable_browse('/') to see available folders.",
-                    )
-
-                # Prevent moving a folder into itself or a descendant
-                if target.is_folder:
-                    if dest_id == target.ID:
+                        similar = find_similar_documents(document, collection)
                         return make_error(
-                            error_type="invalid_move",
-                            message="Cannot move a folder into itself",
-                            suggestion="Choose a different destination folder.",
+                            error_type="document_not_found",
+                            message=f"Document not found: '{document}'",
+                            suggestion="Use remarkable_browse() to find the correct name.",
+                            did_you_mean=similar if similar else None,
                         )
-                    # Walk up from dest to check for cycles
-                    check_id = dest_id
-                    while check_id and check_id in items_by_id:
-                        if check_id == target.ID:
+
+                    # Find the destination folder
+                    dest_id = _resolve_parent_id(dest_folder, items_by_id, collection)
+                    if dest_id is None:
+                        return make_error(
+                            error_type="folder_not_found",
+                            message=f"Destination folder not found: '{dest_folder}'",
+                            suggestion="Use remarkable_browse('/') to see available folders.",
+                        )
+
+                    # Prevent moving a folder into itself or a descendant
+                    if target.is_folder:
+                        if dest_id == target.ID:
                             return make_error(
                                 error_type="invalid_move",
-                                message="Cannot move a folder into one of its subfolders",
-                                suggestion=(
-                                    "Choose a destination that is not inside the folder "
-                                    "being moved."
-                                ),
+                                message="Cannot move a folder into itself",
+                                suggestion="Choose a different destination folder.",
                             )
-                        parent_item = items_by_id[check_id]
-                        check_id = parent_item.Parent if hasattr(parent_item, "Parent") else ""
+                        # Walk up from dest to check for cycles
+                        check_id = dest_id
+                        while check_id and check_id in items_by_id:
+                            if check_id == target.ID:
+                                return make_error(
+                                    error_type="invalid_move",
+                                    message="Cannot move a folder into one of its subfolders",
+                                    suggestion=(
+                                        "Choose a destination that is not inside the folder "
+                                        "being moved."
+                                    ),
+                                )
+                            parent_item = items_by_id[check_id]
+                            check_id = parent_item.Parent if hasattr(parent_item, "Parent") else ""
 
-                # Read existing metadata
-                meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-                metadata = json.loads(meta_content.decode("utf-8"))
+                    # Read existing metadata
+                    meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+                    metadata = json.loads(meta_content.decode("utf-8"))
 
-                old_path = get_item_path(target, items_by_id)
+                    old_path = get_item_path(target, items_by_id)
 
-                # Update parent
-                metadata["parent"] = dest_id
-                metadata["lastModified"] = str(int(time.time() * 1000))
-                metadata["metadatamodified"] = True
-                _write_metadata(ssh_client, target.ID, metadata)
+                    # Update parent
+                    metadata["parent"] = dest_id
+                    metadata["lastModified"] = str(int(time.time() * 1000))
+                    metadata["metadatamodified"] = True
+                    _write_metadata(ssh_client, target.ID, metadata)
 
-                # Restart xochitl
-                _restart_xochitl(ssh_client)
+                    # Restart xochitl
+                    _restart_xochitl(ssh_client)
 
-                # Clear cache
-                ssh_client._documents = []
-                ssh_client._documents_by_id = {}
+                    # Clear cache
+                    ssh_client._documents = []
+                    ssh_client._documents_by_id = {}
 
-                return make_response(
-                    {
-                        "moved": True,
-                        "name": target.VissibleName,
-                        "from": old_path,
-                        "to": dest_folder,
-                    },
-                    "Document moved. Use remarkable_browse() to verify.",
-                )
+                    return make_response(
+                        {
+                            "moved": True,
+                            "name": target.VissibleName,
+                            "from": old_path,
+                            "to": dest_folder,
+                        },
+                        "Document moved. Use remarkable_browse() to verify.",
+                    )
 
-            except Exception as e:
-                return make_error(
-                    error_type="move_failed",
-                    message=f"Failed to move document: {e}",
-                    suggestion="Check SSH connection and try again.",
-                )
+                except Exception as e:
+                    return make_error(
+                        error_type="move_failed",
+                        message=f"Failed to move document: {e}",
+                        suggestion="Check SSH connection and try again.",
+                    )
+
+            return await asyncio.to_thread(_impl)
 
         @mcp.tool(annotations=RENAME_ANNOTATIONS)
         async def remarkable_rename(
@@ -651,62 +666,66 @@ def register_write_tools():
             - remarkable_rename("/Work/Draft", "Final Report")
             </examples>
             """
-            error = _require_ssh_mode()
-            if error:
-                return error
 
-            try:
-                ssh_client = _get_ssh_client()
-                collection = ssh_client.get_meta_items()
-                items_by_id = get_items_by_id(collection)
+            def _impl() -> str:
+                error = _require_ssh_mode()
+                if error:
+                    return error
 
-                # Find the document
-                target = _resolve_document(document, collection, items_by_id)
-                if not target:
-                    from remarkable_mcp.extract import find_similar_documents
+                try:
+                    ssh_client = _get_ssh_client()
+                    collection = ssh_client.get_meta_items()
+                    items_by_id = get_items_by_id(collection)
 
-                    similar = find_similar_documents(document, collection)
-                    return make_error(
-                        error_type="document_not_found",
-                        message=f"Document not found: '{document}'",
-                        suggestion="Use remarkable_browse() to find the correct name.",
-                        did_you_mean=similar if similar else None,
+                    # Find the document
+                    target = _resolve_document(document, collection, items_by_id)
+                    if not target:
+                        from remarkable_mcp.extract import find_similar_documents
+
+                        similar = find_similar_documents(document, collection)
+                        return make_error(
+                            error_type="document_not_found",
+                            message=f"Document not found: '{document}'",
+                            suggestion="Use remarkable_browse() to find the correct name.",
+                            did_you_mean=similar if similar else None,
+                        )
+
+                    # Read existing metadata
+                    meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+                    metadata = json.loads(meta_content.decode("utf-8"))
+
+                    old_name = metadata.get("visibleName", target.VissibleName)
+
+                    # Update name
+                    metadata["visibleName"] = new_name
+                    metadata["lastModified"] = str(int(time.time() * 1000))
+                    metadata["metadatamodified"] = True
+                    _write_metadata(ssh_client, target.ID, metadata)
+
+                    # Restart xochitl
+                    _restart_xochitl(ssh_client)
+
+                    # Clear cache
+                    ssh_client._documents = []
+                    ssh_client._documents_by_id = {}
+
+                    return make_response(
+                        {
+                            "renamed": True,
+                            "old_name": old_name,
+                            "new_name": new_name,
+                        },
+                        "Document renamed. Use remarkable_browse() to verify.",
                     )
 
-                # Read existing metadata
-                meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-                metadata = json.loads(meta_content.decode("utf-8"))
+                except Exception as e:
+                    return make_error(
+                        error_type="rename_failed",
+                        message=f"Failed to rename document: {e}",
+                        suggestion="Check SSH connection and try again.",
+                    )
 
-                old_name = metadata.get("visibleName", target.VissibleName)
-
-                # Update name
-                metadata["visibleName"] = new_name
-                metadata["lastModified"] = str(int(time.time() * 1000))
-                metadata["metadatamodified"] = True
-                _write_metadata(ssh_client, target.ID, metadata)
-
-                # Restart xochitl
-                _restart_xochitl(ssh_client)
-
-                # Clear cache
-                ssh_client._documents = []
-                ssh_client._documents_by_id = {}
-
-                return make_response(
-                    {
-                        "renamed": True,
-                        "old_name": old_name,
-                        "new_name": new_name,
-                    },
-                    "Document renamed. Use remarkable_browse() to verify.",
-                )
-
-            except Exception as e:
-                return make_error(
-                    error_type="rename_failed",
-                    message=f"Failed to rename document: {e}",
-                    suggestion="Check SSH connection and try again.",
-                )
+            return await asyncio.to_thread(_impl)
 
         @mcp.tool(annotations=DELETE_ANNOTATIONS)
         async def remarkable_delete(document: str) -> str:
@@ -728,60 +747,64 @@ def register_write_tools():
             - remarkable_delete("/Books/Archive/Old Draft")
             </examples>
             """
-            error = _require_ssh_mode()
-            if error:
-                return error
 
-            try:
-                ssh_client = _get_ssh_client()
-                collection = ssh_client.get_meta_items()
-                items_by_id = get_items_by_id(collection)
+            def _impl() -> str:
+                error = _require_ssh_mode()
+                if error:
+                    return error
 
-                # Find the document
-                target = _resolve_document(document, collection, items_by_id)
-                if not target:
-                    from remarkable_mcp.extract import find_similar_documents
+                try:
+                    ssh_client = _get_ssh_client()
+                    collection = ssh_client.get_meta_items()
+                    items_by_id = get_items_by_id(collection)
 
-                    similar = find_similar_documents(document, collection)
-                    return make_error(
-                        error_type="document_not_found",
-                        message=f"Document not found: '{document}'",
-                        suggestion="Use remarkable_browse() to find the correct name.",
-                        did_you_mean=similar if similar else None,
+                    # Find the document
+                    target = _resolve_document(document, collection, items_by_id)
+                    if not target:
+                        from remarkable_mcp.extract import find_similar_documents
+
+                        similar = find_similar_documents(document, collection)
+                        return make_error(
+                            error_type="document_not_found",
+                            message=f"Document not found: '{document}'",
+                            suggestion="Use remarkable_browse() to find the correct name.",
+                            did_you_mean=similar if similar else None,
+                        )
+
+                    doc_path = get_item_path(target, items_by_id)
+
+                    # Read existing metadata
+                    meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
+                    metadata = json.loads(meta_content.decode("utf-8"))
+
+                    # Mark as deleted
+                    metadata["deleted"] = True
+                    metadata["lastModified"] = str(int(time.time() * 1000))
+                    metadata["metadatamodified"] = True
+                    _write_metadata(ssh_client, target.ID, metadata)
+
+                    # Restart xochitl
+                    _restart_xochitl(ssh_client)
+
+                    # Clear cache
+                    ssh_client._documents = []
+                    ssh_client._documents_by_id = {}
+
+                    return make_response(
+                        {
+                            "deleted": True,
+                            "name": target.VissibleName,
+                            "path": doc_path,
+                            "type": "folder" if target.is_folder else "document",
+                        },
+                        "Document deleted. It will no longer appear on the tablet.",
                     )
 
-                doc_path = get_item_path(target, items_by_id)
+                except Exception as e:
+                    return make_error(
+                        error_type="delete_failed",
+                        message=f"Failed to delete document: {e}",
+                        suggestion="Check SSH connection and try again.",
+                    )
 
-                # Read existing metadata
-                meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-                metadata = json.loads(meta_content.decode("utf-8"))
-
-                # Mark as deleted
-                metadata["deleted"] = True
-                metadata["lastModified"] = str(int(time.time() * 1000))
-                metadata["metadatamodified"] = True
-                _write_metadata(ssh_client, target.ID, metadata)
-
-                # Restart xochitl
-                _restart_xochitl(ssh_client)
-
-                # Clear cache
-                ssh_client._documents = []
-                ssh_client._documents_by_id = {}
-
-                return make_response(
-                    {
-                        "deleted": True,
-                        "name": target.VissibleName,
-                        "path": doc_path,
-                        "type": "folder" if target.is_folder else "document",
-                    },
-                    "Document deleted. It will no longer appear on the tablet.",
-                )
-
-            except Exception as e:
-                return make_error(
-                    error_type="delete_failed",
-                    message=f"Failed to delete document: {e}",
-                    suggestion="Check SSH connection and try again.",
-                )
+            return await asyncio.to_thread(_impl)

--- a/test_server.py
+++ b/test_server.py
@@ -2355,3 +2355,44 @@ class TestWriteTools:
                     "remarkable_delete",
                 ]:
                     mcp._tool_manager._tools.pop(name, None)
+
+
+class TestConcurrentToolDispatch:
+    """Regression: tool calls must not serialize on the event loop.
+
+    Before the asyncio.to_thread fix, async tool handlers ran their blocking
+    work (subprocess/SSH/requests/etc.) directly on the asyncio loop, so a
+    second concurrent call_tool request was forced to wait for the first one
+    to finish. This test simulates blocking I/O with time.sleep inside the
+    mocked client and asserts that two concurrent calls overlap.
+    """
+
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_concurrent_browse_calls_overlap(self, mock_get_rmapi):
+        import asyncio
+        import time
+
+        call_delay = 0.4
+
+        def slow_get_meta_items():
+            time.sleep(call_delay)
+            return []
+
+        mock_client = Mock()
+        mock_client.get_meta_items.side_effect = slow_get_meta_items
+        mock_get_rmapi.return_value = mock_client
+
+        start = time.monotonic()
+        results = await asyncio.gather(
+            mcp.call_tool("remarkable_browse", {}),
+            mcp.call_tool("remarkable_browse", {}),
+        )
+        elapsed = time.monotonic() - start
+
+        assert len(results) == 2
+        # Two concurrent calls should complete in well under 2x the per-call
+        # delay; if they serialized we'd see ~2 * call_delay.
+        assert elapsed < call_delay * 1.7, (
+            f"Concurrent tool calls appear serialized: elapsed={elapsed:.2f}s "
+            f"vs single-call delay={call_delay}s"
+        )


### PR DESCRIPTION
## Bug

Users reported the MCP server occasionally appearing to hang when issuing parallel tool calls.

## Root cause

FastMCP awaits async tool handlers directly on the asyncio event loop (`call_fn_with_arg_validation` simply `await fn(...)` for async tools and calls sync tools inline — neither path uses a thread pool). Our handlers performed blocking I/O directly inside `async def`:

- SSH `subprocess.run` calls (`ssh.py`)
- `requests` HTTP calls (`sync.py`)
- `pymupdf` / `cairosvg` page rendering
- `pytesseract` OCR
- `zipfile` extraction

Any of these blocked the entire event loop, so a second concurrent `call_tool` request couldn't make progress until the first completed. A genuinely slow call effectively stalled the whole server.

## Fix

- New `remarkable_mcp/concurrency.py` exposing `run_blocking(func, *args, **kwargs)` as a thin wrapper over `asyncio.to_thread`.
- `tools.py`: every blocking call site is now `await run_blocking(...)`. `remarkable_browse` / `remarkable_recent` / `remarkable_status` were converted from `def` → `async def` (FastMCP doesn't offload sync handlers either), and the internal `remarkable_search` caller now awaits `remarkable_browse`.
- `write_tools.py` (upload / mkdir / move / rename / delete): each tool body is wrapped in a nested `def _impl()` executed via `asyncio.to_thread(_impl)` — no inner awaits there so the whole body can run off-loop.
- `ocr_via_sampling` calls are preserved on the main loop because MCP sampling owns the session stream.

No timeouts were missing (SSH uses `subprocess.run(..., timeout=...)`, cloud HTTP uses `requests` with explicit timeouts), so this is purely a concurrency fix.

## Regression test

`TestConcurrentToolDispatch::test_concurrent_browse_calls_overlap` issues two concurrent `remarkable_browse` calls against a mocked client whose `get_meta_items` sleeps for 0.4s, then asserts total elapsed time < 1.7× per-call delay. Before the fix this test would take ~0.8s+ (serialized); with the fix it runs in ~0.4s.

## Verification

```
uv run ruff check .          # All checks passed!
uv run ruff format --check . # 20 files already formatted
uv run pytest test_server.py # 107 passed
```

## Notes for reviewers

- Pure internal refactor — no tool signatures, parameters, or response shapes changed, so no README updates needed.
- Touches `tools.py` and `write_tools.py` which overlap with in-flight PR #87 (USB write tools); easy rebase either way.