### PR TITLE
feat(ssh): agent-free key auth via REMARKABLE_SSH_KEY / --ssh-key

### DIFF
--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -124,6 +124,22 @@ Some password managers provide built-in SSH agents, letting you use passphrase-p
 
 These integrate seamlessly — the agent handles authentication automatically, and you get the security benefits of passphrase-protected keys without manual setup.
 
+> ⚠️ **Headless servers and interactive agents:** Agents like 1Password sign keys only after **interactive approval** (a GUI prompt or biometric). When the MCP server runs somewhere that approval can't be shown — a remote box, CI, or an automated agent — that prompt never appears and SSH calls **hang** until they time out. In that case, pin an unencrypted on-disk key instead:
+>
+> ```json
+> {
+>   "servers": {
+>     "remarkable": {
+>       "command": "uvx",
+>       "args": ["remarkable-mcp", "--ssh", "--ssh-key", "~/.ssh/id_ed25519"],
+>       "env": { "GOOGLE_VISION_API_KEY": "your-api-key" }
+>     }
+>   }
+> }
+> ```
+>
+> `--ssh-key` (or the `REMARKABLE_SSH_KEY` env var) makes ssh use **only** that key (`IdentitiesOnly=yes`) and ignore the agent, so authentication never blocks. Make sure that key's public half is in the tablet's `~/.ssh/authorized_keys` (e.g. via `ssh-copy-id`).
+
 ### SSH Config Alias
 
 For convenience, add to `~/.ssh/config`:
@@ -170,6 +186,7 @@ Note: WiFi is slower than USB but works from anywhere on your network.
 | `REMARKABLE_SSH_USER` | `root` | SSH username |
 | `REMARKABLE_SSH_PORT` | `22` | SSH port |
 | `REMARKABLE_SSH_PASSWORD` | *(none)* | SSH password (requires `sshpass`, key auth recommended) |
+| `REMARKABLE_SSH_KEY` | *(none)* | Path to a private key for key auth. Pins this on-disk identity (`IdentitiesOnly`) and ignores any ssh-agent. |
 
 ## Troubleshooting
 
@@ -190,6 +207,10 @@ Note: WiFi is slower than USB but works from anywhere on your network.
 - The tablet may be asleep — tap the screen to wake it
 - Try unplugging and reconnecting the USB cable
 - Restart the tablet if issues persist
+
+### Commands hang, then time out
+
+If SSH connects but every command stalls for the full timeout, an **interactive ssh-agent** (e.g. 1Password) is likely holding the authorized key and waiting for approval the server can't show. Pin an unencrypted on-disk key with `--ssh-key ~/.ssh/id_ed25519` (or `REMARKABLE_SSH_KEY`) to bypass the agent. See [SSH Key Authentication](#ssh-key-authentication-recommended).
 
 ### Slow Performance
 

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -44,6 +44,9 @@ Examples:
   # SSH with custom host (e.g., using SSH config)
   REMARKABLE_SSH_HOST="remarkable" uvx remarkable-mcp --ssh
 
