### PR TITLE
fix: read & render PDFs/EPUBs in cloud mode (were misclassified as notebooks)

### DIFF
--- a/remarkable_mcp/api.py
+++ b/remarkable_mcp/api.py
@@ -147,8 +147,17 @@ def download_raw_file(client, doc, extension: str):
     if hasattr(client, "download_raw_file"):
         return client.download_raw_file(doc, extension)
 
-    # Cloud client - raw files are not available via API
-    # The cloud API only returns the notebook annotations, not source PDFs/EPUBs
+    # Cloud client: the source PDF/EPUB IS present in the document's blob package.
+    # Fetch it directly by its content-addressed hash (doc.files lists every blob).
+    files = getattr(doc, "files", None)
+    if files and hasattr(client, "_get_file"):
+        suffix = "." + extension.lstrip(".")
+        for entry in files:
+            if str(entry.get("id", "")).endswith(suffix):
+                try:
+                    return client._get_file(entry["hash"], entry["id"])
+                except Exception:
+                    return None
     return None
 
 
@@ -168,6 +177,32 @@ def get_file_type(client, doc) -> str:
         file_type = client.get_file_type(doc)
         if file_type:
             return file_type
+
+    # Cloud client: read the authoritative fileType from the document's .content
+    # blob (reMarkable stores "pdf" | "epub" | "notebook" there). Without this the
+    # cloud path defaulted every doc to "notebook", so PDFs/EPUBs were misrouted to
+    # the .rm parser and failed to read/render.
+    files = getattr(doc, "files", None)
+    if files and hasattr(client, "_get_file"):
+        for entry in files:
+            if str(entry.get("id", "")).endswith(".content"):
+                try:
+                    content = json_module.loads(
+                        client._get_file(entry["hash"], entry["id"]).decode("utf-8")
+                    )
+                    ft = content.get("fileType")
+                    if ft:
+                        return ft
+                except Exception:
+                    break
+        # Fallback: a PDF/EPUB-backed doc has the payload blob even if .content
+        # didn't name a fileType.
+        for entry in files:
+            fid = str(entry.get("id", ""))
+            if fid.endswith(".pdf"):
+                return "pdf"
+            if fid.endswith(".epub"):
+                return "epub"
 
     # Infer from document name
     name = doc.VissibleName.lower()

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -927,6 +927,29 @@ def document_zip_has_pdf_underlay(zip_path: Path) -> bool:
         return False
 
 
