### PR TITLE
feat: cross-transport read/write parity, capability matrix & portability (1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Your reMarkable tablet is a powerful tool for thinking, note-taking, and researc
 - **Typed text extraction** — Native support for Type Folio and typed annotations
 - **Handwriting OCR** — Convert handwritten notes to searchable text
 - **PDF & EPUB support** — Extract text from documents, plus your annotations
-- **Robust page rendering** — Renders pages locally and, in USB/SSH mode, automatically falls back to the tablet's own PDF export, so images work across firmware versions and even without system graphics libraries installed
+- **Robust page rendering** — Renders pages locally and automatically falls back to a source PDF when the local stroke renderer can't (USB/SSH use the tablet's own PDF export; cloud uses the original source PDF), so images work across firmware versions and even without system graphics libraries installed
 - **Smart search** — Find content across your entire library
 - **Second brain integration** — Use with Obsidian, note-taking apps, or any AI workflow
 
@@ -180,17 +180,19 @@ AI assistants use the tools to read documents, search content, and more:
 
 ## Connection Modes
 
-All three modes expose the same read tools, so pick based on how your tablet is connected — not on capability. Here's each option and when to reach for it:
+All three modes share the same read, render, and upload tools. **Cloud and SSH additionally support full library management** — create folders, move, rename, and delete (with `--write`) — so capability is near-identical and you can genuinely pick whichever matches how your tablet is connected:
 
-- **🔌 USB Web Interface** — *the recommended default.* Plug in over USB and enable the web interface in Storage Settings. No subscription, no developer mode, fast, and supports raw PDF export and write tools. Use this whenever your tablet is in front of you.
-- **☁️ Cloud** — *recommended when the device isn't connected.* Reads your library straight from reMarkable's cloud, so it works wirelessly from anywhere with a Connect subscription — no cable, no developer mode. Parallel fetching plus an on-disk blob cache make it fast after the first sync. Choose this for remote/headless setups or when you simply don't want to plug in.
-- **⚡ SSH** — *for power users who need filesystem-level access.* Requires developer mode over USB. Adds folder create/move/rename/delete on top of the read and upload tools. Pick this only if you specifically need those filesystem operations.
+- **☁️ Cloud** — *device-free, works from anywhere.* Reads your library straight from reMarkable's cloud over Wi‑Fi with a Connect subscription — no cable, no developer mode. Full read/render plus full write (upload, create folder, move, rename, delete → trash). Parallel fetching and an on-disk blob cache make it fast after the first sync. Best for remote/headless setups or when you don't want to plug in.
+- **🔌 USB Web Interface** — *best when the tablet is plugged in.* Enable the web interface in Storage Settings — no subscription, no developer mode. Full read/render plus upload (to your root folder). The tablet's USB web firmware exposes no folder/move/rename/delete endpoints, so for those over a cable use SSH.
+- **⚡ SSH** — *for power users who want filesystem-level access.* Requires developer mode over USB. Full read/render plus full write including folder create/move/rename/delete, straight from the tablet filesystem.
 
-| Mode | Setup | Subscription | Offline | Raw files | Write tools |
-|------|-------|--------------|---------|-----------|-------------|
-| **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ PDF | ✅ upload |
-| **☁️ Cloud** | One-time code | Connect | ❌ | ❌ | ❌ |
-| **⚡ SSH** | Developer mode | Not required | ✅ | ✅ PDF/EPUB | ✅ upload + mkdir/move/rename/delete |
+| Mode | Setup | Subscription | Offline | Read + render | Raw PDF/EPUB | Upload | Folder ops¹ |
+|------|-------|--------------|---------|---------------|--------------|--------|-------------|
+| **☁️ Cloud** | One-time code | Connect | ❌ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
+| **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ | ✅ PDF | ✅ (to root) | ❌ |
+| **⚡ SSH** | Developer mode | Not required | ✅ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
+
+¹ Folder ops = create folder / move / rename / delete. Upload and folder ops require the `--write` flag (off by default). Deletes move items to the trash and can prompt for confirmation when your client supports elicitation.
 
 **📖 Detailed Setup Guides:**
 - [USB Web Interface Setup](docs/usb-web-setup.md) — **recommended** — simple setup, full feature support
