### PR TITLE
fix: send rm-filename header for cloud file GETs

### DIFF
--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -220,25 +220,31 @@ class RemarkableClient:
             "Get a new code from: https://my.remarkable.com/device/desktop/connect"
         )
 
-    def _request(self, url: str, method: str = "GET") -> requests.Response:
+    def _request(
+        self, url: str, method: str = "GET", headers: Optional[Dict[str, str]] = None
+    ) -> requests.Response:
         """Make an authenticated request."""
         if not self.user_token:
             self.renew_token()
 
-        headers = {"Authorization": f"Bearer {self.user_token}"}
-        response = _http_request_with_retry(method, url, headers=headers, timeout=60)
+        request_headers = {"Authorization": f"Bearer {self.user_token}"}
+        if headers:
+            request_headers.update(headers)
+        response = _http_request_with_retry(method, url, headers=request_headers, timeout=60)
 
         if response.status_code == 401:
             # Token expired, try to renew
             self.renew_token()
-            headers = {"Authorization": f"Bearer {self.user_token}"}
-            response = _http_request_with_retry(method, url, headers=headers, timeout=60)
+            request_headers = {"Authorization": f"Bearer {self.user_token}"}
+            if headers:
+                request_headers.update(headers)
+            response = _http_request_with_retry(method, url, headers=request_headers, timeout=60)
 
         return response
 
-    def _get_file(self, file_hash: str) -> bytes:
+    def _get_file(self, file_hash: str, file_name: str) -> bytes:
         """Download a file by its hash."""
-        response = self._request(f"{FILES_URL}/{file_hash}")
+        response = self._request(f"{FILES_URL}/{file_hash}", headers={"rm-filename": file_name})
         response.raise_for_status()
         return response.content
 
@@ -298,7 +304,7 @@ class RemarkableClient:
         root_hash = root_data["hash"]
 
         # Get root index
-        root_index = self._get_file(root_hash)
+        root_index = self._get_file(root_hash, "root.docSchema")
         entries = self._parse_index(root_index)
 
         documents = []
@@ -309,7 +315,7 @@ class RemarkableClient:
 
             # Fetch the document's blob index
             try:
-                blob_content = self._get_file(doc_hash)
+                blob_content = self._get_file(doc_hash, f"{doc_id}.docSchema")
                 blob_entries = self._parse_index(blob_content)
             except Exception:
                 continue
@@ -322,7 +328,7 @@ class RemarkableClient:
                 files.append(blob_entry)
                 if blob_entry["id"].endswith(".metadata"):
                     try:
-                        meta_content = self._get_file(blob_entry["hash"])
+                        meta_content = self._get_file(blob_entry["hash"], blob_entry["id"])
                         metadata = json.loads(meta_content.decode("utf-8"))
                     except Exception:
                         pass
@@ -378,7 +384,7 @@ class RemarkableClient:
         import io
         import zipfile
 
-        blob_content = self._get_file(doc.hash)
+        blob_content = self._get_file(doc.hash, f"{doc.id}.docSchema")
         blob_entries = self._parse_index(blob_content)
 
         zip_buffer = io.BytesIO()
@@ -389,7 +395,7 @@ class RemarkableClient:
 
                 # Download the file
                 try:
-                    file_content = self._get_file(file_hash)
+                    file_content = self._get_file(file_hash, file_id)
                     zf.writestr(file_id, file_content)
                 except Exception:
                     continue

--- a/test_server.py
+++ b/test_server.py
@@ -1912,6 +1912,104 @@ class TestUSBWebInterface:
 # =============================================================================
 
 