+  # SSH pinning an explicit key (ignores ssh-agent, e.g. 1Password)
+  uvx remarkable-mcp --ssh --ssh-key ~/.ssh/id_ed25519
+
 USB Web Interface Environment Variables:
   REMARKABLE_USB_HOST      USB web interface host (default: http://10.11.99.1)
   REMARKABLE_USB_TIMEOUT   Request timeout in seconds (default: 10)
@@ -53,6 +56,9 @@ SSH Environment Variables:
   REMARKABLE_SSH_USER      SSH user (default: root)
   REMARKABLE_SSH_PORT      SSH port (default: 22)
   REMARKABLE_SSH_PASSWORD  SSH password (optional, requires sshpass)
+  REMARKABLE_SSH_KEY       Private key path for key auth (optional). Pins this
+                           on-disk identity and ignores any ssh-agent, avoiding
+                           hangs with interactive agents like 1Password.
 
 Security Note:
   For better security, set up SSH key authentication instead of using
@@ -68,6 +74,15 @@ Security Note:
         "--ssh",
         action="store_true",
         help="Use SSH transport instead of cloud API (requires developer mode)",
+    )
+    parser.add_argument(
+        "--ssh-key",
+        metavar="PATH",
+        help=(
+            "Path to a private key for SSH key auth (sets REMARKABLE_SSH_KEY). "
+            "Pins this on-disk identity and ignores any ssh-agent, avoiding hangs "
+            "with interactive agents like 1Password in a headless server."
+        ),
     )
     parser.add_argument(
         "--usb",
@@ -127,6 +142,8 @@ Security Note:
     elif args.ssh:
         # SSH mode - set environment variable and run server
         os.environ["REMARKABLE_USE_SSH"] = "1"
+        if args.ssh_key:
+            os.environ["REMARKABLE_SSH_KEY"] = args.ssh_key
         if args.write:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         from remarkable_mcp.server import run

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -110,18 +110,40 @@ class SSHClient:
         user: str = DEFAULT_SSH_USER,
         port: int = DEFAULT_SSH_PORT,
         password: Optional[str] = None,
+        key_path: Optional[str] = None,
     ):
         self.host = host
         self.user = user
         self.port = port
         self.password = password
+        self.key_path = os.path.expanduser(key_path) if key_path else None
         self._documents: List[Document] = []
         self._documents_by_id: Dict[str, Document] = {}
+
+    def _auth_ssh_options(self) -> List[str]:
+        """SSH options for key-based auth.
+
+        When a password is set, auth is handled by wrapping the command with
+        ``sshpass`` (see callers), so no options are added here.
+
+        Otherwise we use ``BatchMode=yes`` (never prompt) and, if an explicit
+        key is configured, pin it with ``-i`` plus ``IdentitiesOnly=yes``. The
+        latter makes ssh use only that on-disk key and ignore any ssh-agent
+        (e.g. 1Password), so signing never blocks on interactive approval in a
+        headless MCP server.
+        """
+        if self.password:
+            return []
+        opts = ["-o", "BatchMode=yes"]
+        if self.key_path:
+            opts += ["-i", self.key_path, "-o", "IdentitiesOnly=yes"]
+        return opts
 
     def _ssh_command(self, command: str, timeout: int = 30) -> str:
         """Execute a command on the tablet via SSH."""
         ssh_args = [
             "ssh",
+            *self._auth_ssh_options(),
             "-o",
             "ConnectTimeout=5",
             "-o",
@@ -132,12 +154,8 @@ class SSHClient:
             command,
         ]
 
-        # If no password, use BatchMode for key-based auth
-        if not self.password:
-            ssh_args.insert(1, "-o")
-            ssh_args.insert(2, "BatchMode=yes")
-        else:
-            # Use sshpass for password authentication
+        # Use sshpass for password authentication
+        if self.password:
             ssh_args = ["sshpass", "-p", self.password] + ssh_args
 
         try:
@@ -173,6 +191,7 @@ class SSHClient:
         # This avoids issues with /dev/stdout on various platforms
         ssh_args = [
             "ssh",
+            *self._auth_ssh_options(),
             "-o",
             "ConnectTimeout=5",
             "-o",
@@ -183,12 +202,8 @@ class SSHClient:
             f"cat '{remote_path}'",
         ]
 
-        # If no password, use BatchMode for key-based auth
-        if not self.password:
-            ssh_args.insert(1, "-o")
-            ssh_args.insert(2, "BatchMode=yes")
-        else:
-            # Use sshpass for password authentication
+        # Use sshpass for password authentication
+        if self.password:
             ssh_args = ["sshpass", "-p", self.password] + ssh_args
 
         try:
@@ -486,7 +501,7 @@ def check_ssh_available(
     port: int = DEFAULT_SSH_PORT,
 ) -> bool:
     """Check if SSH connection to reMarkable tablet is available."""
