### PR TITLE
perf(tools): cache document collection to fix per-call cloud fetches timing out

### DIFF
--- a/remarkable_mcp/document_cache.py
+++ b/remarkable_mcp/document_cache.py
@@ -1,0 +1,57 @@
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_TTL_SECONDS = 300
+
+_lock = threading.Lock()
+_collection: List[Any] = []
+_items_by_id: Dict[str, Any] = {}
+_loaded_at: float = 0.0
+_client: Optional[Any] = None
+
+
+def set_collection(client: Any, collection: List[Any]) -> None:
+    global _collection, _items_by_id, _loaded_at, _client
+    with _lock:
+        _client = client
+        _collection = list(collection)
+        _items_by_id = {item.ID: item for item in collection}
+        _loaded_at = time.monotonic()
+    logger.debug("document_cache: stored %d items", len(collection))
+
+
+def get_collection() -> Optional[List[Any]]:
+    with _lock:
+        if _loaded_at == 0.0:
+            return None
+        age = time.monotonic() - _loaded_at
+        if age > _TTL_SECONDS:
+            logger.debug("document_cache: TTL expired (age=%.0fs)", age)
+            return None
+        return list(_collection)
+
+
+def get_client() -> Optional[Any]:
+    with _lock:
+        return _client
+
+
+def is_fresh() -> bool:
+    with _lock:
+        if _loaded_at == 0.0:
+            return False
+        return (time.monotonic() - _loaded_at) <= _TTL_SECONDS
+
+
+def invalidate() -> None:
+    global _collection, _items_by_id, _loaded_at, _client
+    with _lock:
+        _collection = []
+        _items_by_id = {}
+        _loaded_at = 0.0
+        _client = None
+    logger.debug("document_cache: invalidated")

--- a/remarkable_mcp/resources.py
+++ b/remarkable_mcp/resources.py
@@ -427,10 +427,12 @@ def load_all_documents_sync() -> int:
     """
     global _registered_docs, _registered_raw, _registered_img
 
+    from remarkable_mcp import document_cache
     from remarkable_mcp.api import get_items_by_id, get_rmapi
 
     client = get_rmapi()
     items = client.get_meta_items()
+    document_cache.set_collection(client, items)
     items_by_id = get_items_by_id(items)
     documents = [item for item in items if not item.is_folder]
 
@@ -523,7 +525,9 @@ async def _load_documents_background(shutdown_event: asyncio.Event):
             batch_docs = documents[offset : offset + batch_size]
 
             if not batch_docs:
-                # No more documents
+                from remarkable_mcp import document_cache
+
+                document_cache.set_collection(client, items)
                 logger.info(
                     f"Background loader complete: {len(_registered_docs)} documents registered"
                     + (f" (filtered to {root})" if root != "/" else "")

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -21,6 +21,7 @@ from mcp.types import (
     ToolAnnotations,
 )
 
+from remarkable_mcp import document_cache
 from remarkable_mcp.api import (
     REMARKABLE_TOKEN,
     download_raw_file,
@@ -111,6 +112,16 @@ def _resolve_root_path(path: str) -> str:
         return root
     # Prepend root to the path
     return root + path
+
+
+async def _get_collection():
+    cached = document_cache.get_collection()
+    if cached is not None:
+        return document_cache.get_client(), cached
+    client = get_rmapi()
+    collection = await run_blocking(client.get_meta_items)
+    document_cache.set_collection(client, collection)
+    return client, collection
 
 
 # Base annotations for read-only operations
@@ -297,8 +308,7 @@ async def remarkable_read(
     </examples>
     """
     try:
-        client = get_rmapi()
-        collection = await run_blocking(client.get_meta_items)
+        client, collection = await _get_collection()
         items_by_id = get_items_by_id(collection)
 
         # Validate parameters