+class TestCloudSyncFileHeaders:
+    """Regression tests for reMarkable cloud rm-filename header validation."""
+
+    def _response(self, *, text="", content=b"", json_data=None):
+        response = Mock()
+        response.status_code = 200
+        response.text = text
+        response.content = content
+        response.headers = {}
+        response.raise_for_status = Mock()
+        if json_data is not None:
+            response.json.return_value = json_data
+        return response
+
+    @patch("remarkable_mcp.sync._http_request_with_retry")
+    def test_get_meta_items_sends_logical_rm_filename_headers(self, mock_request):
+        """Cloud sync list requests must send the logical filename for each blob."""
+        from remarkable_mcp.sync import FILES_URL, RemarkableClient
+
+        root_hash = "root-hash"
+        doc_id = "doc-123"
+        doc_hash = "doc-hash"
+        metadata_hash = "metadata-hash"
+
+        mock_request.side_effect = [
+            self._response(text='{"hash": "root-hash"}', json_data={"hash": root_hash}),
+            self._response(content=f"3\n{doc_hash}:80000000:{doc_id}:1:123\n".encode("utf-8")),
+            self._response(
+                content=(f"3\n{metadata_hash}:0:{doc_id}.metadata:0:77\n").encode("utf-8")
+            ),
+            self._response(
+                content=json.dumps(
+                    {
+                        "visibleName": "Header Test",
+                        "type": "DocumentType",
+                        "lastModified": "1710000000000",
+                    }
+                ).encode("utf-8")
+            ),
+        ]
+
+        client = RemarkableClient(user_token="user-token")
+        docs = client.get_meta_items()
+
+        assert [doc.name for doc in docs] == ["Header Test"]
+        file_headers = {
+            call.args[1]: call.kwargs["headers"].get("rm-filename")
+            for call in mock_request.call_args_list
+            if call.args[1].startswith(FILES_URL)
+        }
+        assert file_headers == {
+            f"{FILES_URL}/{root_hash}": "root.docSchema",
+            f"{FILES_URL}/{doc_hash}": f"{doc_id}.docSchema",
+            f"{FILES_URL}/{metadata_hash}": f"{doc_id}.metadata",
+        }
+
+    @patch("remarkable_mcp.sync._http_request_with_retry")
+    def test_download_sends_entry_ids_as_rm_filename_headers(self, mock_request):
+        """Cloud sync downloads must pass each blob's index id as rm-filename."""
+        from remarkable_mcp.sync import FILES_URL, Document, RemarkableClient
+
+        doc_id = "doc-123"
+        doc_hash = "doc-hash"
+        content_hash = "content-hash"
+        page_hash = "page-hash"
+
+        mock_request.side_effect = [
+            self._response(
+                content=(
+                    f"3\n{content_hash}:0:{doc_id}.content:0:18\n"
+                    f"{page_hash}:0:{doc_id}/page-1.rm:0:9\n"
+                ).encode("utf-8")
+            ),
+            self._response(content=b'{"fileType": "notebook"}'),
+            self._response(content=b"rm-bytes"),
+        ]
+
+        client = RemarkableClient(user_token="user-token")
+        doc = Document(id=doc_id, hash=doc_hash, name="Header Test", doc_type="DocumentType")
+        payload = client.download(doc)
+
+        import io
+
+        with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+            assert zf.read(f"{doc_id}.content") == b'{"fileType": "notebook"}'
+            assert zf.read(f"{doc_id}/page-1.rm") == b"rm-bytes"
+        file_headers = {
+            call.args[1]: call.kwargs["headers"].get("rm-filename")
+            for call in mock_request.call_args_list
+            if call.args[1].startswith(FILES_URL)
+        }
+        assert file_headers == {
+            f"{FILES_URL}/{doc_hash}": f"{doc_id}.docSchema",
+            f"{FILES_URL}/{content_hash}": f"{doc_id}.content",
+            f"{FILES_URL}/{page_hash}": f"{doc_id}/page-1.rm",
+        }
+
+
 class TestRetryBackoff:
     """Test retry with exponential backoff for cloud API requests."""
 


### PR DESCRIPTION
## Summary

- thread the logical reMarkable filename into cloud `/sync/v3/files/{hash}` GET requests
- send `rm-filename` for root indexes, document indexes, metadata files, and downloaded document entries
- add regression coverage for the exact headers used by `get_meta_items()` and `download()`

## Context

Fixes #92.

On or around May 18, 2026, reMarkable started validating the `rm-filename` header for sync v3 file downloads. Missing or malformed values produce HTTP 400 with the misleading response `unexpected rm-filename http header`.

This mirrors the same fix pattern used in:

- ddvk/rmapi#63
- erikbrinkman/rmapi-js#48

## Verification

- `python -m pytest test_server.py -q` -> `109 passed`
- `ruff check remarkable_mcp/sync.py test_server.py` -> passed
- `ruff format --check remarkable_mcp/sync.py test_server.py` -> passed
- Manually verified patched cloud mode locally via MCP: status, browse, and recent document listing work again with cloud transport.