+def document_zip_is_pure_pdf(zip_path: Path) -> bool:
+    """Return True when the zip is a PDF-backed doc with no annotation .rm files.
+
+    A pure-PDF document has a .pdf entry but zero .rm entries.  The render
+    path for such documents should rasterize the PDF directly rather than
+    trying to interpret an empty annotation layer.
+
+    Args:
+        zip_path: Path to the reMarkable document zip file.
+
+    Returns:
+        True if the zip contains a .pdf file and no .rm files.
+    """
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            names = zf.namelist()
+            has_pdf = any(name.endswith(".pdf") for name in names)
+            has_rm = any(name.endswith(".rm") for name in names)
+            return has_pdf and not has_rm
+    except Exception:
+        return False
+
+
 def _read_cpages_entries(tmpdir_path: Path) -> List[Dict[str, Any]]:
     """Read cPages.pages entries from the .content metadata file.
 
@@ -1002,6 +1025,62 @@ def _render_pdf_page_to_png(
         return None
 
 
+def render_pdf_page_from_document_zip(
+    zip_path: Path,
+    page: int = 1,
+) -> Optional[bytes]:
+    """Rasterize a page from a PDF-backed reMarkable document zip.
+
+    Extracts the embedded .pdf file from the zip and rasterizes the requested
+    page using pymupdf (fitz).  This function is the correct render path for
+    pure-PDF documents (no annotation .rm layer).
+
+    Args:
+        zip_path: Path to the reMarkable document zip file.
+        page: Page number (1-indexed).
+
+    Returns:
+        PNG image bytes, or None if rendering failed or page is out of range.
+    """
+    try:
+        import fitz
+    except ImportError:
+        return None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmpdir_path)
+
+        pdf_files = list(tmpdir_path.glob("**/*.pdf"))
+        if not pdf_files:
+            return None
+
+        # Prefer the PDF whose stem matches the .content document id
+        content_stems = {p.stem for p in tmpdir_path.glob("*.content")}
+        matching = [p for p in pdf_files if p.stem in content_stems]
+        pdf_path = matching[0] if matching else sorted(pdf_files)[0]
+
+        pdf_bytes = pdf_path.read_bytes()
+
+        try:
+            doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+            try:
+                page_index = page - 1  # convert to 0-based
+                if page_index < 0 or page_index >= doc.page_count:
+                    return None
+                pdf_page = doc[page_index]
+                # Render at 2× resolution for readability (150 dpi equivalent)
+                mat = fitz.Matrix(2.0, 2.0)
+                pix = pdf_page.get_pixmap(matrix=mat, alpha=False)
+                return pix.tobytes("png")
+            finally:
+                doc.close()
+        except Exception:
+            return None
+
+
 def render_merged_page_from_document_zip(
     zip_path: Path,
     page: int = 1,
@@ -1065,10 +1144,47 @@ def render_merged_page_from_document_zip(
         cpages = _read_cpages_entries(tmpdir_path)
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
-        if page < 1 or page > len(rm_files):
-            return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
+        # For PDF-backed docs the authoritative page count is the PDF itself,
+        # not the (possibly empty) .rm layer.
+        try:
+            pdf_doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+            try:
+                pdf_total_pages = pdf_doc.page_count
+            finally:
+                pdf_doc.close()
+        except Exception:
+            pdf_total_pages = len(rm_files)
 
-        target_rm_file = rm_files[page - 1]
+        if page < 1 or page > pdf_total_pages:
+            return None, f"Page {page} out of range (document has {pdf_total_pages} pages)."
+
+        # For pure PDF (no .rm overlay), rasterize the PDF page directly.
+        if not rm_files:
+            # 0-based PDF page index: page 1 → index 0
+            pdf_page_index = page - 1
+            pdf_png = _render_pdf_page_to_png(
+                pdf_bytes,
+                pdf_page_index,
+                canvas_width or int(1190 * 2),  # ~A4 at 96 dpi × 2
+                canvas_height or int(1684 * 2),
+            )
+            if pdf_png is None:
+                return None, f"PDF rasterization failed for page {page}."
+            return pdf_png, None
+
+        target_rm_file = rm_files[page - 1] if page <= len(rm_files) else None
+        if target_rm_file is None:
+            # Page exists in PDF but has no annotation layer — render PDF only.
+            pdf_page_index = page - 1
+            pdf_png = _render_pdf_page_to_png(
+                pdf_bytes,
+                pdf_page_index,
+                canvas_width or int(1190 * 2),
+                canvas_height or int(1684 * 2),
+            )
+            if pdf_png is None:
+                return None, f"PDF rasterization failed for page {page}."
+            return pdf_png, "Page has no annotation layer; returned PDF-only render."
 
         # Determine which PDF page this reMarkable page maps to
         pdf_page_index: Optional[int] = None
@@ -1191,8 +1307,9 @@ def get_document_page_count(zip_path: Path) -> int:
     """
     Get the number of pages in a reMarkable document zip.
 
-    Uses the .content metadata file for accurate page count (includes
-    user-added pages in PDFs). Falls back to counting .rm files.
+    For PDF-backed documents (fileType=="pdf" in .content), returns the PDF's
+    actual page count via pymupdf (falling back to the .content pageCount field).
+    For notebooks, uses cPages/pages arrays or counts .rm files.
 
     Args:
         zip_path: Path to the document zip file
@@ -1207,16 +1324,39 @@ def get_document_page_count(zip_path: Path) -> int:
             zf.extractall(tmpdir_path)
 
         # Try .content metadata first — it's the authoritative page list
+        content_data: Optional[Dict[str, Any]] = None
         for content_file in tmpdir_path.glob("*.content"):
             try:
-                data = json.loads(content_file.read_text())
-                if "cPages" in data and "pages" in data["cPages"]:
-                    return len(data["cPages"]["pages"])
-                if "pages" in data and isinstance(data["pages"], list):
-                    return len(data["pages"])
+                content_data = json.loads(content_file.read_text())
             except Exception:
                 pass
             break