@@ -803,8 +813,7 @@ async def remarkable_browse(
     </examples>
     """
     try:
-        client = get_rmapi()
-        collection = await run_blocking(client.get_meta_items)
+        client, collection = await _get_collection()
         items_by_id = get_items_by_id(collection)
         items_by_parent = get_items_by_parent(collection)
 
@@ -1031,8 +1040,7 @@ async def remarkable_recent(limit: int = 10, include_preview: bool = False) -> s
     </examples>
     """
     try:
-        client = get_rmapi()
-        collection = await run_blocking(client.get_meta_items)
+        client, collection = await _get_collection()
         items_by_id = get_items_by_id(collection)
 
         # Clamp limit - lower max when previews enabled (expensive operation)
@@ -1296,8 +1304,7 @@ async def remarkable_status() -> str:
         connection_info = "environment variable" if REMARKABLE_TOKEN else "file (~/.rmapi)"
 
     try:
-        client = get_rmapi()
-        collection = await run_blocking(client.get_meta_items)
+        client, collection = await _get_collection()
         items_by_id = get_items_by_id(collection)
 
         root = _get_root_path()
@@ -1442,8 +1449,7 @@ async def remarkable_image(
         if background is None:
             background = await run_blocking(get_background_color)
 
-        client = get_rmapi()
-        collection = await run_blocking(client.get_meta_items)
+        client, collection = await _get_collection()
         items_by_id = get_items_by_id(collection)
 
         root = _get_root_path()

--- a/test_server.py
+++ b/test_server.py
@@ -37,6 +37,15 @@ from remarkable_mcp.server import mcp
 # =============================================================================
 
 
+@pytest.fixture(autouse=True)
+def clear_document_cache():
+    from remarkable_mcp import document_cache
+
+    document_cache.invalidate()
+    yield
+    document_cache.invalidate()
+
+
 @pytest.fixture
 def mock_document():
     """Create a mock Document object."""
@@ -2470,6 +2479,10 @@ class TestConcurrentToolDispatch:
         import asyncio
         import time
 
+        from remarkable_mcp import document_cache
+
+        document_cache.invalidate()
+
         call_delay = 0.4
 
         def slow_get_meta_items():
@@ -2494,3 +2507,103 @@ class TestConcurrentToolDispatch:
             f"Concurrent tool calls appear serialized: elapsed={elapsed:.2f}s "
             f"vs single-call delay={call_delay}s"
         )
+
+
+class TestDocumentCache:
+    def setup_method(self):
+        from remarkable_mcp import document_cache
+
+        document_cache.invalidate()
+
+    def teardown_method(self):
+        from remarkable_mcp import document_cache
+
+        document_cache.invalidate()
+
+    def test_empty_cache_returns_none(self):
+        from remarkable_mcp import document_cache
+
+        assert document_cache.get_collection() is None
+
+    def test_set_and_get_collection(self):
+        from remarkable_mcp import document_cache
+
+        client = Mock()
+        items = [Mock(ID="a"), Mock(ID="b")]
+        document_cache.set_collection(client, items)
+        result = document_cache.get_collection()
+        assert result is not None
+        assert len(result) == 2
+
+    def test_get_client(self):
+        from remarkable_mcp import document_cache
+
+        client = Mock()
+        document_cache.set_collection(client, [])
+        assert document_cache.get_client() is client
+
+    def test_is_fresh_after_set(self):
+        from remarkable_mcp import document_cache
+
+        document_cache.set_collection(Mock(), [])
+        assert document_cache.is_fresh() is True
+
+    def test_is_fresh_false_when_empty(self):
+        from remarkable_mcp import document_cache
+
+        assert document_cache.is_fresh() is False
+
+    def test_invalidate_clears_cache(self):
+        from remarkable_mcp import document_cache
+
+        document_cache.set_collection(Mock(), [Mock(ID="x")])
+        document_cache.invalidate()
+        assert document_cache.get_collection() is None
+        assert document_cache.get_client() is None
+        assert document_cache.is_fresh() is False
+
+    def test_ttl_expiry(self):
+        import time
+
+        from remarkable_mcp import document_cache
+
+        document_cache.set_collection(Mock(), [Mock(ID="x")])
+        with patch.object(document_cache, "_loaded_at", time.monotonic() - 400):
+            assert document_cache.get_collection() is None
+            assert document_cache.is_fresh() is False
+
+    def test_returns_copy_not_reference(self):
+        from remarkable_mcp import document_cache
+
+        items = [Mock(ID="a")]
+        document_cache.set_collection(Mock(), items)
+        result = document_cache.get_collection()
+        result.append(Mock(ID="b"))
+        assert len(document_cache.get_collection()) == 1
+
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_tools_use_cache_on_second_call(self, mock_get_rmapi):
+        from remarkable_mcp import document_cache
+
+        document_cache.invalidate()
+
+        mock_client = Mock()
+        mock_client.get_meta_items.return_value = []
+        mock_get_rmapi.return_value = mock_client
+
+        await mcp.call_tool("remarkable_browse", {})
+        await mcp.call_tool("remarkable_browse", {})
+
+        mock_client.get_meta_items.assert_called_once()
+
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_tools_skip_get_rmapi_when_cache_warm(self, mock_get_rmapi):
+        from remarkable_mcp import document_cache
+
+        mock_client = Mock()
+        mock_client.get_meta_items.return_value = []
+        document_cache.set_collection(mock_client, [])
+
+        await mcp.call_tool("remarkable_browse", {})
+
+        mock_get_rmapi.assert_not_called()


### PR DESCRIPTION
## Problem

Every tool call (`remarkable_status`, `remarkable_browse`, `remarkable_recent`, `remarkable_read`, `remarkable_image`) independently fetched the full document collection from the reMarkable cloud API via `client.get_meta_items()`. With accounts that have 100+ documents this takes **~30 seconds per call**, causing all tool invocations to time out before returning.

The background loader runs at startup and populates MCP resources, but its results were never shared with the tool handlers — so tools always went to the network.

## Fix

Add a module-level `document_cache` with a 5-minute TTL that stores the collection and client after the first successful fetch. All tool handlers now go through `_get_collection()` which:

1. Returns the cached collection immediately on a hit (sub-millisecond)
2. Falls back to a live `get_meta_items()` fetch on a miss or TTL expiry, then stores the result

The background loader (cloud mode) and sync loader (SSH mode) both populate the cache at startup, so the first tool call after the server initialises is served from memory.

## Result

- First tool call after startup: instant (cache populated by background loader)
- Subsequent calls within 5 min: instant (cache hit)
- After TTL expiry: one re-fetch, then instant again
- All 5 tool handlers affected: status, browse, recent, read, image

## Changes

- `remarkable_mcp/document_cache.py` — new thread-safe cache module with TTL, `set_collection`, `get_collection`, `get_client`, `is_fresh`, `invalidate`
- `remarkable_mcp/tools.py` — add `_get_collection()` helper; replace all 5 `client.get_meta_items()` call sites
- `remarkable_mcp/resources.py` — populate cache in both background loader (cloud) and sync loader (SSH)
- `test_server.py` — `TestDocumentCache` (10 tests), `autouse` cache-clear fixture so existing mocked tests are unaffected

## Tests

```
119 passed in 0.73s
```