### PR TITLE
fix(cloud): honour HTTP-date Retry-After for rate-limit backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Cloud API requests automatically retry on transient failures (HTTP 429, 500, 502
 | `REMARKABLE_RETRY_ATTEMPTS` | `3` | Maximum number of request attempts (minimum 1) |
 | `REMARKABLE_RETRY_DELAY` | `2.0` | Base delay in seconds for exponential backoff |
 
-The retry logic honours the `Retry-After` header from rate-limited responses, capped at 20 seconds. Auth failures (401) are not retried — they trigger automatic token renewal instead.
+The retry logic honours the `Retry-After` header from rate-limited responses — both the numeric (seconds) form and the HTTP-date form (which Cloudflare, fronting the reMarkable cloud, often sends) — capped at 20 seconds. Auth failures (401) are not retried — they trigger automatic token renewal instead.
 
 ---
 

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -18,7 +18,8 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -117,16 +118,39 @@ def _get_retry_delay() -> float:
 def _parse_retry_after(response: requests.Response) -> Optional[float]:
     """Parse the Retry-After header, returning seconds or None.
 
-    Only the numeric form (seconds) is supported; HTTP-date values
-    and invalid/negative/non-finite values fall back to jittered backoff.
+    Supports both forms defined by RFC 9110:
+    - delay-seconds (e.g. ``120``)
+    - HTTP-date (e.g. ``Wed, 21 Oct 2026 07:28:00 GMT``) — Cloudflare, which
+      fronts the reMarkable cloud, often uses this on 429s. The delay is the
+      time from now until that date.
+
+    The result is clamped to ``[0, MAX_RETRY_DELAY]`` (consistent with the
+    jittered backoff). Missing/invalid/negative values return None, so the
+    caller falls back to exponential backoff with jitter.
     """
     header = response.headers.get("Retry-After")
     if header is None:
         return None
+
+    # delay-seconds form.
+    val: Optional[float]
     try:
         val = float(header)
     except (ValueError, TypeError):
-        return None
+        val = None
+
+    # HTTP-date form.
+    if val is None:
+        try:
+            retry_at = parsedate_to_datetime(header)
+        except (TypeError, ValueError):
+            return None
+        if retry_at is None:
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        val = (retry_at - datetime.now(timezone.utc)).total_seconds()
+
     if not math.isfinite(val) or val < 0:
         return None
     return min(val, MAX_RETRY_DELAY)

--- a/test_server.py
+++ b/test_server.py
@@ -2350,6 +2350,70 @@ class TestRetryBackoff:
         assert result.status_code == 503
         assert mock_request.call_count == 3
 
+    def test_parse_retry_after_seconds(self):
+        """Numeric (delay-seconds) Retry-After is parsed as seconds."""
+        from remarkable_mcp.sync import _parse_retry_after
+
+        resp = Mock()
+        resp.headers = {"Retry-After": "7"}
+        assert _parse_retry_after(resp) == 7.0
+
+    def test_parse_retry_after_http_date_future_capped(self):
+        """HTTP-date Retry-After in the future is honoured and capped at MAX."""
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+
+        from remarkable_mcp.sync import MAX_RETRY_DELAY, _parse_retry_after
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        resp = Mock()
+        resp.headers = {"Retry-After": format_datetime(future)}
+        # An hour out is well beyond MAX_RETRY_DELAY, so it clamps to the cap.
+        assert _parse_retry_after(resp) == MAX_RETRY_DELAY
+
+    def test_parse_retry_after_http_date_past_returns_none(self):
+        """An HTTP-date already in the past yields None (fall back to backoff)."""
+        from remarkable_mcp.sync import _parse_retry_after
+
+        resp = Mock()
+        resp.headers = {"Retry-After": "Wed, 21 Oct 2020 07:28:00 GMT"}
+        assert _parse_retry_after(resp) is None
+
+    def test_parse_retry_after_invalid_and_missing_return_none(self):
+        """Garbage or missing Retry-After yields None."""
+        from remarkable_mcp.sync import _parse_retry_after
+
+        garbage = Mock()
+        garbage.headers = {"Retry-After": "soon-ish"}
+        assert _parse_retry_after(garbage) is None
+
+        missing = Mock()
+        missing.headers = {}
+        assert _parse_retry_after(missing) is None
+
+    @patch("remarkable_mcp.sync.time.sleep")
+    @patch("remarkable_mcp.sync._issue_request")
+    def test_retry_after_http_date_honoured_through_wrapper(self, mock_request, mock_sleep):
+        """A 429 with an HTTP-date Retry-After drives the backoff sleep."""
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+
+        from remarkable_mcp.sync import MAX_RETRY_DELAY, _http_request_with_retry
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        rate_limited = Mock()
+        rate_limited.status_code = 429
+        rate_limited.headers = {"Retry-After": format_datetime(future)}
+
+        ok_response = Mock()
+        ok_response.status_code = 200
+
+        mock_request.side_effect = [rate_limited, ok_response]
+
+        result = _http_request_with_retry("GET", "https://example.com/api")
+        assert result.status_code == 200
+        mock_sleep.assert_called_once_with(MAX_RETRY_DELAY)
+
 
 # =============================================================================
 # Test Write Tools


### PR DESCRIPTION
## Summary

The reMarkable cloud is fronted by Cloudflare, which commonly returns the `Retry-After` header in **HTTP-date** form (e.g. `Wed, 21 Oct 2026 07:28:00 GMT`) on `429` responses. Our `_parse_retry_after` only handled the numeric **delay-seconds** form, so date-form values were silently ignored and the client fell back to short jittered backoff instead of honouring the server-requested interval.

## Changes

- `remarkable_mcp/sync.py`: `_parse_retry_after` now parses **both** forms via `email.utils.parsedate_to_datetime`, computes the delay from now (treating naive datetimes as UTC), and clamps to `[0, MAX_RETRY_DELAY]` for consistency with the numeric path. Past / invalid / missing values still return `None` so the exponential-backoff-with-jitter fallback applies unchanged.
- `test_server.py`: +5 tests in `TestRetryBackoff` covering numeric seconds, future HTTP-date (clamped to cap), past HTTP-date → None, garbage/missing → None, and the wrapper honouring a date-form header.
- `README.md`: clarified that both `Retry-After` forms are honoured.

## Validation

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run pytest test_server.py -v` — 141 passed

The existing numeric path and all non-429 behaviour are unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>