-    client = SSHClient(host=host, user=user, port=port)
+    client = create_ssh_client(host=host, user=user, port=port)
     return client.check_connection()
 
 
@@ -495,6 +510,7 @@ def create_ssh_client(
     user: Optional[str] = None,
     port: Optional[int] = None,
     password: Optional[str] = None,
+    key_path: Optional[str] = None,
 ) -> SSHClient:
     """
     Create an SSH client with settings from environment or defaults.
@@ -503,11 +519,16 @@ def create_ssh_client(
     - REMARKABLE_SSH_HOST: SSH host (default: 10.11.99.1)
     - REMARKABLE_SSH_USER: SSH user (default: root)
     - REMARKABLE_SSH_PORT: SSH port (default: 22)
-    - REMARKABLE_SSH_PASSWORD: SSH password (optional, key-based auth recommended)
+    - REMARKABLE_SSH_PASSWORD: SSH password (optional, requires sshpass)
+    - REMARKABLE_SSH_KEY: path to a private key for key-based auth (optional).
+      When set, ssh uses only this identity (IdentitiesOnly) and ignores any
+      ssh-agent, avoiding hangs with interactive agents such as 1Password in a
+      headless server.
     """
     return SSHClient(
         host=host or os.environ.get("REMARKABLE_SSH_HOST", DEFAULT_SSH_HOST),
         user=user or os.environ.get("REMARKABLE_SSH_USER", DEFAULT_SSH_USER),
         port=port or int(os.environ.get("REMARKABLE_SSH_PORT", str(DEFAULT_SSH_PORT))),
         password=password or os.environ.get("REMARKABLE_SSH_PASSWORD"),
+        key_path=key_path or os.environ.get("REMARKABLE_SSH_KEY"),
     )

--- a/test_server.py
+++ b/test_server.py
@@ -3066,3 +3066,90 @@ class TestCloudClientCache:
         third = api.get_rmapi()
         assert third is not first
         assert len(created) == 2
+
+
+class TestSSHKeyAuth:
+    """SSH command construction for key-based / password / agent-free auth."""
+
+    def _capture(self, monkeypatch, *, text):
+        """Patch subprocess.run in ssh module and capture the argv it receives."""
+        import remarkable_mcp.ssh as ssh_mod
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return Mock(returncode=0, stdout=("ok" if text else b"ok"), stderr="")
+
+        monkeypatch.setattr(ssh_mod.subprocess, "run", fake_run)
+        return captured
+
+    def test_explicit_key_pins_identity_and_ignores_agent(self, monkeypatch):
+        from remarkable_mcp.ssh import SSHClient
+
+        captured = self._capture(monkeypatch, text=True)
+        client = SSHClient(key_path="~/.ssh/id_ed25519")
+        client._ssh_command("echo ok")
+
+        argv = captured["args"]
+        expected_key = os.path.expanduser("~/.ssh/id_ed25519")
+        assert "sshpass" not in argv
+        assert "-o" in argv and "BatchMode=yes" in argv
+        assert "-i" in argv
+        assert expected_key in argv
+        assert "IdentitiesOnly=yes" in argv
+        # Identity must be supplied before the destination/command.
+        assert argv.index(expected_key) < argv.index("echo ok")
+
+    def test_keyless_default_has_batchmode_but_no_identity(self, monkeypatch):
+        from remarkable_mcp.ssh import SSHClient
+
+        captured = self._capture(monkeypatch, text=True)
+        client = SSHClient()
+        client._ssh_command("echo ok")
+
+        argv = captured["args"]
+        assert "BatchMode=yes" in argv
+        assert "-i" not in argv
+        assert "IdentitiesOnly=yes" not in argv
+        assert "sshpass" not in argv
+
+    def test_password_uses_sshpass_without_batchmode(self, monkeypatch):
+        from remarkable_mcp.ssh import SSHClient
+
+        captured = self._capture(monkeypatch, text=True)
+        client = SSHClient(password="secret")
+        client._ssh_command("echo ok")
+
+        argv = captured["args"]
+        assert argv[:3] == ["sshpass", "-p", "secret"]
+        # Password auth must not force BatchMode (it would block the password).
+        assert "BatchMode=yes" not in argv
+        assert "IdentitiesOnly=yes" not in argv
+
+    def test_scp_download_also_pins_identity(self, monkeypatch):
+        from remarkable_mcp.ssh import SSHClient
+
+        captured = self._capture(monkeypatch, text=False)
+        client = SSHClient(key_path="/keys/rm_ed25519")
+        client._scp_download("/home/root/file.pdf")
+
+        argv = captured["args"]
+        assert "-i" in argv
+        assert "/keys/rm_ed25519" in argv
+        assert "IdentitiesOnly=yes" in argv
+        assert "BatchMode=yes" in argv
+
+    def test_create_ssh_client_reads_key_env(self, monkeypatch):
+        from remarkable_mcp.ssh import create_ssh_client
+
+        monkeypatch.setenv("REMARKABLE_SSH_KEY", "~/.ssh/rm_key")
+        monkeypatch.delenv("REMARKABLE_SSH_PASSWORD", raising=False)
+        client = create_ssh_client()
+        assert client.key_path == os.path.expanduser("~/.ssh/rm_key")
+
+    def test_key_path_defaults_to_none(self):
+        from remarkable_mcp.ssh import SSHClient
+
+        assert SSHClient().key_path is None