+
+        if content_data is not None:
+            # PDF-backed document: page count comes from the PDF itself
+            if content_data.get("fileType") == "pdf":
+                pdf_files = list(tmpdir_path.glob("**/*.pdf"))
+                if pdf_files:
+                    try:
+                        import fitz
+
+                        doc = fitz.open(str(pdf_files[0]))
+                        try:
+                            return doc.page_count
+                        finally:
+                            doc.close()
+                    except Exception:
+                        pass
+                # Fall back to pageCount field in .content
+                page_count = content_data.get("pageCount")
+                if isinstance(page_count, int) and page_count > 0:
+                    return page_count
+
+            # Notebook: use cPages or pages array
+            if "cPages" in content_data and "pages" in content_data["cPages"]:
+                return len(content_data["cPages"]["pages"])
+            if "pages" in content_data and isinstance(content_data["pages"], list):
+                return len(content_data["pages"])
 
         # Fallback to counting .rm files
         return len(list(tmpdir_path.glob("**/*.rm")))

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -33,6 +33,7 @@ from remarkable_mcp.api import (
 from remarkable_mcp.concurrency import run_blocking
 from remarkable_mcp.extract import (
     cache_page_ocr,
+    document_zip_is_pure_pdf,
     extract_text_from_document_zip,
     extract_text_from_epub,
     extract_text_from_pdf,
@@ -44,6 +45,7 @@ from remarkable_mcp.extract import (
     render_merged_page_from_document_zip,
     render_page_from_document_zip,
     render_page_from_document_zip_svg,
+    render_pdf_page_from_document_zip,
 )
 from remarkable_mcp.responses import make_error, make_response
 from remarkable_mcp.sampling import (
@@ -1591,7 +1593,15 @@ async def remarkable_image(
                     return [info, embedded]
             else:
                 # PNG format
+
+                # Detect pure-PDF docs (has .pdf, no .rm overlay) so we can
+                # rasterize the PDF directly instead of routing through the
+                # empty annotation-layer path.
+                is_pure_pdf = await run_blocking(document_zip_is_pure_pdf, tmp_path)
+
                 if render_merged:
+                    # render_merged_page_from_document_zip handles pure-PDF
+                    # correctly (returns rasterized PDF page when no .rm layer).
                     png_data, merged_note = await run_blocking(
                         render_merged_page_from_document_zip,
                         tmp_path,
@@ -1599,6 +1609,13 @@ async def remarkable_image(
                         background_color=background,
                     )
                     is_merged = png_data is not None and merged_note is None
+                elif is_pure_pdf:
+                    # Pure PDF: rasterize the PDF page directly via pymupdf.
+                    png_data = await run_blocking(
+                        render_pdf_page_from_document_zip,
+                        tmp_path,
+                        page,
+                    )
                 else:
                     png_data = await run_blocking(
                         render_page_from_document_zip,

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -1,0 +1,75 @@
+"""Regression tests for cloud document type detection + raw extraction.
+
+Bug: the cloud path of api.get_file_type ignored the .content fileType and
+defaulted every document to "notebook", so PDFs/EPUBs (including ones pushed
+via remarkable_upload) were misrouted to the .rm parser and failed to read.
+And download_raw_file returned None for cloud, so PDF/EPUB text never extracted.
+"""
+
+import json
+
+from remarkable_mcp import api
+
+
+class FakeCloudClient:
+    """Mimics the cloud RemarkableClient: has _get_file, NOT get_file_type/download_raw_file."""
+
+    def __init__(self, blobs):
+        self._blobs = blobs  # id -> bytes
+
+    def _get_file(self, file_hash, file_id):
+        return self._blobs[file_id]
+
+
+class FakeDoc:
+    def __init__(self, files, name="Doc"):
+        self.files = files
+        self.VissibleName = name
+
+
+def _doc(entries):
+    return FakeDoc([{"id": fid, "hash": "h_" + fid} for fid in entries])
+
+
+def test_pdf_detected_from_content_filetype():
+    client = FakeCloudClient({
+        "u.content": json.dumps({"fileType": "pdf", "pageCount": 3}).encode(),
+        "u.pdf": b"%PDF-1.4 ...",
+    })
+    doc = _doc(["u.content", "u.pdf"])
+    assert api.get_file_type(client, doc) == "pdf"
+
+
+def test_notebook_detected_from_content_filetype():
+    client = FakeCloudClient({
+        "u.content": json.dumps({"fileType": "notebook"}).encode(),
+        "u/0.rm": b"reMarkable .lines file, version=6",
+    })
+    doc = _doc(["u.content", "u/0.rm"])
+    assert api.get_file_type(client, doc) == "notebook"
+
+
+def test_epub_detected_from_content_filetype():
+    client = FakeCloudClient({"u.content": json.dumps({"fileType": "epub"}).encode()})
+    doc = _doc(["u.content"])
+    assert api.get_file_type(client, doc) == "epub"
+
+
+def test_pdf_fallback_when_content_lacks_filetype():
+    # .content has no fileType, but a .pdf payload is present
+    client = FakeCloudClient({"u.content": b"{}", "u.pdf": b"%PDF"})
+    doc = _doc(["u.content", "u.pdf"])
+    assert api.get_file_type(client, doc) == "pdf"
+
+
+def test_download_raw_file_extracts_pdf_from_package():
+    pdf_bytes = b"%PDF-1.4 hello"
+    client = FakeCloudClient({"u.content": b'{"fileType":"pdf"}', "u.pdf": pdf_bytes})
+    doc = _doc(["u.content", "u.pdf"])
+    assert api.download_raw_file(client, doc, "pdf") == pdf_bytes
+
+
+def test_download_raw_file_none_when_no_payload():
+    client = FakeCloudClient({"u.content": b'{"fileType":"notebook"}', "u/0.rm": b"x"})
+    doc = _doc(["u.content", "u/0.rm"])
+    assert api.download_raw_file(client, doc, "pdf") is None

--- a/tests/test_pdf_render.py
+++ b/tests/test_pdf_render.py
@@ -1,0 +1,145 @@
+"""Tests for PDF-backed reMarkable document rendering via pymupdf.
+
+These tests build a self-contained fixture: a minimal reMarkable-style zip that
+contains a small multi-page PDF (generated with fitz) and the accompanying
+.content / .metadata files.  No libcairo is required, so the tests run locally
+even when cairosvg is absent.
+"""
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_minimal_pdf(n_pages: int = 3) -> bytes:
+    """Create a tiny N-page PDF using pymupdf and return the bytes."""
+    fitz = pytest.importorskip("fitz", reason="pymupdf not installed")
+    doc = fitz.open()
+    for i in range(n_pages):
+        page = doc.new_page(width=595, height=842)  # A4
+        page.insert_text((72, 100), f"Page {i + 1} of {n_pages}", fontsize=24)
+    buf = io.BytesIO()
+    doc.save(buf)
+    doc.close()
+    return buf.getvalue()
+
+
+def _make_remarkable_pdf_zip(n_pages: int = 3, uuid: str = "test-doc-uuid") -> bytes:
+    """Return bytes of a minimal reMarkable-style doc zip for a pure-PDF document."""
+    pdf_bytes = _make_minimal_pdf(n_pages)
+
+    content_json = json.dumps(
+        {
+            "fileType": "pdf",
+            "pageCount": n_pages,
+        }
+    )
+    metadata_json = json.dumps(
+        {
+            "visibleName": "Test PDF",
+            "type": "DocumentType",
+        }
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"{uuid}.content", content_json)
+        zf.writestr(f"{uuid}.metadata", metadata_json)
+        zf.writestr(f"{uuid}.pdf", pdf_bytes)
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def pdf_zip_path(tmp_path: Path) -> Path:
+    """Write a 3-page pure-PDF reMarkable zip to a temp file and return its path."""
+    zip_bytes = _make_remarkable_pdf_zip(n_pages=3)
+    p = tmp_path / "test_doc.zip"
+    p.write_bytes(zip_bytes)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_get_document_page_count_pdf(pdf_zip_path: Path) -> None:
+    """get_document_page_count must return the PDF's real page count, not 0."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import get_document_page_count
+
+    count = get_document_page_count(pdf_zip_path)
+    assert count == 3, f"Expected 3 pages, got {count}"
+
+
+def test_render_pdf_page_returns_png(pdf_zip_path: Path) -> None:
+    """render_pdf_page_from_document_zip must return valid PNG bytes for page 1."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import render_pdf_page_from_document_zip
+
+    result = render_pdf_page_from_document_zip(pdf_zip_path, page=1)
+    assert result is not None, "render_pdf_page_from_document_zip returned None for page 1"
+    assert result[:4] == b"\x89PNG", "Returned bytes do not start with PNG magic bytes"
+
+
+def test_render_pdf_all_pages(pdf_zip_path: Path) -> None:
+    """All pages of a pure-PDF doc must render successfully."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import render_pdf_page_from_document_zip
+
+    for page_num in (1, 2, 3):
+        result = render_pdf_page_from_document_zip(pdf_zip_path, page=page_num)
+        assert result is not None, f"Page {page_num} returned None"
+        assert result[:4] == b"\x89PNG", f"Page {page_num} is not a PNG"
+
+
+def test_render_pdf_page_out_of_range_returns_none(pdf_zip_path: Path) -> None:
+    """Requesting a page beyond the PDF's range must return None (not crash)."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import render_pdf_page_from_document_zip
+
+    result = render_pdf_page_from_document_zip(pdf_zip_path, page=99)
+    assert result is None, "Out-of-range page should return None"
+
+
+def test_render_pdf_page_zero_returns_none(pdf_zip_path: Path) -> None:
+    """Requesting page 0 (invalid 1-indexed) must return None."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import render_pdf_page_from_document_zip
+
+    result = render_pdf_page_from_document_zip(pdf_zip_path, page=0)
+    assert result is None, "Page 0 (out of range) should return None"
+
+
+def test_document_zip_is_pure_pdf(pdf_zip_path: Path) -> None:
+    """document_zip_is_pure_pdf must return True for a pure-PDF zip."""
+    from remarkable_mcp.extract import document_zip_is_pure_pdf
+
+    assert document_zip_is_pure_pdf(pdf_zip_path) is True
+
+
+def test_render_merged_pure_pdf_returns_png(pdf_zip_path: Path) -> None:
+    """render_merged_page_from_document_zip must handle a pure-PDF zip gracefully."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import render_merged_page_from_document_zip
+
+    png_bytes, note = render_merged_page_from_document_zip(pdf_zip_path, page=1)
+    assert png_bytes is not None, f"render_merged returned None; note={note!r}"
+    assert png_bytes[:4] == b"\x89PNG", "Returned bytes do not start with PNG magic bytes"
+
+
+def test_render_merged_pure_pdf_out_of_range(pdf_zip_path: Path) -> None:
+    """render_merged_page_from_document_zip must return (None, error) for out-of-range page."""
+    pytest.importorskip("fitz", reason="pymupdf not installed")
+    from remarkable_mcp.extract import render_merged_page_from_document_zip
+
+    png_bytes, note = render_merged_page_from_document_zip(pdf_zip_path, page=99)
+    assert png_bytes is None, "Out-of-range page should produce None bytes"
+    assert note is not None, "Out-of-range page should produce an error note"
+    assert "out of range" in note.lower(), f"Unexpected note: {note!r}"


### PR DESCRIPTION
## Problem

In **cloud mode**, PDFs and EPUBs are unreadable and unrenderable: `remarkable_read` returns empty with `file_type: "notebook"`, and `remarkable_image` fails. This hits any cloud PDF/EPUB — including the device's built-in *Learn the basics* / *Go further* guides and any PDF a user uploads.

## Root cause

Three cloud-path gaps:
1. `api.get_file_type` has no cloud branch — it ignores the document's `.content` `fileType` and defaults to `"notebook"`, so PDFs/EPUBs are routed to the `.rm` parser.
2. `api.download_raw_file` returns `None` for the cloud client (stale *"raw files not available via API"* assumption) — but the source `.pdf`/`.epub` is present in the document's blob package.
3. PDF page count / rendering derive from the `.rm`/annotation layer, which is empty for a pure PDF → *"document has 0 pages"*.

## Fix

- **`get_file_type`** (cloud): read the authoritative `fileType` from the document's `.content` blob (via `doc.files` + `client._get_file`), with a `.pdf`/`.epub`-presence fallback.
- **`download_raw_file`** (cloud): fetch the `.pdf`/`.epub` blob from the package by hash.
- **`extract.py`**: derive PDF page count from the PDF itself (pymupdf); add `render_pdf_page_from_document_zip` + `document_zip_is_pure_pdf`; let `render_merged_page_from_document_zip` rasterize pure PDFs.
- **`tools.py`**: route pure-PDF docs to PDF rendering in `remarkable_image`.

`remarkable_read` already branched on `file_type in ("pdf","epub")`, so fixing detection + raw extraction makes text, raw, and rendering all work together.

## Tests

- `tests/test_filetype.py` — type detection + raw extraction (mocked cloud client).
- `tests/test_pdf_render.py` — PDF page count + rasterization via pymupdf (no libcairo needed).
