### PR TITLE
Render fallback to tablet PDF + robust recent sort (release readiness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Your reMarkable tablet is a powerful tool for thinking, note-taking, and researc
 - **Typed text extraction** — Native support for Type Folio and typed annotations
 - **Handwriting OCR** — Convert handwritten notes to searchable text
 - **PDF & EPUB support** — Extract text from documents, plus your annotations
+- **Robust page rendering** — Renders pages locally and, in USB/SSH mode, automatically falls back to the tablet's own PDF export, so images work across firmware versions and even without system graphics libraries installed
 - **Smart search** — Find content across your entire library
 - **Second brain integration** — Use with Obsidian, note-taking apps, or any AI workflow
 
@@ -284,6 +285,12 @@ remarkable_image("Logo Sketch", background="#00000000")
 # Compatibility mode: return resource URI instead of embedded resource
 remarkable_image("Diagram", compatibility=True)
 ```
+
+> **Note:** In USB and SSH modes, PNG rendering automatically falls back to the
+> tablet's native PDF export when the local stroke renderer can't produce an
+> image (empty pages, newer `.rm` formats, or a machine without `libcairo`).
+> This keeps `remarkable_image` working across firmware versions and platforms.
+> Cloud mode has no native export, so it relies on the local renderer.
 
 ---
 

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1002,6 +1002,59 @@ def _render_pdf_page_to_png(
         return None
 
 
+def render_tablet_pdf_page_to_png(
+    pdf_bytes: bytes, page: int = 1, target_long_edge: int = 2048
+) -> Optional[bytes]:
+    """Rasterize one page of the tablet's native PDF export to PNG bytes.
+
+    This is the portable fallback used when the local stroke renderer cannot
+    produce an image. The reMarkable's own firmware renders every notebook (and
+    annotated PDF/EPUB) to a PDF served at ``/download/<uuid>/pdf``, so this path
+    works regardless of the .rm block format, handles empty pages, and—crucially
+    for portability—does not depend on a working ``cairo``/``libcairo`` for
+    ``cairosvg`` (PyMuPDF bundles its own renderer). Credit: ljdutel (#95).
+
+    Args:
+        pdf_bytes: Raw bytes of the tablet-exported PDF.
+        page: 1-based page number (matches notebook page ordering 1:1).
+        target_long_edge: Target pixel size for the longest page edge.
+
+    Returns:
+        PNG image bytes, or None on failure / out-of-range page.
+    """
+    try:
+        import fitz
+    except ImportError:
+        return None
+
+    # The tablet's PDFs sometimes reference graphics-state resources MuPDF
+    # considers malformed; it still rasterizes them correctly, so suppress the
+    # noisy non-fatal error output.
+    try:
+        fitz.TOOLS.mupdf_display_errors(False)
+    except Exception:
+        pass
+
+    try:
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    except Exception:
+        return None
+
+    try:
+        index = page - 1
+        if index < 0 or index >= len(doc):
+            return None
+        pdf_page = doc[index]
+        longest_edge = max(pdf_page.rect.width, pdf_page.rect.height) or 1.0
+        zoom = target_long_edge / longest_edge
+        pix = pdf_page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+        return pix.tobytes("png")
+    except Exception:
+        return None
+    finally:
+        doc.close()
+
+
 def render_merged_page_from_document_zip(
     zip_path: Path,
     page: int = 1,

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -45,6 +45,7 @@ from remarkable_mcp.extract import (
     render_merged_page_from_document_zip,
     render_page_from_document_zip,
     render_page_from_document_zip_svg,
+    render_tablet_pdf_page_to_png,
 )
 from remarkable_mcp.responses import make_error, make_response
 from remarkable_mcp.sampling import (
@@ -1567,8 +1568,11 @@ async def remarkable_image(
                         error_type="render_failed",
                         message="Failed to render page to SVG.",
                         suggestion=(
-                            "This may be an older notebook format (v5) not supported by rmc. "
-                            "Try remarkable_read() to extract text instead."
+                            "SVG output requires local stroke parsing, so the "
+                            "page may be empty or in a newer format. Try "
+                            "output_format='png', which falls back to the "
+                            "tablet's native PDF export in USB/SSH mode, or "
+                            "remarkable_read() to extract text instead."
                         ),
                     )
 
@@ -1625,13 +1629,35 @@ async def remarkable_image(
                         background_color=background,
                     )
 
+                # Portable fallback: the local stroke renderer can fail to
+                # produce an image for empty pages, newer .rm block formats, or
+                # when the client machine lacks a working cairo/libcairo for
+                # cairosvg. In USB and SSH modes the tablet exports a
+                # natively-rendered PDF that covers all of those cases, so
+                # rasterize the requested page from it with PyMuPDF (which needs
+                # no system cairo). Cloud mode has no such export, so
+                # download_raw_file returns None there and this safely no-ops.
+                # Credit: ljdutel (#95).
+                rendered_via_pdf = False
+                if png_data is None:
+                    pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
+                    if pdf_bytes:
+                        png_data = await run_blocking(
+                            render_tablet_pdf_page_to_png, pdf_bytes, page
+                        )
+                        rendered_via_pdf = png_data is not None
+
                 if png_data is None:
                     return make_error(
                         error_type="render_failed",
                         message="Failed to render page to image.",
                         suggestion=(
-                            "This may be an older notebook format (v5) not supported by rmc. "
-                            "Try remarkable_read() to extract text instead."
+                            "The page may be empty, or local rendering "
+                            "dependencies (cairo/libcairo for cairosvg) may be "
+                            "missing. In USB/SSH mode the tablet's native PDF "
+                            "export is used automatically as a fallback—make "
+                            "sure the tablet is connected. You can also try "
+                            "remarkable_read() to extract text instead."
                         ),
                     )
 
@@ -1702,6 +1728,11 @@ async def remarkable_image(
                         hint = f"{merged_note} {hint}"
                     elif is_merged:
                         hint = f"Rendered with PDF + annotation compositing. {hint}"
+                    if rendered_via_pdf:
+                        hint = (
+                            "Rendered via the tablet's native PDF export "
+                            "(local stroke render unavailable). " + hint
+                        )
 
                     response_data = {
                         "data_uri": data_uri,
@@ -1711,6 +1742,7 @@ async def remarkable_image(
                         "total_pages": total_pages,
                         "resource_uri": resource_uri,
                         "merged": is_merged,
+                        "render_source": "tablet_pdf" if rendered_via_pdf else "strokes",
                         **ocr_info,
                     }
                     return make_response(response_data, hint)
@@ -1727,6 +1759,11 @@ async def remarkable_image(
                     info_text += f"Resource URI: {resource_uri}"
                     if is_merged:
                         info_text += "\nRendered with PDF + annotation compositing."
+                    if rendered_via_pdf:
+                        info_text += (
+                            "\nRendered via the tablet's native PDF export "
+                            "(local stroke render unavailable)."
+                        )
                     if merged_note:
                         info_text += f"\nNote: {merged_note}"
                     if include_ocr and ocr_text:

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -9,6 +9,7 @@ import base64
 import os
 import re
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import List, Literal, Optional
 
@@ -164,6 +165,28 @@ def _is_cloud_archived(item) -> bool:
     # Cloud mode: check parent == "trash"
     parent = item.Parent if hasattr(item, "Parent") else getattr(item, "parent", "")
     return parent == "trash"
+
+
+def _modified_sort_key(item) -> float:
+    """Return a sortable timestamp for an item's modified date.
+
+    Normalizes ``ModifiedClient`` to a float epoch timestamp so documents with a
+    missing/null modified date (e.g. freshly-created notebooks) sort to the
+    bottom instead of crashing the comparator.
+
+    A plain sentinel ``datetime`` cannot be used here: USB ``ModifiedClient``
+    values are timezone-aware (parsed via ``fromisoformat``) while cloud and SSH
+    values are naive (parsed via ``fromtimestamp``), and Python refuses to
+    compare naive and aware datetimes. Reducing everything to ``.timestamp()``
+    sidesteps both the str/datetime and the naive/aware comparison errors.
+    """
+    modified = getattr(item, "ModifiedClient", None)
+    if isinstance(modified, datetime):
+        try:
+            return modified.timestamp()
+        except (OverflowError, OSError, ValueError):
+            return 0.0
+    return 0.0
 
 
 def _ocr_png_tesseract(png_path: Path) -> Optional[str]:
@@ -1051,12 +1074,7 @@ async def remarkable_recent(limit: int = 10, include_preview: bool = False) -> s
                 continue
             documents.append(item)
 
-        documents.sort(
-            key=lambda x: (
-                x.ModifiedClient if hasattr(x, "ModifiedClient") and x.ModifiedClient else ""
-            ),
-            reverse=True,
-        )
+        documents.sort(key=_modified_sort_key, reverse=True)
 
         results = []
         for doc in documents[:limit]:

--- a/test_server.py
+++ b/test_server.py
@@ -457,6 +457,44 @@ class TestRemarkableRecent:
         assert "_error" not in data
         assert "documents" in data
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_recent_handles_null_and_mixed_modified_dates(self, mock_get_rmapi):
+        """Regression test for #96: remarkable_recent must not crash when documents
+        have a null modified date, nor when modified dates mix tz-aware (USB) and
+        tz-naive (cloud/SSH) datetimes.
+
+        Previously the sort key returned "" (str) for missing dates and a datetime
+        otherwise, raising TypeError ('<' not supported between str and datetime).
+        A tz-aware sentinel would still crash cloud/SSH (naive vs aware compare).
+        """
+        from datetime import datetime, timezone
+
+        class FakeDoc:
+            def __init__(self, doc_id, name, modified):
+                self.ID = doc_id
+                self.VissibleName = name
+                self.Parent = ""
+                self.is_folder = False
+                self.tags = []
+                self.ModifiedClient = modified
+
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        # newest: tz-aware (USB style); middle: tz-naive (cloud style); oldest: None
+        mock_client.get_meta_items.return_value = [
+            FakeDoc("a", "Naive Middle", datetime(2024, 6, 1, 12, 0, 0)),
+            FakeDoc("b", "Fresh Notebook", None),
+            FakeDoc("c", "Aware Newest", datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)),
+        ]
+
+        result = await mcp.call_tool("remarkable_recent", {})
+        data = json.loads(result[0][0].text)
+
+        assert "_error" not in data
+        names = [d["name"] for d in data["documents"]]
+        assert names == ["Aware Newest", "Naive Middle", "Fresh Notebook"]
+
 
 # =============================================================================
 # Test remarkable_search Tool

--- a/test_server.py
+++ b/test_server.py
@@ -883,6 +883,132 @@ class TestMergedRendering:
         assert mock_render_merged.called
 
 
+def _make_synthetic_pdf(pages: int = 2) -> bytes:
+    """Build a small multi-page PDF in memory for fallback tests."""
+    import fitz
+
+    doc = fitz.open()
+    for _ in range(pages):
+        # reMarkable-ish portrait page dimensions in points
+        doc.new_page(width=445, height=594)
+    data = doc.tobytes()
+    doc.close()
+    return data
+
+
+class TestRenderTabletPdfFallback:
+    """Tests for the portable tablet-PDF render fallback (issue #95/#102/#94)."""
+
+    def test_render_tablet_pdf_page_to_png_returns_png(self):
+        """A valid PDF page rasterizes to PNG bytes."""
+        from remarkable_mcp.extract import render_tablet_pdf_page_to_png
+
+        pdf = _make_synthetic_pdf(2)
+        png = render_tablet_pdf_page_to_png(pdf, page=1)
+        assert png is not None
+        assert png.startswith(b"\x89PNG\r\n\x1a\n")
+
+    def test_render_tablet_pdf_page_out_of_range(self):
+        """Out-of-range page returns None rather than raising."""
+        from remarkable_mcp.extract import render_tablet_pdf_page_to_png
+
+        pdf = _make_synthetic_pdf(1)
+        assert render_tablet_pdf_page_to_png(pdf, page=5) is None
+        assert render_tablet_pdf_page_to_png(pdf, page=0) is None
+
+    def test_render_tablet_pdf_invalid_bytes(self):
+        """Invalid PDF bytes return None rather than raising."""
+        from remarkable_mcp.extract import render_tablet_pdf_page_to_png
+
+        assert render_tablet_pdf_page_to_png(b"not a pdf", page=1) is None
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.download_raw_file")
+    @patch("remarkable_mcp.tools.render_page_from_document_zip")
+    @patch("remarkable_mcp.tools.get_document_page_count")
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_image_falls_back_to_tablet_pdf(
+        self,
+        mock_get_rmapi,
+        mock_page_count,
+        mock_render,
+        mock_download_raw,
+        mock_document,
+    ):
+        """When local stroke render returns None, fall back to the tablet PDF."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = b"fake zip"
+        mock_page_count.return_value = 2
+        # Local stroke renderer fails (e.g. empty page or missing libcairo)
+        mock_render.return_value = None
+        # Tablet exposes a natively-rendered PDF
+        mock_download_raw.return_value = _make_synthetic_pdf(2)
+
+        with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
+            mock_tmp = Mock()
+            mock_tmp.__enter__ = Mock(return_value=mock_tmp)
+            mock_tmp.__exit__ = Mock(return_value=False)
+            mock_tmp.name = "/tmp/test.zip"
+            mock_tmpfile.return_value = mock_tmp
+            with patch("pathlib.Path.unlink"):
+                result = await mcp.call_tool(
+                    "remarkable_image",
+                    {"document": "Test Document", "page": 2, "compatibility": True},
+                )
+
+        data = json.loads(result[0].text)
+        assert "_error" not in data
+        assert data.get("render_source") == "tablet_pdf"
+        assert data.get("image_base64")
+        assert "native PDF export" in data.get("_hint", "")
+        mock_download_raw.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.download_raw_file")
+    @patch("remarkable_mcp.tools.render_page_from_document_zip")
+    @patch("remarkable_mcp.tools.get_document_page_count")
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_image_render_failed_when_no_fallback(
+        self,
+        mock_get_rmapi,
+        mock_page_count,
+        mock_render,
+        mock_download_raw,
+        mock_document,
+    ):
+        """With no local render and no tablet PDF (e.g. cloud), report render_failed."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = b"fake zip"
+        mock_page_count.return_value = 1
+        mock_render.return_value = None
+        mock_download_raw.return_value = None  # cloud: no native export
+
+        with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
+            mock_tmp = Mock()
+            mock_tmp.__enter__ = Mock(return_value=mock_tmp)
+            mock_tmp.__exit__ = Mock(return_value=False)
+            mock_tmp.name = "/tmp/test.zip"
+            mock_tmpfile.return_value = mock_tmp
+            with patch("pathlib.Path.unlink"):
+                result = await mcp.call_tool(
+                    "remarkable_image",
+                    {"document": "Test Document", "page": 1, "compatibility": True},
+                )
+
+        data = json.loads(result[0].text)
+        assert data["_error"]["type"] == "render_failed"
+        # The misleading "v5 / rmc" message is gone; guidance is actionable
+        suggestion = data["_error"]["suggestion"].lower()
+        assert "v5" not in suggestion
+        assert "cairo" in suggestion or "native pdf" in suggestion
+
+
 # =============================================================================
 # Test Registration
 # =============================================================================


### PR DESCRIPTION
## Summary

Two validated fixes to get the project ready for a release. Both were reproduced and root-caused before fixing; the render fix was validated **end-to-end against a real reMarkable on current firmware** over the USB web interface.

### 1. 🐛 Portable page-render fallback to the tablet's native PDF (`d56fd59`) — closes #95

`remarkable_image` returned a misleading *"older v5 format not supported by rmc"* error and **no image** whenever the local stroke renderer returned `None`.

**Root cause (reproduced on device):** this happens for
- **empty pages** (a header-only `.rm` → renderer returns `None`), and
- client machines **without a working `cairo`/`libcairo`** for `cairosvg` — exactly the macOS/Windows case behind #95 and #102. (On current firmware, `rmscene` 0.6.1 parses notebooks fine — verified identical stroke extraction vs 0.8.0 on real files — so the version was never the cause.)

**Fix:** in USB and SSH modes the tablet already serves a natively-rendered PDF at `/download/<uuid>/pdf`. When local rendering returns `None`, we now rasterize the requested page from it with **PyMuPDF** (bundles its own renderer, needs no system cairo). This is portable across platforms and robust to any `.rm` block format. Cloud mode has no native export, so the fallback safely no-ops there.

- `extract.render_tablet_pdf_page_to_png()` — page mapping is 1:1 with the notebook (validated on device, including a previously-failing empty page that now renders).
- Replaced the inaccurate "v5/rmc" suggestions with actionable guidance.
- Response now reports `render_source` (`"strokes"` | `"tablet_pdf"`) plus a hint note.

Credit: @ljdutel (#95) for the fallback approach.

### 2. 🐛 Robust `remarkable_recent` sort with null/mixed modified dates (`de9d1c9`) — fixes #96

The sort key mixed `""` (str) and `datetime`, crashing on documents with a missing modified date. The issue's suggested aware-`datetime.min` sentinel would itself crash cloud/SSH (naive datetimes can't compare to an aware sentinel). Fix normalizes every value to a float epoch via `.timestamp()`, which is correct for USB (tz-aware), cloud, and SSH (tz-naive) alike.

## Validation
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest test_server.py -v` → **113 passed** ✅
- Real device (USB, current firmware): empty page `Quick sheets` p2 → now a 13.8 KB PNG via `tablet_pdf`; normal pages still render locally via `strokes`.

## Notes
- This does **not** touch PR #97's approach (drop `rmc` / bump `rmscene`): device testing showed the version bump is unnecessary for current firmware and that removing `rmc` risks PDF-overlay coordinate alignment. The PDF fallback addresses the actual reported failures more robustly.