### PR DESCRIPTION
## Why

While live-validating the SSH transport (USB-connected tablet, Dropbear), I hit a hard failure: the device's `authorized_keys` trusted a key served by the **1Password SSH agent**, and every SSH call **hung** until it timed out.

Root cause: the key-based path uses `BatchMode=yes` (so it never prompts for a password), but the agent still blocks on **interactive signing approval** that a headless MCP server can't surface. So auth neither succeeds nor fails fast — it stalls for the full subprocess timeout on every call. This affects anyone running the server somewhere a GUI/biometric prompt can't appear (remote box, CI, automated agent) while using an interactive agent like 1Password, Secretive, or KeePassXC.

## What

Opt-in **explicit identity**:

- New `REMARKABLE_SSH_KEY` env var and `--ssh-key PATH` CLI flag.
- When set, ssh runs with `-i <key> -o IdentitiesOnly=yes` → it uses **only** that on-disk key and **ignores any agent**, so auth is deterministic and never blocks.
- **Default behaviour is unchanged**: keyless setups still use `BatchMode` key auth via the agent/default identities (which works fine when the agent can sign non-interactively).

Also in this change:
- Refactored the duplicated ssh-arg building in `_ssh_command` / `_scp_download` into a shared `_auth_ssh_options()` helper.
- Routed `check_ssh_available` through `create_ssh_client` so the status probe honours the same password/key env vars as the runtime client.
- Docs: `ssh-setup.md` gains a headless/interactive-agent note, a config example, an env-var-table row, and a "commands hang then time out" troubleshooting entry. CLI `--help` documents the flag and env var.

## Validation

- `ruff check` ✅ · `ruff format --check` ✅ · `pytest` ✅ (136 passed, 6 new)
- New tests assert the exact argv: explicit-key (identity pinned, agent ignored), keyless default (BatchMode, no `-i`), password (sshpass wrapper, no BatchMode), scp download, and `REMARKABLE_SSH_KEY` parsing.
- Empirically verified against the real tablet that `-i <key> -o IdentitiesOnly=yes` bypasses the 1Password agent and returns in ~0.3s (clean result) instead of hanging.

> Note: end-to-end *successful* device auth still requires the chosen key's public half to be in the tablet's `authorized_keys` (`ssh-copy-id`). This PR fixes the mechanism that made agent-backed setups hang; the unit tests cover command construction.