@@ -232,10 +234,10 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_browse` | Navigate folders, search by document name, or filter by tags |
 | `remarkable_search` | Search content across multiple documents (with tag filtering) |
 | `remarkable_recent` | Get recently modified documents |
-| `remarkable_status` | Check connection status |
+| `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-All tools are **read-only** and return structured JSON with hints for next actions.
+These six tools are **read-only** and return structured JSON with hints for next actions. Opt-in **write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are also available with the `--write` flag — see [Write Tools](#write-tools-cloud-ssh--usb-web).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -292,10 +294,11 @@ remarkable_image("Logo Sketch", background="#00000000")
 remarkable_image("Diagram", compatibility=True)
 ```
 
-> **Note:** In USB and SSH modes, PNG rendering automatically falls back to the
-> tablet's native PDF export when the local stroke renderer can't produce an
-> image (empty pages, newer `.rm` formats, or a machine without `libcairo`).
-> This keeps `remarkable_image` working across firmware versions and platforms.
+> **Note:** PNG rendering automatically falls back to a source PDF when the
+> local stroke renderer can't produce an image (empty pages, newer `.rm`
+> formats, or a machine without `libcairo`). USB and SSH modes use the tablet's
+> native PDF export; cloud mode uses the document's original source PDF. This
+> keeps `remarkable_image` working across firmware versions and platforms.
 > Cloud mode has no native export, so it relies on the local renderer.
 
 ---
@@ -406,31 +409,43 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 | Speed | ⚡ 10-100x faster | ⚡ Fast | ⚡ Fast (parallel + cached) |
 | Offline | ✅ Yes | ✅ Yes | ❌ No |
 | Subscription | ✅ Not required | ✅ Not required | ❌ Connect required |
-| Raw files | ✅ PDFs, EPUBs | ✅ PDFs | ❌ Not available |
-| Upload | ✅ With `--write` | ✅ With `--write` | ❌ Not available |
-| mkdir/move/rename/delete | ✅ With `--write` | ❌ | ❌ |
+| Raw files | ✅ PDFs, EPUBs | ✅ PDFs | ✅ PDFs, EPUBs |
+| Upload | ✅ With `--write` | ✅ With `--write` | ✅ With `--write` |
+| mkdir/move/rename/delete | ✅ With `--write` | ❌ | ✅ With `--write` |
 | Setup | Developer mode | Enable in Settings | One-time code |
 
 📖 **[SSH Setup Guide](docs/ssh-setup.md)**
 
 ---
 
-## Write Tools (SSH & USB Web)
+## Write Tools (Cloud, SSH & USB Web)
 
-Opt-in write tools let you upload, organize, and manage documents directly on your reMarkable tablet. **Disabled by default** for safety.
+Opt-in write tools let you upload, organize, and manage documents on your reMarkable. **Disabled by default** for safety. Cloud and SSH modes support the full set; USB web supports upload only (its firmware exposes no folder operations).
 
-| Feature | SSH Mode | USB Web Mode | Cloud Mode |
-|---------|:--------:|:------------:|:----------:|
-| Upload | ✅ | ✅ | ❌ |
-| Mkdir | ✅ | ❌ | ❌ |
-| Move | ✅ | ❌ | ❌ |
-| Rename | ✅ | ❌ | ❌ |
-| Delete | ✅ | ❌ | ❌ |
+| Feature | Cloud Mode | SSH Mode | USB Web Mode |
+|---------|:----------:|:--------:|:------------:|
+| Upload | ✅ | ✅ | ✅ (to root) |
+| Mkdir | ✅ | ✅ | ❌ |
+| Move | ✅ | ✅ | ❌ |
+| Rename | ✅ | ✅ | ❌ |
+| Delete | ✅ (→ trash) | ✅ | ❌ |
 
 ### Enabling Write Tools
 
-Add the `--write` flag when running in SSH or USB web mode:
+Add the `--write` flag. It works in any mode (cloud is the default — no flag needed to select it):
 
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--write"]
+    }
+  }
+}
+```
+
+For SSH or USB web, combine `--write` with the transport flag:
 ```json
 {
   "servers": {
@@ -442,7 +457,7 @@ Add the `--write` flag when running in SSH or USB web mode:
 }
 ```
 
-Or with USB web mode (upload only):
+USB web mode (upload only):
 ```json
 {
   "servers": {
@@ -467,35 +482,35 @@ Or set the environment variable:
 
 | Tool | Description |
 |------|-------------|
-| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file |
-| `remarkable_mkdir(folder_name, parent)` | Create a new folder (SSH only) |
-| `remarkable_move(document, dest_folder)` | Move a document or folder (SSH only) |
-| `remarkable_rename(document, new_name)` | Rename a document or folder (SSH only) |
-| `remarkable_delete(document)` | Delete a document or folder — destructive (SSH only) |
+| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file (all modes; USB web ignores folder/name and uploads to root) |
+| `remarkable_mkdir(folder_name, parent)` | Create a new folder (cloud and SSH) |
+| `remarkable_move(document, dest_folder)` | Move a document or folder (cloud and SSH) |
+| `remarkable_rename(document, new_name)` | Rename a document or folder (cloud and SSH) |
+| `remarkable_delete(document)` | Delete a document or folder — destructive (cloud and SSH) |
 
 ### Safety
 
-- **Upload registers in SSH and USB web mode** — cloud mode returns a clear error
-- **mkdir, move, rename, delete are only registered in SSH mode** — they are not exposed at all on USB web or cloud, keeping the tool list scoped to what the active transport actually supports
-- **Delete is destructive and immediate** — the MCP client is responsible for confirming with the user before invoking. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
-- After each write operation (SSH), the tablet UI restarts automatically to reflect changes
+- **Upload registers in all modes** — cloud, SSH, and USB web.
+- **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
+- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting; otherwise it relies on the host to gate the call. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to bypass the prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
+- After each write operation in SSH mode, the tablet UI restarts automatically to reflect changes.
 
 ### Examples
 
 ```python
 # Upload a PDF
-remarkable_upload("/tmp/paper.pdf", parent_folder="/Research")
+remarkable_upload("paper.pdf", parent_folder="/Research")
 
-# Create a folder (SSH only)
+# Create a folder
 remarkable_mkdir("2024 Archive", parent="/Archive")
 
-# Move a document (SSH only)
+# Move a document
 remarkable_move("Meeting Notes", "/Archive/2024 Archive")
 
-# Rename a document (SSH only)
+# Rename a document
 remarkable_rename("Untitled", "Q4 Planning Notes")
 
-# Delete (destructive — confirm with user first) (SSH only)
+# Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
 ```
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -6,10 +6,10 @@ Documents in your reMarkable library are automatically registered as MCP resourc
 
 | URI Scheme | Description | Mode |
 |------------|-------------|------|
-| `remarkable:///` | Your annotations, typed text, and handwriting | Both |
-| `remarkableraw:///` | Original PDF/EPUB text | SSH only |
-| `remarkableimg:///` | PNG page images (notebooks) | Both |
-| `remarkablesvg:///` | SVG page images (notebooks) | Both |
+| `remarkable:///` | Your annotations, typed text, and handwriting | All modes |
+| `remarkableraw:///` | Original PDF/EPUB text | All modes (USB web: PDF) |
+| `remarkableimg:///` | PNG page images (notebooks) | All modes |
+| `remarkablesvg:///` | SVG page images (notebooks) | All modes |
 
 ## Text Resources (`remarkable:///`)
 
@@ -86,10 +86,14 @@ This paper explores the relationship between...
 
 | Mode | Text Resources | Raw Resources |
 |------|----------------|---------------|
-| SSH | ✅ Yes | ✅ Yes |
-| Cloud | ✅ Yes | ❌ No |
+| Cloud | ✅ Yes | ✅ Yes (PDF/EPUB) |
+| SSH | ✅ Yes | ✅ Yes (PDF/EPUB) |
+| USB Web | ✅ Yes | ✅ Yes (PDF) |
 
-The Cloud API doesn't provide access to original source files, so raw resources are only available when using SSH mode.
+All modes can access the original source files. Cloud stores the source blob
+alongside the notebook data, so PDFs/EPUBs are available wirelessly — though
+very large files that the device hasn't synced to the cloud may be missing.
+USB web exposes the tablet's PDF export.
 
 ## Image Resources (`remarkableimg:///` and `remarkablesvg:///`)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -51,7 +51,7 @@ With this configuration:
 ### Content Types
 
 - **`"text"`** — Full extracted text: raw document content plus annotations, highlights, and typed text (default)
-- **`"raw"`** — Only the original PDF/EPUB text, no annotations. SSH mode only.
+- **`"raw"`** — Only the original PDF/EPUB text, no annotations. Works in all modes when the source file is present (very large PDFs/EPUBs may not be synced to the cloud).
 - **`"annotations"`** — Only annotations: highlights, typed text from notebooks, and OCR content
 
 ### Examples
@@ -300,9 +300,12 @@ remarkable_status()
 | Field | Description |
 |-------|-------------|
 | `authenticated` | Whether authentication succeeded |
-| `transport` | `"ssh"` or `"cloud"` |
+| `transport` | `"cloud"`, `"ssh"`, or `"usb-web"` |
 | `connection` | Connection details |
 | `document_count` | Total documents in library (filtered by root if configured) |
+| `write_enabled` | Whether write tools are enabled (the `--write` flag) |
+| `capabilities` | Effective capabilities for the active transport (read/render/upload/mkdir/move/rename/delete) |
+| `capabilities_by_transport` | The full per-transport capability matrix |
 | `root_path` | Configured root path filter (only present if set) |
 | `ocr_backend` | Which OCR backend is configured |
 

--- a/remarkable_mcp/api.py
+++ b/remarkable_mcp/api.py
@@ -170,12 +170,12 @@ def download_raw_file(client, doc, extension: str):
     Returns:
         Raw file bytes, or None if file doesn't exist or not supported
     """
-    # SSH client has direct download_raw_file method
+    # All transports (cloud, SSH, USB web) implement download_raw_file. The
+    # cloud store keeps the original source blob alongside the notebook data, so
+    # PDFs/EPUBs are downloadable in every mode.
     if hasattr(client, "download_raw_file"):
         return client.download_raw_file(doc, extension)
 
-    # Cloud client - raw files are not available via API
-    # The cloud API only returns the notebook annotations, not source PDFs/EPUBs
     return None
 
 
@@ -190,13 +190,14 @@ def get_file_type(client, doc) -> str:
     Returns:
         File type string: 'pdf', 'epub', or 'notebook'
     """
-    # SSH client has direct get_file_type method
+    # Every transport implements get_file_type. Cloud derives it from the blob
+    # index, SSH/USB read the .content fileType field.
     if hasattr(client, "get_file_type"):
         file_type = client.get_file_type(doc)
         if file_type:
             return file_type
 
-    # Infer from document name
+    # Last-resort fallback: infer from the document name.
     name = doc.VissibleName.lower()
     if name.endswith(".pdf"):
         return "pdf"

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -77,7 +77,10 @@ Security Note:
     parser.add_argument(
         "--write",
         action="store_true",
-        help="Enable write tools (upload, mkdir, move, rename, delete). SSH and USB web mode.",
+        help=(
+            "Enable write tools (upload, mkdir, move, rename, delete). "
+            "Cloud and SSH support all of them; USB web supports upload only."
+        ),
     )
 
     args = parser.parse_args()
@@ -130,12 +133,9 @@ Security Note:
 
         run()
     else:
-        # MCP server mode - only now import the full server
+        # Cloud mode (default) - now write-capable via the sync protocol
         if args.write:
-            print(
-                "⚠️  --write flag ignored: write tools require SSH or USB web mode.",
-                file=sys.stderr,
-            )
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         from remarkable_mcp.server import run
 
         run()

--- a/remarkable_mcp/resources.py
+++ b/remarkable_mcp/resources.py
@@ -142,9 +142,6 @@ def _make_raw_resource(client, document, file_type: str):
 
     def raw_resource() -> str:
         try:
-            if not _is_ssh_mode():
-                return "Error: Raw file download only available in SSH mode"
-
             raw_data = download_raw_file(client, document, file_type)
 
             if not raw_data:
@@ -257,7 +254,7 @@ def _register_document(
 
     Registers:
     - Text resource for all documents
-    - Raw resource for PDF/EPUB files (SSH mode only)
+    - Raw resource for PDF/EPUB files (all transports)
     - Image template resource for notebooks (not PDF/EPUB)
 
     Args:
@@ -333,8 +330,8 @@ def _register_document(
         else:
             file_type = "notebook"
 
-    # Register raw resource for PDF/EPUB files (SSH mode only)
-    if _is_ssh_mode() and file_type in ("pdf", "epub"):
+    # Register raw resource for PDF/EPUB files (all transports support this)
+    if file_type in ("pdf", "epub"):
         # Raw resources now return extracted text, use .txt extension
         raw_uri = f"remarkableraw:///{uri_path}.{file_type}.txt"
         raw_counter = 1
@@ -440,9 +437,11 @@ def load_all_documents_sync() -> int:
 
     logger.info(f"Found {len(documents)} documents")
 
-    # Pre-load all file types in a single SSH call (SSH mode optimization)
+    # Pre-load all file types up front. Every transport implements this now:
+    # cloud derives types from the already-fetched blob index (no extra network),
+    # SSH batches a single command, USB reads its cached listing.
     file_types = {}
-    if _is_ssh_mode() and hasattr(client, "get_all_file_types"):
+    if hasattr(client, "get_all_file_types"):
         logger.info("Pre-loading file types for raw resources...")
         file_types = client.get_all_file_types()
         logger.info(f"Loaded {len(file_types)} file types")
@@ -453,7 +452,7 @@ def load_all_documents_sync() -> int:
                 client,
                 doc,
                 items_by_id,
-                file_types if _is_ssh_mode() else None,
+                file_types or None,
                 root=root,
             )
         except Exception as e:

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -268,13 +268,14 @@ from remarkable_mcp import (  # noqa: E402
     tools,  # noqa: F401
 )
 
-# Conditionally register write tools when enabled
+# Conditionally register write tools when enabled.
+# Write works in all three transports: cloud (default), SSH, and USB web.
+# Cloud and SSH support the full set (upload/mkdir/move/rename/delete); the USB
+# web interface only supports upload, so only that tool registers in USB mode
+# (see the per-tool gating in write_tools.register_write_tools).
 from remarkable_mcp import write_tools as _write_tools  # noqa: E402
 
-if _write_tools.write_enabled() and (
-    os.environ.get("REMARKABLE_USE_SSH", "").lower() in ("1", "true", "yes")
-    or os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in ("1", "true", "yes")
-):
+if _write_tools.write_enabled():
     _write_tools.register_write_tools()
 
 

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -160,7 +160,12 @@ class SSHClient:
                     "brew install hudochenkov/sshpass/sshpass (macOS), "
                     "or set up SSH key authentication instead."
                 )
-            raise RuntimeError("SSH client not found. Install openssh-client.")
+            raise RuntimeError(
+                "SSH client ('ssh') not found on PATH. Install OpenSSH: "
+                "Windows (Settings → Optional Features → OpenSSH Client, or it is "
+                "built in on Windows 10+), macOS (preinstalled), "
+                "Linux (apt install openssh-client / equivalent)."
+            )
 
     def _scp_download(self, remote_path: str, timeout: int = 60) -> bytes:
         """Download a file from the tablet via SSH cat (more reliable than SCP)."""
@@ -360,9 +365,11 @@ class SSHClient:
             except Exception:
                 pass
 
-        # Create zip archive
+        # Create zip archive. This archive is an internal transport container that
+        # is extracted in-memory by the caller and never written to disk, so we use
+        # ZIP_STORED (no compression) to avoid pointless compress/decompress CPU cost.
         zip_buffer = io.BytesIO()
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
             for remote_path in file_list:
                 try:
                     content = self._scp_download(remote_path)

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -7,6 +7,7 @@ rmapy is abandoned and uses deprecated endpoints that return 500 errors.
 Based on the protocol used by ddvk/rmapi.
 """
 
+import hashlib
 import json
 import logging
 import math
@@ -14,6 +15,7 @@ import os
 import random
 import threading
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -82,8 +84,16 @@ DEVICE_TOKEN_URL = f"{AUTH_HOST}/token/json/2/device/new"
 USER_TOKEN_URL = f"{AUTH_HOST}/token/json/2/user/new"
 
 SYNC_HOST = "https://internal.cloud.remarkable.com"
-ROOT_URL = f"{SYNC_HOST}/sync/v4/root"
+ROOT_URL = f"{SYNC_HOST}/sync/v4/root"  # GET current root (hash + generation)
+ROOT_PUT_URL = f"{SYNC_HOST}/sync/v3/root"  # PUT to commit a new root (generation-gated)
 FILES_URL = f"{SYNC_HOST}/sync/v3/files"
+
+# Index serialization constants (reMarkable sync15 content-addressed store).
+_SCHEMA_DOC = "3"  # document blob indexes are emitted as schema 3
+_SCHEMA_ROOT = "4"  # root indexes must be emitted as schema 4 for writes
+_TYPE_FILE = "0"  # entry type for a file inside a document index
+# Max attempts to win the generation race when committing a new root.
+_ROOT_COMMIT_ATTEMPTS = 5
 
 
 def _get_retry_attempts() -> int:
@@ -210,6 +220,85 @@ def _http_request_with_retry(method: str, url: str, **kwargs) -> requests.Respon
     raise last_exception  # noqa: TRY302  # exhausted retries, re-raise last connection error
 
 
+def _hash_entries(files: List[Dict[str, Any]]) -> str:
+    """Compute a document/root index hash from its entries.
+
+    Mirrors ddvk/rmapi ``HashEntries``: sort entries by id, then SHA-256 over the
+    concatenation of each entry's raw (hex-decoded) blob hash. Used for document
+    index hashes (the hash a document is stored under in the root index).
+    """
+    hasher = hashlib.sha256()
+    for entry in sorted(files, key=lambda e: e["id"]):
+        hasher.update(bytes.fromhex(entry["hash"]))
+    return hasher.hexdigest()
+
+
+def _serialize_doc_index(files: List[Dict[str, Any]]) -> bytes:
+    """Serialize a document's blob index (schema 3).
+
+    Line 0 is the schema version; each subsequent line is
+    ``hash:0:filename:0:size`` for one file blob.
+    """
+    lines = [_SCHEMA_DOC]
+    for f in sorted(files, key=lambda e: e["id"]):
+        lines.append(f"{f['hash']}:{_TYPE_FILE}:{f['id']}:0:{f['size']}")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _serialize_root_index(entries: List[Dict[str, Any]]) -> bytes:
+    """Serialize the root index (schema 4).
+
+    Current servers reject new schema-3 root uploads, so writes always emit
+    schema 4: line 0 is ``4``; line 1 is ``0:.:<numDocs>:<totalSize>``; each
+    document line is ``hash:0:docId:<numFiles>:<size>``. The resulting root hash
+    is ``sha256`` of this serialized body (not ``HashEntries``).
+    """
+    ordered = sorted(entries, key=lambda e: e["id"])
+    total = sum(int(e["size"]) for e in ordered)
+    lines = [_SCHEMA_ROOT, f"0:.:{len(ordered)}:{total}"]
+    for e in ordered:
+        lines.append(f"{e['hash']}:{_TYPE_FILE}:{e['id']}:{int(e['subfiles'])}:{int(e['size'])}")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+class CloudWriteError(RuntimeError):
+    """Raised when a cloud write cannot be completed."""
+
+
+# CRC32C (Castagnoli) table for the GCS ``x-goog-hash`` upload integrity header.
+# reMarkable's blob store sits behind Google Cloud Storage, which rejects PUTs
+# without a matching ``crc32c`` checksum. stdlib ``zlib.crc32`` is IEEE, not
+# Castagnoli, so we compute CRC32C ourselves (preferring the fast C extension).
+_CRC32C_POLY = 0x82F63B78
+_CRC32C_TABLE = []
+for _i in range(256):
+    _crc = _i
+    for _ in range(8):
+        _crc = (_crc >> 1) ^ (_CRC32C_POLY & -(_crc & 1))
+    _CRC32C_TABLE.append(_crc & 0xFFFFFFFF)
+
+
+def _crc32c_value(data: bytes) -> int:
+    try:
+        import google_crc32c
+
+        return int.from_bytes(google_crc32c.Checksum(data).digest(), "big")
+    except Exception:
+        crc = 0xFFFFFFFF
+        for byte in data:
+            crc = (crc >> 8) ^ _CRC32C_TABLE[(crc ^ byte) & 0xFF]
+        return crc ^ 0xFFFFFFFF
+
+
+def _crc32c_header(data: bytes) -> str:
+    """Return the ``x-goog-hash`` value (``crc32c=<base64>``) for ``data``."""
+    import base64
+    import struct
+
+    digest = struct.pack(">I", _crc32c_value(data))
+    return "crc32c=" + base64.b64encode(digest).decode("ascii")
+
+
 @dataclass
 class Document:
     """Represents a document or folder in the reMarkable cloud."""
@@ -270,6 +359,7 @@ class RemarkableClient:
         self.user_token = user_token
         self._documents: List[Document] = []
         self._documents_by_id: Dict[str, Document] = {}
+        self._file_type_cache: Dict[str, Optional[str]] = {}
 
     def renew_token(self) -> str:
         """Exchange device token for a fresh user token."""
@@ -293,16 +383,26 @@ class RemarkableClient:
         )
 
     def _request(
-        self, url: str, method: str = "GET", headers: Optional[Dict[str, str]] = None
+        self,
+        url: str,
+        method: str = "GET",
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> requests.Response:
-        """Make an authenticated request."""
+        """Make an authenticated request.
+
+        Extra keyword arguments (e.g. ``data`` or ``json``) are forwarded to the
+        underlying HTTP call, so the same auth/renew path serves writes too.
+        """
         if not self.user_token:
             self.renew_token()
 
         request_headers = {"Authorization": f"Bearer {self.user_token}"}
         if headers:
             request_headers.update(headers)
-        response = _http_request_with_retry(method, url, headers=request_headers, timeout=60)
+        response = _http_request_with_retry(
+            method, url, headers=request_headers, timeout=60, **kwargs
+        )
 
         if response.status_code == 401:
             # Token expired, try to renew
@@ -310,7 +410,9 @@ class RemarkableClient:
             request_headers = {"Authorization": f"Bearer {self.user_token}"}
             if headers:
                 request_headers.update(headers)
-            response = _http_request_with_retry(method, url, headers=request_headers, timeout=60)
+            response = _http_request_with_retry(
+                method, url, headers=request_headers, timeout=60, **kwargs
+            )
 
         return response
 
@@ -551,6 +653,438 @@ class RemarkableClient:
 
         zip_buffer.seek(0)
         return zip_buffer.read()
+
+    def _ensure_files(self, doc: Document) -> List[Dict[str, Any]]:
+        """Return the document's blob index entries, fetching them if needed.
+
+        Documents loaded via ``get_meta_items`` already carry ``files``; this is
+        a defensive fallback for documents constructed without them.
+        """
+        if doc.files:
+            return doc.files
+        try:
+            blob_content = self._get_file(doc.hash, f"{doc.id}.docSchema")
+            doc.files = self._parse_index(blob_content)
+        except Exception as e:
+            logger.debug(f"Could not load blob index for {doc.id}: {e}")
+            doc.files = []
+        return doc.files
+
+    def get_file_type(self, doc: Document) -> Optional[str]:
+        """Return the document's source file type ('pdf', 'epub', or 'notebook').
+
+        The cloud store keeps every blob of a document, including the original
+        ``{id}.pdf`` / ``{id}.epub`` when present, so the type can be derived
+        from the (already fetched) blob index without extra network calls. As a
+        fallback the ``.content`` blob's ``fileType`` field is consulted.
+        """
+        if doc.id in self._file_type_cache:
+            return self._file_type_cache[doc.id]
+
+        file_type: Optional[str] = None
+        content_hash: Optional[str] = None
+        for entry in self._ensure_files(doc):
+            entry_id = entry.get("id", "")
+            if entry_id.endswith(".pdf"):
+                file_type = "pdf"
+                break
+            if entry_id.endswith(".epub"):
+                file_type = "epub"
+                break
+            if entry_id.endswith(".content"):
+                content_hash = entry.get("hash")
+
+        if file_type is None and content_hash:
+            try:
+                content = self._get_file(content_hash, f"{doc.id}.content")
+                data = json.loads(content.decode("utf-8"))
+                ft = data.get("fileType")
+                if ft:
+                    file_type = ft
+            except Exception as e:
+                logger.debug(f"Could not read .content fileType for {doc.id}: {e}")
+
+        if file_type is None:
+            file_type = "notebook"
+
+        self._file_type_cache[doc.id] = file_type
+        return file_type
+
+    def download_raw_file(self, doc: Document, extension: str) -> Optional[bytes]:
+        """Download the original source file (PDF or EPUB) for a document.
+
+        Returns the raw bytes, or ``None`` if the document has no such source
+        blob. The blob is content-addressed, so it is served from the local
+        cache on warm reads.
+        """
+        ext = extension.lower().lstrip(".")
+        suffix = f".{ext}"
+        for entry in self._ensure_files(doc):
+            if entry.get("id", "").endswith(suffix):
+                try:
+                    return self._get_file(entry["hash"], entry["id"])
+                except Exception as e:
+                    logger.debug(f"Failed to download {entry['id']} for {doc.id}: {e}")
+                    return None
+        return None
+
+    def get_all_file_types(self) -> Dict[str, Optional[str]]:
+        """Return a ``{doc_id: file_type}`` map for every loaded document.
+
+        Types of PDF/EPUB documents are derived from each document's blob index
+        with no extra network calls; the remaining documents (notebooks) consult
+        their ``.content`` blob, so those reads are issued in parallel.
+        """
+        if not self._documents_by_id:
+            self.get_meta_items()
+
+        docs = list(self._documents_by_id.values())
+        workers = _get_sync_workers()
+        if workers > 1 and len(docs) > 1:
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                list(executor.map(self.get_file_type, docs))
+        return {doc.id: self.get_file_type(doc) for doc in docs}
+
+    def check_connection(self) -> bool:
+        """Return True if the cloud API is reachable and the token is valid."""
+        try:
+            response = self._request(ROOT_URL)
+            return response.ok
+        except Exception as e:
+            logger.debug(f"Cloud connection check failed: {e}")
+            return False
+
+    # ------------------------------------------------------------------
+    # Cloud write support
+    #
+    # The store is a content-addressed Merkle tree:
+    #   * file blob  -> stored under sha256(content)
+    #   * doc index  -> stored under HashEntries(files) (schema 3 body)
+    #   * root index -> stored under sha256(body) (schema 4 body)
+    # A write uploads any new blobs, re-serializes the root index, uploads it,
+    # then commits it with the current generation (optimistic concurrency).
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _now_ms() -> str:
+        return str(int(time.time() * 1000))
+
+    def _put_blob(
+        self,
+        content: bytes,
+        blob_hash: str,
+        filename: str,
+        content_type: str = "application/octet-stream",
+    ) -> None:
+        """Upload a blob's bytes, stored under ``blob_hash``.
+
+        The store sits behind Google Cloud Storage, which requires a matching
+        ``x-goog-hash`` (CRC32C) header on every upload.
+        """
+        headers = {
+            "rm-filename": filename,
+            "x-goog-hash": _crc32c_header(content),
+            "content-type": content_type,
+        }
+        response = self._request(
+            f"{FILES_URL}/{blob_hash}", method="PUT", headers=headers, data=content
+        )
+        response.raise_for_status()
+        # The bytes are immutable under this hash, so prime the read cache.
+        self._cache_write(blob_hash, content)
+
+    def _upload_file_blob(self, content: bytes, filename: str) -> Dict[str, Any]:
+        """Upload a file blob (hashed by content) and return its index entry."""
+        blob_hash = hashlib.sha256(content).hexdigest()
+        self._put_blob(content, blob_hash, filename)
+        return {
+            "hash": blob_hash,
+            "type": _TYPE_FILE,
+            "id": filename,
+            "subfiles": 0,
+            "size": len(content),
+        }
+
+    def _upload_doc_index(self, doc_id: str, files: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Upload a document blob index and return its root entry."""
+        body = _serialize_doc_index(files)
+        doc_hash = _hash_entries(files)
+        self._put_blob(body, doc_hash, f"{doc_id}.docSchema")
+        return {
+            "hash": doc_hash,
+            "type": _TYPE_FILE,
+            "id": doc_id,
+            "subfiles": len(files),
+            "size": sum(int(f["size"]) for f in files),
+        }
+
+    def get_root(self) -> tuple:
+        """Return the current ``(root_hash, generation)`` from the cloud."""
+        response = self._request(ROOT_URL)
+        response.raise_for_status()
+        data = response.json()
+        return data["hash"], data.get("generation", 0)
+
+    def _read_root_entries(self) -> tuple:
+        """Return ``(entries, generation)`` for the current root index."""
+        root_hash, generation = self.get_root()
+        root_index = self._get_file(root_hash, "root.docSchema")
+        return self._parse_index(root_index), generation
+
+    def _commit_root(self, root_hash: str, generation: int, broadcast: bool = True) -> int:
+        """Commit a new root hash, gated on ``generation``.
+
+        Returns the new generation. Raises ``CloudWriteError`` with ``conflict``
+        set when the generation no longer matches (someone else wrote first).
+        """
+        body = {"broadcast": broadcast, "hash": root_hash, "generation": generation}
+        response = self._request(
+            ROOT_PUT_URL,
+            method="PUT",
+            headers={"rm-filename": "roothash"},
+            json=body,
+        )
+        # 409/412/428 mean another client committed first (generation race) and
+        # the write should be retried against the fresh root.
+        if response.status_code in (409, 412, 428):
+            err = CloudWriteError(
+                f"Root generation conflict (HTTP {response.status_code}); will retry."
+            )
+            err.conflict = True
+            raise err
+        if not response.ok:
+            raise CloudWriteError(
+                f"Root commit failed (HTTP {response.status_code}): {response.text[:200]}"
+            )
+        data = response.json()
+        if data.get("hash") != root_hash:
+            raise CloudWriteError("Root commit returned a mismatched hash.")
+        return data.get("generation", generation)
+
+    def _sync_root(self, mutate) -> None:
+        """Apply ``mutate(entries) -> new_entries`` and commit a new root.
+
+        ``mutate`` may upload blobs as a side effect; it is re-invoked on a
+        generation conflict after re-reading the remote root, so it must be
+        idempotent with respect to blob uploads (content-addressed uploads are).
+        On success all in-memory document caches are invalidated.
+        """
+        last_error: Optional[Exception] = None
+        for attempt in range(_ROOT_COMMIT_ATTEMPTS):
+            entries, generation = self._read_root_entries()
+            new_entries = mutate(list(entries))
+            root_body = _serialize_root_index(new_entries)
+            root_hash = hashlib.sha256(root_body).hexdigest()
+            self._put_blob(root_body, root_hash, "root.docSchema", "text/plain; charset=UTF-8")
+            try:
+                self._commit_root(root_hash, generation)
+                self._invalidate_caches()
+                return
+            except CloudWriteError as e:
+                if getattr(e, "conflict", False) and attempt < _ROOT_COMMIT_ATTEMPTS - 1:
+                    last_error = e
+                    time.sleep(_compute_sleep(_get_retry_delay(), attempt))
+                    continue
+                raise
+        raise CloudWriteError(
+            f"Could not commit root after {_ROOT_COMMIT_ATTEMPTS} attempts: {last_error}"
+        )
+
+    def _invalidate_caches(self) -> None:
+        """Drop in-memory document/file-type caches after a mutation."""
+        self._documents = []
+        self._documents_by_id = {}
+        self._file_type_cache = {}
+
+    def _mutate_doc_metadata(self, entry: Dict[str, Any], apply: "Any") -> Dict[str, Any]:
+        """Rewrite one document's ``.metadata`` blob and return its new root entry.
+
+        ``apply(metadata: dict)`` mutates the metadata in place. The version is
+        bumped and ``lastModified`` refreshed so the device picks up the change.
+        """
+        doc_id = entry["id"]
+        files = self._parse_index(self._get_file(entry["hash"], f"{doc_id}.docSchema"))
+        meta_entry = next((f for f in files if f["id"].endswith(".metadata")), None)
+        if meta_entry is None:
+            raise CloudWriteError(f"Document {doc_id} has no metadata blob.")
+
+        metadata = json.loads(self._get_file(meta_entry["hash"], meta_entry["id"]).decode("utf-8"))
+        apply(metadata)
+        try:
+            metadata["version"] = int(metadata.get("version", 1)) + 1
+        except (TypeError, ValueError):
+            metadata["version"] = 1
+        metadata["lastModified"] = self._now_ms()
+        metadata["metadatamodified"] = True
+
+        new_meta = json.dumps(metadata, sort_keys=True).encode("utf-8")
+        new_entry = self._upload_file_blob(new_meta, meta_entry["id"])
+        files = [new_entry if f["id"] == meta_entry["id"] else f for f in files]
+        return self._upload_doc_index(doc_id, files)
+
+    def _replace_root_entry(self, entries, new_entry):
+        """Return ``entries`` with the entry matching ``new_entry['id']`` replaced."""
+        return [new_entry if e["id"] == new_entry["id"] else e for e in entries]
+
+    def _require_entry(self, entries, doc_id):
+        entry = next((e for e in entries if e["id"] == doc_id), None)
+        if entry is None:
+            raise CloudWriteError(f"Document {doc_id} not found in cloud root.")
+        return entry
+
+    def create_folder(self, name: str, parent_id: str = "") -> Document:
+        """Create a folder (CollectionType) in the cloud and return it."""
+        doc_id = str(uuid.uuid4())
+        now = self._now_ms()
+        metadata = {
+            "createdTime": now,
+            "lastModified": now,
+            "new": False,
+            "parent": parent_id or "",
+            "pinned": False,
+            "source": "",
+            "type": "CollectionType",
+            "visibleName": name,
+        }
+        meta_bytes = json.dumps(metadata, sort_keys=True).encode("utf-8")
+        files = [self._upload_file_blob(meta_bytes, f"{doc_id}.metadata")]
+        new_entry = self._upload_doc_index(doc_id, files)
+        self._sync_root(lambda entries: entries + [new_entry])
+        return Document(
+            id=doc_id,
+            hash=new_entry["hash"],
+            name=name,
+            doc_type="CollectionType",
+            parent=parent_id or "",
+        )
+
+    def rename(self, doc_id: str, new_name: str) -> None:
+        """Rename a document or folder in the cloud."""
+
+        def apply(meta):
+            meta["visibleName"] = new_name
+
+        def mutate(entries):
+            entry = self._require_entry(entries, doc_id)
+            return self._replace_root_entry(entries, self._mutate_doc_metadata(entry, apply))
+
+        self._sync_root(mutate)
+
+    def move(self, doc_id: str, new_parent_id: str) -> None:
+        """Move a document or folder under a new parent ("" = root)."""
+
+        def apply(meta):
+            meta["parent"] = new_parent_id or ""
+
+        def mutate(entries):
+            entry = self._require_entry(entries, doc_id)
+            return self._replace_root_entry(entries, self._mutate_doc_metadata(entry, apply))
+
+        self._sync_root(mutate)
+
+    def delete(self, doc_id: str) -> None:
+        """Move a document or folder to the trash (recoverable via ``restore``)."""
+        self.move(doc_id, "trash")
+
+    def restore(self, doc_id: str, parent_id: str = "") -> None:
+        """Restore a trashed document or folder back to ``parent_id`` ("" = root)."""
+        self.move(doc_id, parent_id or "")
+
+    def upload_document(
+        self,
+        content: bytes,
+        name: str,
+        file_type: str,
+        parent_id: str = "",
+    ) -> Document:
+        """Upload a PDF or EPUB document to the cloud and return it.
+
+        Builds the four blobs a reMarkable document needs (``.content``,
+        ``.metadata``, ``.pagedata`` and the source ``.pdf``/``.epub``), then
+        adds the document to the root index.
+        """
+        ext = file_type.lower().lstrip(".")
+        if ext not in ("pdf", "epub"):
+            raise CloudWriteError(f"Unsupported upload type '{ext}'; use pdf or epub.")
+
+        doc_id = str(uuid.uuid4())
+        now = self._now_ms()
+
+        page_count, page_uuids = self._page_layout(content, ext)
+        content_json = {
+            "coverPageNumber": -1,
+            "documentMetadata": {},
+            "dummyDocument": False,
+            "extraMetadata": {},
+            "fileType": ext,
+            "fontName": "",
+            "formatVersion": 1,
+            "lineHeight": -1,
+            "margins": 100,
+            "orientation": "portrait",
+            "pageCount": page_count,
+            "pageTags": [],
+            "pages": page_uuids,
+            "tags": [],
+            "textScale": 1,
+        }
+        metadata = {
+            "createdTime": now,
+            "deleted": False,
+            "lastModified": now,
+            "lastOpened": now,
+            "lastOpenedPage": 0,
+            "metadatamodified": False,
+            "modified": False,
+            "new": False,
+            "parent": parent_id or "",
+            "pinned": False,
+            "source": "",
+            "synced": False,
+            "type": "DocumentType",
+            "version": 1,
+            "visibleName": name,
+        }
+        pagedata = ("Blank\n" * page_count) if page_count else "\n"
+
+        files = [
+            self._upload_file_blob(
+                json.dumps(content_json, sort_keys=True).encode("utf-8"), f"{doc_id}.content"
+            ),
+            self._upload_file_blob(
+                json.dumps(metadata, sort_keys=True).encode("utf-8"), f"{doc_id}.metadata"
+            ),
+            self._upload_file_blob(pagedata.encode("utf-8"), f"{doc_id}.pagedata"),
+            self._upload_file_blob(content, f"{doc_id}.{ext}"),
+        ]
+        new_entry = self._upload_doc_index(doc_id, files)
+        self._sync_root(lambda entries: entries + [new_entry])
+        return Document(
+            id=doc_id,
+            hash=new_entry["hash"],
+            name=name,
+            doc_type="DocumentType",
+            parent=parent_id or "",
+        )
+
+    @staticmethod
+    def _page_layout(content: bytes, ext: str) -> tuple:
+        """Return ``(page_count, page_uuids)`` for a source file.
+
+        PDFs are measured with PyMuPDF so the device shows the right page count;
+        EPUBs reflow on-device, so they start with no fixed pages.
+        """
+        if ext != "pdf":
+            return 0, []
+        try:
+            import fitz
+
+            with fitz.open(stream=content, filetype="pdf") as pdf:
+                count = pdf.page_count
+            return count, [str(uuid.uuid4()) for _ in range(count)]
+        except Exception as e:  # pragma: no cover - defensive; upload still proceeds
+            logger.debug(f"Could not count PDF pages: {e}")
+            return 0, []
 
 
 def register_device(one_time_code: str) -> Dict[str, str]:

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1,8 +1,9 @@
 """
 MCP Tools for reMarkable tablet access.
 
-All tools are read-only and idempotent - they only retrieve data from the
-reMarkable Cloud and do not modify any documents.
+All tools in this module are read-only and idempotent - they only retrieve
+data from your reMarkable (via whichever transport is active: cloud, SSH, or
+USB web) and do not modify any documents.
 """
 
 import base64
@@ -292,7 +293,9 @@ async def remarkable_read(
 
     Content types:
     - "text" (default): Full extracted text (PDF/EPUB content + annotations)
-    - "raw": Original PDF/EPUB text only (no annotations). SSH mode only.
+    - "raw": Original PDF/EPUB text only (no annotations). Works in every
+      transport, as long as the source file is present (very large PDFs/EPUBs
+      may not be synced to the cloud).
     - "annotations": Only annotations, highlights, and handwritten notes
 
     Use pagination to read large documents without overwhelming context:
@@ -395,14 +398,13 @@ async def remarkable_read(
                 finally:
                     tmp_path.unlink(missing_ok=True)
             elif content_type == "raw":
-                # Raw requested but not available (likely cloud mode)
+                # The document has no source PDF/EPUB blob (e.g. a pure notebook).
                 return make_error(
                     error_type="raw_not_available",
-                    message="Raw file download only available in SSH mode",
+                    message=f"No raw {file_type.upper()} source file found for this document",
                     suggestion=(
                         "Use content_type='text' for extracted content, "
-                        "or switch to SSH mode for raw file access. "
-                        "See: https://remarkable.guide/guide/access/ssh.html"
+                        "or content_type='annotations' for handwritten notes."
                     ),
                 )
 
@@ -779,7 +781,11 @@ async def remarkable_read(
             hint_parts.append(f"Page {page}/{total_pages} (complete).")
 
         if content_type == "text" and not raw_available and file_type in ("pdf", "epub"):
-            hint_parts.append("Raw content requires SSH mode.")
+            hint_parts.append(
+                "No source PDF/EPUB blob was found for this document, so only "
+                "annotations were extracted. Very large files may not be synced "
+                "to the cloud; try SSH/USB mode with the device connected."
+            )
 
         return make_response(result, " ".join(hint_parts))
 
@@ -1278,10 +1284,20 @@ async def remarkable_search(
 @mcp.tool(annotations=STATUS_ANNOTATIONS)
 async def remarkable_status() -> str:
     """
-    <usecase>Check connection status and authentication with reMarkable Cloud.</usecase>
+    <usecase>Check connection status, active transport, and write capabilities.</usecase>
     <instructions>
-    Returns authentication status and diagnostic information.
-    Use this to verify your connection or troubleshoot issues.
+    Returns authentication status, the active transport (cloud, ssh, or usb-web),
+    the document count, and a capability matrix describing what each transport can
+    do. Use this to verify your connection, choose a transport, or troubleshoot.
+
+    Capability notes:
+    - Cloud (default): full read/render/upload/mkdir/move/rename/delete — no device
+      needed, works from anywhere your token is valid.
+    - SSH: full capabilities over a local/USB connection to the tablet.
+    - USB web: read, render, and upload (to root) only — the tablet's USB web
+      interface firmware exposes no folder/move/rename/delete endpoints. For full
+      write parity over a USB cable, use SSH mode pointed at the USB IP.
+    Write tools (upload/mkdir/move/rename/delete) require the --write flag.
     </instructions>
     <examples>
     - remarkable_status()
@@ -1290,6 +1306,7 @@ async def remarkable_status() -> str:
     import os
 
     from remarkable_mcp.api import REMARKABLE_USE_SSH, REMARKABLE_USE_USB_WEB
+    from remarkable_mcp.write_tools import write_enabled
 
     # Determine transport mode
     if REMARKABLE_USE_USB_WEB:
@@ -1314,6 +1331,46 @@ async def remarkable_status() -> str:
         transport = "cloud"
         connection_info = "environment variable" if REMARKABLE_TOKEN else "file (~/.rmapi)"
 
+    # What each transport is capable of (independent of whether --write is on).
+    # read/render are always available; the booleans below are the write surface.
+    capability_matrix = {
+        "cloud": {
+            "read": True,
+            "render": True,
+            "upload": True,
+            "mkdir": True,
+            "move": True,
+            "rename": True,
+            "delete": True,
+        },
+        "ssh": {
+            "read": True,
+            "render": True,
+            "upload": True,
+            "mkdir": True,
+            "move": True,
+            "rename": True,
+            "delete": True,
+        },
+        "usb-web": {
+            "read": True,
+            "render": True,
+            "upload": True,
+            "mkdir": False,
+            "move": False,
+            "rename": False,
+            "delete": False,
+        },
+    }
+    writes_on = write_enabled()
+    # Effective capabilities for the active transport: write ops only count when
+    # the --write flag is enabled.
+    transport_caps = capability_matrix[transport]
+    effective_caps = {
+        cap: (supported if cap in ("read", "render") else supported and writes_on)
+        for cap, supported in transport_caps.items()
+    }
+
     try:
         client = get_rmapi()
         collection = await run_blocking(client.get_meta_items)
@@ -1336,6 +1393,9 @@ async def remarkable_status() -> str:
             "connection": connection_info,
             "status": "connected",
             "document_count": doc_count,
+            "write_enabled": writes_on,
+            "capabilities": effective_caps,
+            "capabilities_by_transport": capability_matrix,
         }
 
         # Add root path info if configured
@@ -1345,6 +1405,18 @@ async def remarkable_status() -> str:
         hint_parts = [f"Connected successfully via {transport}. Found {doc_count} documents."]
         if root != "/":
             hint_parts.append(f"Filtered to root: {root}")
+        if writes_on:
+            if transport == "usb-web":
+                hint_parts.append(
+                    "Write is enabled, but the USB web interface only supports upload "
+                    "(to root). For mkdir/move/rename/delete over USB, use SSH mode."
+                )
+            else:
+                hint_parts.append(
+                    "Write is enabled: upload, mkdir, move, rename, and delete are available."
+                )
+        else:
+            hint_parts.append("Read-only. Add the --write flag to enable write tools.")
         hint_parts.append(
             "Use remarkable_browse() to see your files, "
             "or remarkable_recent() for recent documents."
@@ -1360,26 +1432,34 @@ async def remarkable_status() -> str:
             "transport": transport,
             "connection": connection_info,
             "error": error_msg,
+            "write_enabled": writes_on,
+            "capabilities_by_transport": capability_matrix,
         }
 
         if REMARKABLE_USE_SSH:
             hint = (
                 "SSH connection failed. Make sure:\n"
-                "1) Developer mode is enabled on your tablet\n"
-                "2) Your reMarkable is connected via USB\n"
+                "1) Developer mode / SSH is enabled on your tablet\n"
+                "2) Your reMarkable is connected (USB or same network)\n"
                 "3) You can run: ssh root@10.11.99.1\n\n"
                 "See: https://remarkable.guide/guide/access/ssh.html\n\n"
-                "Or use cloud mode instead (remove --ssh flag)."
+                "Or use cloud mode instead (remove --ssh flag) — no device needed."
+            )
+        elif REMARKABLE_USE_USB_WEB:
+            hint = (
+                "USB web interface not reachable. Make sure:\n"
+                "1) Your reMarkable is connected via USB\n"
+                "2) USB web interface is enabled (Settings → Storage)\n"
+                "3) The device is on and unlocked"
             )
         else:
             hint = (
-                "To authenticate: "
-                "1) Go to https://my.remarkable.com/device/browser/connect "
-                "2) Get a one-time code "
-                "3) Run: uv run python server.py --register YOUR_CODE "
-                "4) Add REMARKABLE_TOKEN to your MCP config.\n\n"
-                "Or use SSH mode (faster, recommended): uvx remarkable-mcp --ssh\n"
-                "SSH setup guide: https://remarkable.guide/guide/access/ssh.html"
+                "Cloud authentication failed. To connect:\n"
+                "1) Go to https://my.remarkable.com/device/browser/connect\n"
+                "2) Get a one-time code\n"
+                "3) Run: uvx remarkable-mcp --register YOUR_CODE\n"
+                "Cloud mode works from anywhere — no device required. SSH/USB modes "
+                "are also available for local access (add --ssh or --usb)."
             )
 
         return make_response(result, hint)
@@ -1632,12 +1712,12 @@ async def remarkable_image(
                 # Portable fallback: the local stroke renderer can fail to
                 # produce an image for empty pages, newer .rm block formats, or
                 # when the client machine lacks a working cairo/libcairo for
-                # cairosvg. In USB and SSH modes the tablet exports a
-                # natively-rendered PDF that covers all of those cases, so
-                # rasterize the requested page from it with PyMuPDF (which needs
-                # no system cairo). Cloud mode has no such export, so
-                # download_raw_file returns None there and this safely no-ops.
-                # Credit: ljdutel (#95).
+                # cairosvg. In that case we rasterize the requested page from the
+                # document's source PDF with PyMuPDF (which needs no system
+                # cairo). USB/SSH expose the tablet's natively-rendered (merged)
+                # PDF; cloud exposes the original source PDF — either covers the
+                # failure cases above. Notebooks have no PDF, so download_raw_file
+                # returns None and this safely no-ops. Credit: ljdutel (#95).
                 rendered_via_pdf = False
                 if png_data is None:
                     pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
@@ -1654,9 +1734,8 @@ async def remarkable_image(
                         suggestion=(
                             "The page may be empty, or local rendering "
                             "dependencies (cairo/libcairo for cairosvg) may be "
-                            "missing. In USB/SSH mode the tablet's native PDF "
-                            "export is used automatically as a fallback—make "
-                            "sure the tablet is connected. You can also try "
+                            "missing. For PDF-backed documents the source PDF is "
+                            "used automatically as a fallback. You can also try "
                             "remarkable_read() to extract text instead."
                         ),
                     )

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1,16 +1,19 @@
 """
-Write tools for reMarkable tablet via SSH or USB web interface.
+Write tools for reMarkable tablet via cloud, SSH, or USB web interface.
 
 These tools are opt-in — disabled by default. Enable via:
-- CLI flag: remarkable-mcp --ssh --write  (or --usb --write)
+- CLI flag: remarkable-mcp --write  (works in the default cloud mode)
+            remarkable-mcp --ssh --write  (or --usb --write)
 - Environment variable: REMARKABLE_ENABLE_WRITE=1
 
-Available in SSH mode and USB web mode. Cloud mode returns a clear error.
-- SSH mode: full write support (upload, mkdir, move, rename, delete)
+Write support by transport:
+- Cloud mode: upload, mkdir, move, rename, delete (-> trash)
+- SSH mode:   upload, mkdir, move, rename, delete
 - USB web mode: upload only (via POST /upload endpoint)
 
-Inspired by PR #70 from @McSchnizzle. Implemented purely via SSH filesystem
-operations and USB web HTTP endpoints — no external Go binary required.
+Inspired by PR #70 from @McSchnizzle. SSH operations use the tablet filesystem,
+USB uses the web upload endpoint, and cloud uses the sync v3/v4 blob protocol —
+no external Go binary required.
 """
 
 import asyncio
@@ -21,13 +24,16 @@ import time
 import uuid
 from typing import Optional
 
+from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
+from pydantic import BaseModel, Field
 
 from remarkable_mcp.api import (
     get_item_path,
     get_items_by_id,
     get_rmapi,
 )
+from remarkable_mcp.capabilities import client_supports_elicitation
 from remarkable_mcp.responses import make_error, make_response
 from remarkable_mcp.server import mcp
 from remarkable_mcp.ssh import XOCHITL_PATH, SSHClient
@@ -53,49 +59,19 @@ def write_enabled() -> bool:
 
 
 def _require_write_transport() -> Optional[str]:
-    """Return an error string if not in a write-capable mode, or None if OK."""
-    ssh_enabled = os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-    usb_web_enabled = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-    if not ssh_enabled and not usb_web_enabled:
-        return make_error(
-            error_type="write_transport_required",
-            message="Write operations require SSH or USB web mode",
-            suggestion=(
-                "Write tools work with SSH or USB web access to your tablet. "
-                "Run with: remarkable-mcp --ssh --write  (or --usb --write)\n"
-                "See: https://github.com/SamMorrowDrums/remarkable-mcp/blob/main/docs/ssh-setup.md"
-            ),
-        )
-    return None
+    """Return an error string if writes are disabled, else None.
 
-
-def _require_ssh_mode() -> Optional[str]:
-    """Return an error string if not in SSH mode, or None if OK.
-
-    Used for operations that only work via SSH (mkdir, move, rename, delete).
+    Upload works in all three transports (cloud, SSH, USB web). Write tools are
+    only registered when REMARKABLE_ENABLE_WRITE is set, so this is mostly a
+    defensive check that returns a clear error if writes are somehow disabled.
     """
-    ssh_enabled = os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-    if not ssh_enabled:
+    if not write_enabled():
         return make_error(
-            error_type="ssh_required",
-            message="This operation requires SSH mode",
+            error_type="write_disabled",
+            message="Write operations are disabled",
             suggestion=(
-                "mkdir, move, rename, and delete only work with SSH access. "
-                "Upload works with both SSH and USB web mode.\n"
-                "Run with: remarkable-mcp --ssh --write\n"
-                "See: https://github.com/SamMorrowDrums/remarkable-mcp/blob/main/docs/ssh-setup.md"
+                "Enable write tools with the --write flag or REMARKABLE_ENABLE_WRITE=1.\n"
+                "Run with: remarkable-mcp --write  (cloud)  or  --ssh --write / --usb --write"
             ),
         )
     return None
@@ -116,6 +92,30 @@ def _is_usb_web_mode() -> bool:
         "1",
         "true",
         "yes",
+    )
+
+
+def _is_cloud_mode() -> bool:
+    """Check if cloud transport is active (the default when SSH/USB are off)."""
+    return not _is_ssh_mode() and not _is_usb_web_mode()
+
+
+def _require_managed_write_mode() -> Optional[str]:
+    """Return an error string unless in a mode that supports folder operations.
+
+    mkdir, move, rename and delete work in cloud and SSH modes. USB web
+    mode only supports uploads, so it is rejected here with guidance.
+    """
+    if _is_cloud_mode() or _is_ssh_mode():
+        return None
+    return make_error(
+        error_type="unsupported_in_usb_web",
+        message="This operation isn't available in USB web mode",
+        suggestion=(
+            "mkdir, move, rename and delete work in cloud mode (the "
+            "default) and SSH mode. Upload works in all three modes.\n"
+            "Run with: remarkable-mcp --write  (cloud)  or  --ssh --write"
+        ),
     )
 
 
@@ -275,6 +275,197 @@ def _resolve_document(
     return None
 
 
+def _invalidate_client_cache(client) -> None:
+    """Drop the in-memory document cache so the next read reflects the write."""
+    client._documents = []
+    client._documents_by_id = {}
+
+
+def _cloud_mkdir(folder_name: str, parent: str) -> str:
+    """Create a folder in the reMarkable cloud."""
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    parent_id = _resolve_parent_id(parent, items_by_id, collection)
+    if parent_id is None:
+        return make_error(
+            error_type="folder_not_found",
+            message=f"Parent folder not found: '{parent}'",
+            suggestion="Use remarkable_browse('/') to see available folders.",
+        )
+    doc = client.create_folder(folder_name, parent_id)
+    _invalidate_client_cache(client)
+    return make_response(
+        {
+            "created": True,
+            "folder_name": folder_name,
+            "uuid": doc.id,
+            "parent": parent,
+            "transport": "cloud",
+        },
+        "Folder created in the reMarkable cloud. Use remarkable_browse() to verify.",
+    )
+
+
+def _cloud_move(document: str, dest_folder: str) -> str:
+    """Move a document or folder to another folder in the cloud."""
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        from remarkable_mcp.extract import find_similar_documents
+
+        similar = find_similar_documents(document, collection)
+        return make_error(
+            error_type="document_not_found",
+            message=f"Document not found: '{document}'",
+            suggestion="Use remarkable_browse() to find the correct name.",
+            did_you_mean=similar if similar else None,
+        )
+
+    dest_id = _resolve_parent_id(dest_folder, items_by_id, collection)
+    if dest_id is None:
+        return make_error(
+            error_type="folder_not_found",
+            message=f"Destination folder not found: '{dest_folder}'",
+            suggestion="Use remarkable_browse('/') to see available folders.",
+        )
+
+    # Prevent moving a folder into itself or one of its descendants
+    if target.is_folder:
+        if dest_id == target.ID:
+            return make_error(
+                error_type="invalid_move",
+                message="Cannot move a folder into itself",
+                suggestion="Choose a different destination folder.",
+            )
+        check_id = dest_id
+        while check_id and check_id in items_by_id:
+            if check_id == target.ID:
+                return make_error(
+                    error_type="invalid_move",
+                    message="Cannot move a folder into one of its subfolders",
+                    suggestion="Choose a destination that is not inside the folder being moved.",
+                )
+            check_id = getattr(items_by_id[check_id], "Parent", "")
+
+    old_path = get_item_path(target, items_by_id)
+    client.move(target.ID, dest_id)
+    _invalidate_client_cache(client)
+    return make_response(
+        {
+            "moved": True,
+            "name": target.VissibleName,
+            "from": old_path,
+            "to": dest_folder,
+            "transport": "cloud",
+        },
+        "Document moved in the reMarkable cloud. Use remarkable_browse() to verify.",
+    )
+
+
+def _cloud_rename(document: str, new_name: str) -> str:
+    """Rename a document or folder in the cloud."""
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        from remarkable_mcp.extract import find_similar_documents
+
+        similar = find_similar_documents(document, collection)
+        return make_error(
+            error_type="document_not_found",
+            message=f"Document not found: '{document}'",
+            suggestion="Use remarkable_browse() to find the correct name.",
+            did_you_mean=similar if similar else None,
+        )
+
+    old_name = target.VissibleName
+    client.rename(target.ID, new_name)
+    _invalidate_client_cache(client)
+    return make_response(
+        {
+            "renamed": True,
+            "old_name": old_name,
+            "new_name": new_name,
+            "transport": "cloud",
+        },
+        "Document renamed in the reMarkable cloud. Use remarkable_browse() to verify.",
+    )
+
+
+def _cloud_delete(document: str) -> str:
+    """Move a document or folder to the cloud trash (recoverable on-device)."""
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        from remarkable_mcp.extract import find_similar_documents
+
+        similar = find_similar_documents(document, collection)
+        return make_error(
+            error_type="document_not_found",
+            message=f"Document not found: '{document}'",
+            suggestion="Use remarkable_browse() to find the correct name.",
+            did_you_mean=similar if similar else None,
+        )
+
+    doc_path = get_item_path(target, items_by_id)
+    client.delete(target.ID)
+    _invalidate_client_cache(client)
+    return make_response(
+        {
+            "deleted": True,
+            "name": target.VissibleName,
+            "path": doc_path,
+            "type": "folder" if target.is_folder else "document",
+            "transport": "cloud",
+        },
+        "Moved to the trash on your reMarkable (recoverable from the device's Trash).",
+    )
+
+
+class _DeleteConfirmation(BaseModel):
+    """Schema for confirming a destructive delete via elicitation."""
+
+    confirm: bool = Field(
+        default=False,
+        description="Set to true to permanently move this item to the trash.",
+    )
+
+
+async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str]:
+    """Ask the user to confirm a delete when the client supports elicitation.
+
+    Returns None to proceed, or a response string (cancellation) to abort.
+    Skips the prompt when elicitation isn't supported or REMARKABLE_SKIP_CONFIRM=1.
+    """
+    if os.environ.get("REMARKABLE_SKIP_CONFIRM", "").lower() in ("1", "true", "yes"):
+        return None
+    if ctx is None or not client_supports_elicitation(ctx):
+        return None
+    try:
+        result = await ctx.elicit(
+            message=f"Delete '{document}' from your reMarkable? This moves it to the trash.",
+            schema=_DeleteConfirmation,
+        )
+    except Exception as e:  # elicitation unsupported at runtime — proceed
+        logger.debug(f"Elicitation failed, proceeding without confirmation: {e}")
+        return None
+    if result.action != "accept" or not getattr(result.data, "confirm", False):
+        return make_response(
+            {"deleted": False, "cancelled": True, "document": document},
+            "Delete cancelled — nothing was changed.",
+        )
+    return None
+
+
 def register_write_tools():
     """Register all write tools with the MCP server."""
 
@@ -288,20 +479,20 @@ def register_write_tools():
         <usecase>Upload a PDF or EPUB file to the reMarkable tablet.</usecase>
         <instructions>
         Uploads a local file to the tablet. Only PDF and EPUB formats
-        are supported.
-
-        Works in both SSH and USB web mode:
-        - SSH: file is transferred via SSH, metadata is created, xochitl restarts
-        - USB web: file is uploaded via POST /upload HTTP endpoint
+        are supported. Works in all three transports:
+        - Cloud: uploaded via the sync protocol; supports parent_folder + document_name
+        - SSH: transferred over SSH, metadata created; supports parent_folder + document_name
+        - USB web: uploaded via POST /upload; lands at the root (the firmware's
+          upload endpoint has no folder or rename field)
 
         Requires --write flag.
         </instructions>
         <parameters>
         - file_path: Absolute path to the local PDF or EPUB file
         - parent_folder: Destination folder path on tablet (default: root "/").
-          Note: parent_folder is only supported in SSH mode.
+          Honored in cloud and SSH modes; ignored by the USB web interface.
         - document_name: Display name on tablet (default: filename without
-          extension). Note: document_name is only supported in SSH mode.
+          extension). Honored in cloud and SSH modes; ignored by the USB web interface.
         </parameters>
         <examples>
         - remarkable_upload("/tmp/paper.pdf")
@@ -330,6 +521,38 @@ def register_write_tools():
                         error_type="unsupported_format",
                         message=f"Unsupported file format: '.{ext}'",
                         suggestion="Only PDF and EPUB files can be uploaded to reMarkable.",
+                    )
+
+                # Cloud mode: upload via the sync v3/v4 blob protocol
+                if _is_cloud_mode():
+                    client = get_rmapi()
+                    collection = client.get_meta_items()
+                    items_by_id = get_items_by_id(collection)
+                    parent_id = _resolve_parent_id(parent_folder, items_by_id, collection)
+                    if parent_id is None:
+                        folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+                        return make_error(
+                            error_type="folder_not_found",
+                            message=f"Folder not found: '{parent_folder}'",
+                            suggestion="Use remarkable_browse('/') to see available folders.",
+                            did_you_mean=folders[:5] if folders else None,
+                        )
+
+                    name = document_name or os.path.splitext(os.path.basename(file_path))[0]
+                    with open(file_path, "rb") as f:
+                        data = f.read()
+                    doc = client.upload_document(data, name, ext, parent_id)
+                    return make_response(
+                        {
+                            "uploaded": True,
+                            "name": name,
+                            "uuid": doc.id,
+                            "format": ext,
+                            "parent_folder": parent_folder,
+                            "transport": "cloud",
+                        },
+                        "Document uploaded to the reMarkable cloud. "
+                        "Use remarkable_browse() to verify it appears.",
                     )
 
                 # USB web mode: simple HTTP upload
@@ -439,7 +662,7 @@ def register_write_tools():
 
         return await asyncio.to_thread(_impl)
 
-    if _is_ssh_mode():
+    if _is_ssh_mode() or _is_cloud_mode():
 
         @mcp.tool(annotations=MKDIR_ANNOTATIONS)
         async def remarkable_mkdir(
@@ -449,10 +672,12 @@ def register_write_tools():
             """
             <usecase>Create a new folder on the reMarkable tablet.</usecase>
             <instructions>
-            Creates a folder in the tablet's document hierarchy. The folder appears
-            in the tablet UI after xochitl restarts.
+            Creates a folder in the tablet's document hierarchy. In SSH mode the
+            folder appears after xochitl restarts; in cloud mode it syncs to all
+            your devices.
 
-            Requires SSH mode and --write flag. Not available in USB web mode.
+            Works in cloud and SSH modes (requires --write). Not available over the
+            USB web interface (the firmware exposes no folder-create endpoint).
             </instructions>
             <parameters>
             - folder_name: Name of the new folder
@@ -465,9 +690,12 @@ def register_write_tools():
             """
 
             def _impl() -> str:
-                error = _require_ssh_mode()
+                error = _require_managed_write_mode()
                 if error:
                     return error
+
+                if _is_cloud_mode():
+                    return _cloud_mkdir(folder_name, parent)
 
                 try:
                     ssh_client = _get_ssh_client()
@@ -539,7 +767,8 @@ def register_write_tools():
             Moves a document or folder by updating its parent reference in the metadata.
             Find the document name with remarkable_browse() first.
 
-            Requires SSH mode and --write flag. Not available in USB web mode.
+            Works in cloud and SSH modes (requires --write). Not available over the
+            USB web interface.
             </instructions>
             <parameters>
             - document: Name or path of the document/folder to move
@@ -552,9 +781,12 @@ def register_write_tools():
             """
 
             def _impl() -> str:
-                error = _require_ssh_mode()
+                error = _require_managed_write_mode()
                 if error:
                     return error
+
+                if _is_cloud_mode():
+                    return _cloud_move(document, dest_folder)
 
                 try:
                     ssh_client = _get_ssh_client()
@@ -655,7 +887,8 @@ def register_write_tools():
             Changes the display name of a document or folder by updating its metadata.
             Find the document name with remarkable_browse() first.
 
-            Requires SSH mode and --write flag. Not available in USB web mode.
+            Works in cloud and SSH modes (requires --write). Not available over the
+            USB web interface.
             </instructions>
             <parameters>
             - document: Current name or path of the document/folder
@@ -668,9 +901,12 @@ def register_write_tools():
             """
 
             def _impl() -> str:
-                error = _require_ssh_mode()
+                error = _require_managed_write_mode()
                 if error:
                     return error
+
+                if _is_cloud_mode():
+                    return _cloud_rename(document, new_name)
 
                 try:
                     ssh_client = _get_ssh_client()
@@ -728,16 +964,20 @@ def register_write_tools():
             return await asyncio.to_thread(_impl)
 
         @mcp.tool(annotations=DELETE_ANNOTATIONS)
-        async def remarkable_delete(document: str) -> str:
+        async def remarkable_delete(document: str, ctx: Optional[Context] = None) -> str:
             """
             <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
             <instructions>
-            DESTRUCTIVE operation — marks a document as deleted in its metadata.
-            The document won't appear in the tablet UI after restart.
+            DESTRUCTIVE operation. In cloud mode the item is moved to the trash
+            (recoverable from the device's Trash). In SSH mode it is marked deleted
+            in its metadata and disappears from the tablet UI after restart.
 
-            Requires SSH mode and --write flag. Not available in USB web mode.
-            The MCP client is responsible for any user confirmation; this tool
-            performs the delete immediately.
+            Works in cloud and SSH modes (requires --write). Not available over the
+            USB web interface.
+
+            If the client supports elicitation, this tool asks the user to confirm
+            before deleting. Set REMARKABLE_SKIP_CONFIRM=1 to skip the prompt for
+            automation.
             </instructions>
             <parameters>
             - document: Name or path of the document/folder to delete
@@ -747,12 +987,18 @@ def register_write_tools():
             - remarkable_delete("/Books/Archive/Old Draft")
             </examples>
             """
+            error = _require_managed_write_mode()
+            if error:
+                return error
+
+            cancelled = await _confirm_delete(ctx, document)
+            if cancelled:
+                return cancelled
+
+            if _is_cloud_mode():
+                return await asyncio.to_thread(_cloud_delete, document)
 
             def _impl() -> str:
-                error = _require_ssh_mode()
-                if error:
-                    return error
-
                 try:
                     ssh_client = _get_ssh_client()
                     collection = ssh_client.get_meta_items()

--- a/test_server.py
+++ b/test_server.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import requests
@@ -278,6 +278,38 @@ class TestRemarkableStatus:
         assert "connection" in data
         assert data["status"] == "connected"
         assert "_hint" in data
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_status_capability_matrix(self, mock_get_rmapi):
+        """Status exposes per-transport and effective capability matrices."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_client.get_meta_items.return_value = []
+
+        result = await mcp.call_tool("remarkable_status", {})
+        data = json.loads(result[0][0].text)
+
+        assert "write_enabled" in data
+        assert "capabilities" in data
+        assert "capabilities_by_transport" in data
+
+        matrix = data["capabilities_by_transport"]
+        # All three transports are described.
+        assert set(matrix) == {"cloud", "ssh", "usb-web"}
+        # Read/render are universal.
+        for caps in matrix.values():
+            assert caps["read"] is True
+            assert caps["render"] is True
+        # Cloud and SSH have full write surface; USB web is upload-only.
+        for mode in ("cloud", "ssh"):
+            assert all(matrix[mode][op] for op in ("upload", "mkdir", "move", "rename", "delete"))
+        assert matrix["usb-web"]["upload"] is True
+        assert not any(matrix["usb-web"][op] for op in ("mkdir", "move", "rename", "delete"))
+
+        # Effective capabilities for the active transport always cover read/render.
+        assert data["capabilities"]["read"] is True
+        assert data["capabilities"]["render"] is True
 
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.get_rmapi")
@@ -2493,8 +2525,8 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_mkdir_not_registered_in_cloud_mode(self):
-        """SSH-only write tools must not be exposed when there's no SSH transport."""
+    async def test_managed_write_tools_registered_in_cloud_mode(self):
+        """Cloud mode now has full write parity: mkdir/move/rename/delete register."""
         from remarkable_mcp.write_tools import register_write_tools
 
         # Cloud mode: neither SSH nor USB web
@@ -2505,11 +2537,11 @@ class TestWriteTools:
             try:
                 tools = await mcp.list_tools()
                 names = {t.name for t in tools}
-                # Upload is transport-checked at call time and may still register
-                assert "remarkable_mkdir" not in names
-                assert "remarkable_move" not in names
-                assert "remarkable_rename" not in names
-                assert "remarkable_delete" not in names
+                assert "remarkable_upload" in names
+                assert "remarkable_mkdir" in names
+                assert "remarkable_move" in names
+                assert "remarkable_rename" in names
+                assert "remarkable_delete" in names
             finally:
                 for name in [
                     "remarkable_upload",
@@ -2557,46 +2589,52 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_upload_error_in_cloud_mode(self):
-        """Test that upload returns error in cloud mode (no SSH or USB web)."""
+    async def test_upload_dispatches_to_cloud(self):
+        """Upload in cloud mode dispatches to the cloud client's upload_document."""
+        import tempfile
+
         from remarkable_mcp.write_tools import register_write_tools
 
-        register_write_tools()
-
-        try:
-            # Ensure neither SSH nor USB web mode is set
-            old_ssh = os.environ.pop("REMARKABLE_USE_SSH", None)
-            old_usb = os.environ.pop("REMARKABLE_USE_USB_WEB", None)
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env.pop("REMARKABLE_USE_USB_WEB", None)
+        env["REMARKABLE_ENABLE_WRITE"] = "1"
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                tmp.write(b"%PDF-1.4 test")
+                pdf_path = tmp.name
             try:
-                import importlib
+                mock_doc = Mock()
+                mock_doc.id = "new-doc-id"
+                mock_client = Mock(spec=["get_meta_items", "upload_document"])
+                mock_client.get_meta_items.return_value = []
+                mock_client.upload_document.return_value = mock_doc
 
-                import remarkable_mcp.api
-
-                importlib.reload(remarkable_mcp.api)
-
-                result = await mcp.call_tool(
-                    "remarkable_upload",
-                    {"file_path": "/tmp/test.pdf"},
-                )
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=mock_client):
+                    result = await mcp.call_tool(
+                        "remarkable_upload",
+                        {"file_path": pdf_path, "document_name": "My Doc"},
+                    )
                 data = json.loads(result[0][0].text)
-                assert "_error" in data
-                assert data["_error"]["type"] == "write_transport_required"
-                assert "SSH or USB web" in data["_error"]["message"]
+                assert data["uploaded"] is True
+                assert data["transport"] == "cloud"
+                assert data["uuid"] == "new-doc-id"
+                mock_client.upload_document.assert_called_once()
+                # content, name, ext, parent_id
+                args = mock_client.upload_document.call_args[0]
+                assert args[1] == "My Doc"
+                assert args[2] == "pdf"
+                assert args[3] == ""  # root
             finally:
-                if old_ssh is not None:
-                    os.environ["REMARKABLE_USE_SSH"] = old_ssh
-                if old_usb is not None:
-                    os.environ["REMARKABLE_USE_USB_WEB"] = old_usb
-                importlib.reload(remarkable_mcp.api)
-        finally:
-            for name in [
-                "remarkable_upload",
-                "remarkable_mkdir",
-                "remarkable_move",
-                "remarkable_rename",
-                "remarkable_delete",
-            ]:
-                mcp._tool_manager._tools.pop(name, None)
+                os.unlink(pdf_path)
+                for name in [
+                    "remarkable_upload",
+                    "remarkable_mkdir",
+                    "remarkable_move",
+                    "remarkable_rename",
+                    "remarkable_delete",
+                ]:
+                    mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
     async def test_mkdir_not_registered_in_usb_web_mode(self):
@@ -2624,6 +2662,151 @@ class TestWriteTools:
                     "remarkable_delete",
                 ]:
                     mcp._tool_manager._tools.pop(name, None)
+
+
+class TestCloudWriteDispatch:
+    """Cloud-mode write tools dispatch to the RemarkableClient methods."""
+
+    def _cloud_env(self):
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env.pop("REMARKABLE_USE_USB_WEB", None)
+        env["REMARKABLE_ENABLE_WRITE"] = "1"
+        return env
+
+    def _make_item(self, doc_id, name, parent="", is_folder=False):
+        item = Mock()
+        item.ID = doc_id
+        item.VissibleName = name
+        item.Parent = parent
+        item.is_folder = is_folder
+        return item
+
+    def _cleanup(self):
+        for name in [
+            "remarkable_upload",
+            "remarkable_mkdir",
+            "remarkable_move",
+            "remarkable_rename",
+            "remarkable_delete",
+        ]:
+            mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_cloud_mkdir_dispatch(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                new_folder = Mock()
+                new_folder.id = "folder-xyz"
+                client = Mock(spec=["get_meta_items", "create_folder"])
+                client.get_meta_items.return_value = []
+                client.create_folder.return_value = new_folder
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool("remarkable_mkdir", {"folder_name": "Projects"})
+                data = json.loads(result[0][0].text)
+                assert data["created"] is True
+                assert data["transport"] == "cloud"
+                assert data["uuid"] == "folder-xyz"
+                client.create_folder.assert_called_once_with("Projects", "")
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_rename_dispatch(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Old Name")
+                client = Mock(spec=["get_meta_items", "rename"])
+                client.get_meta_items.return_value = [target]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_rename",
+                        {"document": "Old Name", "new_name": "New Name"},
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["renamed"] is True
+                assert data["transport"] == "cloud"
+                client.rename.assert_called_once_with("doc-1", "New Name")
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_move_dispatch(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Report")
+                dest = self._make_item("fold-1", "Archive", is_folder=True)
+                client = Mock(spec=["get_meta_items", "move"])
+                client.get_meta_items.return_value = [target, dest]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_move",
+                        {"document": "Report", "dest_folder": "Archive"},
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["moved"] is True
+                assert data["transport"] == "cloud"
+                client.move.assert_called_once_with("doc-1", "fold-1")
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_delete_dispatch(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Old Notes")
+                client = Mock(spec=["get_meta_items", "delete"])
+                client.get_meta_items.return_value = [target]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result[0][0].text)
+                assert data["deleted"] is True
+                assert data["transport"] == "cloud"
+                client.delete.assert_called_once_with("doc-1")
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_delete_cancelled_by_elicitation(self):
+        """When the user declines elicitation, delete is aborted and nothing changes."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                client = Mock(spec=["get_meta_items", "delete"])
+                decline = Mock()
+                decline.action = "decline"
+                decline.data = None
+                with (
+                    patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                    patch(
+                        "remarkable_mcp.write_tools.client_supports_elicitation",
+                        return_value=True,
+                    ),
+                    patch(
+                        "mcp.server.fastmcp.Context.elicit",
+                        new=AsyncMock(return_value=decline),
+                    ),
+                ):
+                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result[0][0].text)
+                assert data["deleted"] is False
+                assert data["cancelled"] is True
+                client.delete.assert_not_called()
+            finally:
+                self._cleanup()
 
 
 class TestConcurrentToolDispatch:


### PR DESCRIPTION
## Summary

Drives toward **1.0.0**: bring **cloud mode to full parity with SSH**, make per-transport capabilities explicit, and tighten efficiency/portability so users can genuinely *pick their own mode and it just works*.

Builds on the already-landed perf/startup work (fast cached cloud traversal + non-blocking startup) at the base of this branch.

## What's in here

**Cloud read parity** (`sync.py` / `api.py` / `resources.py`)
- New cloud client methods: `get_file_type`, `download_raw_file`, `get_all_file_types`, `check_connection` — type detection is derived from the blob index with zero extra round-trips.
- `api.py` now dispatches uniformly across transports; **PDFs/EPUBs read and render in cloud mode** instead of being misclassified as notebooks.
- `resources.py` prefetches file types in every mode (was SSH-only).

**Cloud write parity** (`sync.py` / `write_tools.py` / `server.py` / `cli.py`)
- `create_folder` / `rename` / `move` / `delete` (→ trash) / `upload` via the sync v3/v4 blob protocol with a generation-gated root commit.
- Write tools now register in cloud mode; `--write` works **without a device**.
- `remarkable_delete` confirms via **MCP elicitation** when the client supports it (`REMARKABLE_SKIP_CONFIRM` bypasses for automation).
- Live-validated end-to-end through the MCP tool layer (mkdir → rename → delete and upload → readback), each with full rollback; library integrity preserved.

**Capability matrix** (`tools.py`)
- `remarkable_status` now reports `write_enabled` plus an effective and a full per-transport capability matrix. Transport-agnostic, accurate docstrings throughout.

**Efficiency / portability**
- SSH `download()` uses `ZIP_STORED` — the archive is extracted in-memory and never persisted, so compression was pure wasted CPU (cloud already did this).
- OS-agnostic "ssh not found" guidance; Windows-safe temp-file handling; subprocess calls use arg lists (no `shell=True`); `sshpass` is optional with a key-auth fallback.

**Docs**
- README Connection Modes, comparison table, and Write Tools section rewritten for cloud/SSH/USB-web parity; render-fallback note now covers cloud's source-PDF path.
- `docs/resources.md` and `docs/tools.md` corrected (raw PDF/EPUB available in all modes; accurate status fields).

## Capability matrix

| Mode | Read+render | Raw PDF/EPUB | Upload | Folder ops (mkdir/move/rename/delete) |
|------|:-----------:|:------------:|:------:|:-------------------------------------:|
| ☁️ Cloud | ✅ | ✅ | ✅ | ✅ |
| 🔌 USB Web | ✅ | ✅ (PDF) | ✅ (root) | ❌ (firmware has no such endpoints) |
| ⚡ SSH | ✅ | ✅ | ✅ | ✅ |

Write tools are opt-in behind `--write`.

## Credit

The cloud PDF/EPUB read+render fix overlaps with **#98 by @khalid-hasan**, who independently identified and fixed the same cloud-mode gap. Credit to them — co-authored on the relevant commit. (This PR supersedes that scope as part of the broader parity work, so #98 can be closed once this merges.)

## Testing
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest test_server.py -v` ✅ (130 passed)
- Cloud read (PDF/EPUB type-detect + raw download + text + render) and cloud write (mkdir/rename/move/delete/upload) live-validated against a real account.

## Not in this PR
The MCP Apps interactive viewer/annotator (the other 1.0.0 headline) is being designed separately and will land in a follow-up.