### PR TITLE
fix: drop rmc to allow rmscene>=0.8.0 (render handwriting on current firmware, #95)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,9 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.0.0",
-    "rmscene>=0.6.0",
+    "rmscene>=0.8.0",
     "pytesseract>=0.3.10",
     "Pillow>=10.0.0",
-    "rmc>=0.3.0",
     "requests>=2.28.0",
     "cairosvg>=2.9.0",
     "pymupdf>=1.26.7",

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -5,9 +5,6 @@ Text extraction helpers for reMarkable documents.
 import json
 import logging
 import os
-import shutil
-import subprocess
-import sys
 import tempfile
 import time
 import zipfile
@@ -18,49 +15,21 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
-def _rmc_executable() -> str:
-    """Return a usable path to the ``rmc`` CLI.
-
-    When installed via ``uvx``, ``rmc`` lives in the venv's ``bin/`` (or
-    ``Scripts/`` on Windows) directory and is not on the system PATH. We
-    check PATH first, then the venv's bin directory (using ``shutil.which``
-    to handle platform-specific extensions like ``.exe``), then fall back
-    to bare ``"rmc"`` (which lets subprocess raise a clear
-    ``FileNotFoundError`` if nothing is found).
-
-    Credit: ColinSha (PR #79)
-    """
-    found = shutil.which("rmc")
-    if found:
-        return found
-    # Check the venv's bin/Scripts directory — shutil.which handles .exe/.cmd
-    venv_bin = str(Path(sys.executable).parent)
-    found = shutil.which("rmc", path=venv_bin)
-    if found:
-        return found
-    return "rmc"
-
-
 def _rm_to_svg(rm_file_path: Path, output_svg_path: Path) -> bool:
-    """Convert a .rm file to SVG, trying rmc then v5/v6 fallback renderers.
+    """Convert a .rm file to SVG using the built-in rmscene renderers.
+
+    The ``rmc`` dependency has been dropped: it transitively pinned
+    ``rmscene<0.7.0``, which cannot parse current-firmware ``.rm`` scene
+    blocks (e.g. ``SceneInfo`` ``block_type=13``). We render via ``rmscene``
+    directly using the in-repo v6/v5 renderers. v6 is tried first since it is
+    the current firmware format.
 
     Writes the SVG content to output_svg_path and returns True on success.
     Returns False if no renderer could handle the file.
-    """
-    # Try rmc first
-    try:
-        result = subprocess.run(
-            [_rmc_executable(), "-t", "svg", "-o", str(output_svg_path), str(rm_file_path)],
-            capture_output=True,
-            timeout=30,
-        )
-        if result.returncode == 0:
-            return True
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
 
-    # rmc failed or not found — try built-in v5/v6 renderers
-    svg_content = _render_rm_v5_to_svg(rm_file_path) or _render_rm_v6_to_svg(rm_file_path)
+    Credit: khalid-hasan (PR #97), ljdutel (#95)
+    """
+    svg_content = _render_rm_v6_to_svg(rm_file_path) or _render_rm_v5_to_svg(rm_file_path)
     if svg_content is not None:
         output_svg_path.write_text(svg_content)
         return True
@@ -594,7 +563,7 @@ def render_rm_file_to_png(
     """
     Render a .rm file to PNG image bytes.
 
-    Uses rmc to convert .rm to SVG, then cairosvg to convert to PNG.
+    Uses the rmscene renderers to convert .rm to SVG, then cairosvg to convert to PNG.
     The output is sized based on the SVG content bounds with a margin.
 
     Args:
@@ -620,7 +589,7 @@ def render_rm_file_to_png(
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
             tmp_png_path = Path(tmp_png.name)
 
-        # Convert .rm to SVG (rmc with v5/v6 fallback)
+        # Convert .rm to SVG via the rmscene renderers
         if not _rm_to_svg(rm_file_path, tmp_svg_path):
             return None
 
@@ -711,7 +680,7 @@ def render_rm_file_to_svg(
     """
     Render a .rm file to SVG string.
 
-    Uses rmc to convert .rm to SVG, optionally adding a background.
+    Uses the rmscene renderers to convert .rm to SVG, optionally adding a background.
 
     Args:
         rm_file_path: Path to the .rm file
@@ -731,7 +700,7 @@ def render_rm_file_to_svg(
         with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
             tmp_svg_path = Path(tmp_svg.name)
 
-        # Convert .rm to SVG (rmc with v5/v6 fallback)
+        # Convert .rm to SVG via the rmscene renderers
         if not _rm_to_svg(rm_file_path, tmp_svg_path):
             return None
 
@@ -1171,14 +1140,13 @@ def render_merged_page_from_document_zip(
             if _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
-                # rmc emits stroke coordinates in PDF points (after its internal
-                # SCALE = 72/226), with the origin at the top of the page and
-                # x=0 in the horizontal center (so x ranges roughly from
-                # -W_pt/2 to +W_pt/2). Setting the viewBox to
-                # (-W_pt/2, 0, W_pt, H_pt) maps that coordinate system to the
-                # PDF page bounds so annotations align. This is specific to
-                # rmc's v6 renderer; if the upstream coordinate convention
-                # changes this alignment will need to be revisited.
+                # rmscene's v6 renderer emits stroke coordinates with the
+                # origin at the top of the page and x=0 in the horizontal
+                # center (so x ranges roughly from -W/2 to +W/2). Setting the
+                # viewBox to (-W_pt/2, 0, W_pt, H_pt) maps that coordinate
+                # system to the PDF page bounds so annotations align. If the
+                # upstream coordinate convention changes, this alignment will
+                # need to be revisited.
                 svg_content = ann_svg_path.read_text()
 
                 svg_content = re.sub(
@@ -1432,7 +1400,7 @@ def extract_handwriting_ocr(rm_files: List[Path]) -> tuple[Optional[List[str]], 
     Supports multiple backends (set REMARKABLE_OCR_BACKEND env var):
     - "sampling": Uses client's LLM via MCP sampling (requires async context, tools only)
     - "google": Google Cloud Vision - best for handwriting
-    - "tesseract": pytesseract - basic OCR, requires rmc + cairosvg
+    - "tesseract": pytesseract - basic OCR, requires cairosvg (or inkscape)
     - "auto" (default): Google if API key provided, else Tesseract
 
     Note: "sampling" backend requires async context and is only available via tools,
@@ -1511,7 +1479,7 @@ def _ocr_google_vision_rest(rm_files: List[Path], api_key: str) -> Optional[List
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
                 tmp_png_path = Path(tmp_png.name)
 
-            # Convert .rm to SVG (rmc with v5/v6 fallback)
+            # Convert .rm to SVG via the rmscene renderers
             if not _rm_to_svg(rm_file, tmp_svg_path):
                 continue
             # Convert SVG to PNG
@@ -1616,7 +1584,7 @@ def _ocr_google_vision_sdk(rm_files: List[Path]) -> Optional[List[str]]:
                 with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
                     tmp_png_path = Path(tmp_png.name)
 
-                # Convert .rm to SVG (rmc with v5/v6 fallback)
+                # Convert .rm to SVG via the rmscene renderers
                 if not _rm_to_svg(rm_file, tmp_svg_path):
                     continue
                 try:
@@ -1697,7 +1665,7 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
     OCR using Tesseract.
     Basic quality - designed for printed text, not handwriting.
 
-    Requires: pytesseract, rmc, cairosvg (or inkscape)
+    Requires: pytesseract, cairosvg (or inkscape)
     """
     try:
         import subprocess
@@ -1719,7 +1687,7 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
                 with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
                     tmp_png_path = Path(tmp_png.name)
 
-                # Convert .rm to SVG (rmc with v5/v6 fallback)
+                # Convert .rm to SVG via the rmscene renderers
                 if not _rm_to_svg(rm_file, tmp_svg_path):
                     continue
 

--- a/test_server.py
+++ b/test_server.py
@@ -7,7 +7,6 @@ Tests the 4 intent-based tools using FastMCP's testing capabilities.
 
 import json
 import os
-import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -1833,63 +1832,118 @@ class TestIsCloudArchivedFix:
         assert doc.is_cloud_archived is True
 
 
-class TestRmcResolution:
-    """Regression tests for rmc binary resolution (issues #52, #78, #80)."""
+def _make_v6_rm_bytes() -> bytes:
+    """Build a minimal current-firmware (v6) .rm file with a single line.
 
-    def test_rmc_executable_returns_string(self):
-        """_rmc_executable should always return a string path."""
-        from remarkable_mcp.extract import _rmc_executable
+    Uses rmscene's own writer, which both produces a deterministic fixture and
+    exercises the rmscene>=0.8.0 read/write round-trip our renderer relies on
+    (the version that parses the current scene format — see #95 / PR #97).
+    """
+    import io
+    import uuid
 
-        result = _rmc_executable()
-        assert isinstance(result, str)
-        assert len(result) > 0
+    from rmscene import scene_items as si
+    from rmscene.crdt_sequence import CrdtSequenceItem
+    from rmscene.scene_stream import (
+        AuthorIdsBlock,
+        MigrationInfoBlock,
+        PageInfoBlock,
+        SceneLineItemBlock,
+        SceneTreeBlock,
+        TreeNodeBlock,
+        write_blocks,
+    )
+    from rmscene.tagged_block_common import CrdtId
 
-    def test_rmc_executable_finds_venv_binary(self):
-        """_rmc_executable should find rmc in the venv's bin directory."""
-        from remarkable_mcp.extract import _rmc_executable
+    points = [
+        si.Point(x=float(x), y=0.0, speed=0, direction=0, width=2, pressure=0) for x in (-50, 0, 50)
+    ]
+    line = si.Line(
+        color=si.PenColor.BLACK,
+        tool=si.Pen.BALLPOINT_1,
+        points=points,
+        thickness_scale=1.0,
+        starting_length=0.0,
+    )
+    node_id = CrdtId(0, 11)
+    blocks = [
+        AuthorIdsBlock(author_uuids={1: uuid.uuid4()}),
+        MigrationInfoBlock(migration_id=CrdtId(0, 1), is_device=True),
+        PageInfoBlock(loads_count=1, merges_count=0, text_chars_count=0, text_lines_count=0),
+        SceneTreeBlock(
+            tree_id=node_id,
+            node_id=CrdtId(0, 0),
+            is_update=True,
+            parent_id=CrdtId(0, 0),
+        ),
+        TreeNodeBlock(group=si.Group(node_id=node_id)),
+        SceneLineItemBlock(
+            parent_id=node_id,
+            item=CrdtSequenceItem(
+                item_id=CrdtId(0, 12),
+                left_id=CrdtId(0, 0),
+                right_id=CrdtId(0, 0),
+                deleted_length=0,
+                value=line,
+            ),
+        ),
+    ]
+    buf = io.BytesIO()
+    write_blocks(buf, blocks)
+    return buf.getvalue()
 
-        result = _rmc_executable()
-        # Should find it either on PATH or in venv
-        assert Path(result).stem == "rmc"
 
-    def test_rmc_executable_falls_back_to_venv(self):
-        """When rmc is not on PATH, should find it in the venv bin."""
-        import sys
+class TestRmToSvgRendering:
+    """Regression tests for .rm -> SVG rendering after dropping rmc (PR #97).
 
-        from remarkable_mcp.extract import _rmc_executable
+    rmc transitively pinned rmscene<0.7.0, which cannot parse current-firmware
+    .rm scene blocks (#95). _rm_to_svg now renders via the in-repo rmscene v6/v5
+    renderers directly, with no rmc subprocess.
+    """
 
-        venv_rmc = Path(sys.executable).parent / "rmc"
-        if not venv_rmc.exists():
-            pytest.skip("rmc not in venv bin")
+    def test_rmc_dependency_removed(self):
+        """The rmc subprocess helper is gone; rmscene is the modern (>=0.8) parser."""
+        from importlib.metadata import version
 
-        # Capture real which() before patching
-        real_which = shutil.which
+        from packaging.version import Version
 
-        # Patch so PATH lookup returns None, but venv-bin lookup works
-        with patch("remarkable_mcp.extract.shutil.which") as mock_which:
-            mock_which.side_effect = lambda name, path=None: (
-                real_which(name, path=path) if path else None
-            )
-            result = _rmc_executable()
-        assert Path(result).stem == "rmc"
+        from remarkable_mcp import extract
 
-    @patch("remarkable_mcp.extract.shutil.which", return_value=None)
-    def test_rmc_executable_falls_back_to_bare(self, mock_which):
-        """When rmc is nowhere, should return bare 'rmc' for clear error."""
-        from remarkable_mcp.extract import _rmc_executable
+        assert not hasattr(extract, "_rmc_executable")
+        assert Version(version("rmscene")) >= Version("0.8.0")
 
-        result = _rmc_executable()
-        assert result == "rmc"
+    def test_rm_to_svg_renders_v6_current_firmware(self):
+        """_rm_to_svg renders a current-firmware (v6) file via rmscene (the #95 fix)."""
+        from remarkable_mcp.extract import _rm_to_svg
 
-    @patch("remarkable_mcp.extract.subprocess.run")
-    def test_rm_to_svg_v5_fallback(self, mock_run):
-        """_rm_to_svg should use v5 fallback when rmc is not available."""
+        try:
+            data = _make_v6_rm_bytes()
+        except Exception as exc:  # pragma: no cover - guards rmscene API drift
+            pytest.skip(f"could not synthesize a v6 fixture with rmscene: {exc}")
+
+        assert data[:33] == b"reMarkable .lines file, version=6"
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(data)
+            rm_path = Path(rm_tmp.name)
+        with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as svg_tmp:
+            svg_path = Path(svg_tmp.name)
+
+        try:
+            result = _rm_to_svg(rm_path, svg_path)
+            assert result is True
+            svg_content = svg_path.read_text()
+            assert "<svg" in svg_content
+            assert "<path" in svg_content
+        finally:
+            rm_path.unlink(missing_ok=True)
+            svg_path.unlink(missing_ok=True)
+
+    def test_rm_to_svg_renders_v5(self):
+        """_rm_to_svg renders a v5 file via the built-in renderer (no rmc needed)."""
         import struct
 
         from remarkable_mcp.extract import _rm_to_svg
-
-        # Simulate rmc not found
-        mock_run.side_effect = FileNotFoundError("rmc not found")
 
         # Build minimal v5 .rm file with one stroke
         buf = bytearray()

--- a/uv.lock
+++ b/uv.lock
@@ -1362,7 +1362,6 @@ dependencies = [
     { name = "pymupdf" },
     { name = "pytesseract" },
     { name = "requests" },
-    { name = "rmc" },
     { name = "rmscene" },
 ]
 
@@ -1397,8 +1396,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.28.0" },
-    { name = "rmc", specifier = ">=0.3.0" },
-    { name = "rmscene", specifier = ">=0.6.0" },
+    { name = "rmscene", specifier = ">=0.8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev", "ocr"]
@@ -1425,28 +1423,15 @@ wheels = [
 ]
 
 [[package]]
-name = "rmc"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rmscene" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/00/5e05be08e8905f888ece9e5835b96e4ec3aabb480cce564c4ec5e5e0ca32/rmc-0.3.0.tar.gz", hash = "sha256:57afe14d56694085b6a382aa2b93b7b86eb21e93e720b16a82990aa0d6513dcb", size = 10799, upload-time = "2025-03-21T08:04:46.362Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/b0/486783b0321557d4294195e73e10b58dc5b5e1ac8519791c48160f863097/rmc-0.3.0-py3-none-any.whl", hash = "sha256:f2957bf08c48902bf50b047ee08aeb0be5a8c0a64bf7a1a46e23ae02c0c75780", size = 12626, upload-time = "2025-03-21T08:04:45.074Z" },
-]
-
-[[package]]
 name = "rmscene"
-version = "0.6.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/27/bb1c99959216af939ade7b5b470d049cfa368a179a2c021153e93a922c5a/rmscene-0.6.1.tar.gz", hash = "sha256:82f7797bdfa407f9ad27245e7333a7c6e81f8da3390a4f9d9d89736643fe163c", size = 22790, upload-time = "2024-12-03T21:21:57.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/dd/2ec964e1f5e007e3b6492e3aace7bfdb58422d6770a2cda08988068089bf/rmscene-0.8.0.tar.gz", hash = "sha256:db9417a6b8cc86e80c1be8cefa29cec24d4d49777433d49d1fc741773f10d5be", size = 23794, upload-time = "2026-04-05T14:56:59.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/77/4de4d4e0203d83288d33b4e448aafbe9aff6fe4deeb344f28c1cca901b98/rmscene-0.6.1-py3-none-any.whl", hash = "sha256:9cd50ae8eede26e3263d78102db880644d39dcc6a5376d38627c060e47bf9045", size = 25316, upload-time = "2024-12-03T21:21:56.043Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/c98189fa471986c13acb35dbce444345e05d8b58096b4457c1c4b3494443/rmscene-0.8.0-py3-none-any.whl", hash = "sha256:78f2bb8a746ceb6428005aa5fcb576eb7cf10ad537d043c49659c950633b01d1", size = 26765, upload-time = "2026-04-05T14:56:58.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Rendering handwritten notebooks fails on current reMarkable firmware (#95): `rmscene` throws a parse error on the newer `.rm` scene format (`SceneInfo` `block_type=13`, *"newer format than this reader supports"*).

**Root cause:** `rmc>=0.3.0` transitively pins `rmscene>=0.6.0,<0.7.0`. The repo's own `_render_rm_v6_to_svg` fallback already existed, but ran against that too-old `rmscene`, so it failed too. This is most visible in **cloud mode**, where pure handwritten notebooks have no source PDF for the PyMuPDF rasterization fallback to rely on.

## Changes

- **`pyproject.toml`**: drop `rmc`, bump `rmscene>=0.8.0`.
- **`remarkable_mcp/extract.py`**: `_rm_to_svg` now calls the built-in `_render_rm_v6_to_svg` / `_render_rm_v5_to_svg` renderers directly (v6 first, the current format). Removed the dead `rmc` subprocess path + `_rmc_executable` helper and scrubbed stale *"uses rmc"* comments/docstrings.
- **`test_server.py`**: replaced the rmc-binary-resolution suite with renderer tests — a **v6 fixture synthesized via rmscene's own writer** (also exercises the 0.8.0 read/write round-trip), the v5 path, a garbage-input guard, and an assertion that `rmc` is gone / `rmscene>=0.8.0`.

## Validation

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run pytest test_server.py -v` — **139 passed**
- **Live**: rendered 6 real current-firmware cloud notebooks (incl. pure v6) → all produced non-empty PNGs (112–158 KB), where the pinned 0.6.x returns nothing.

## Credit

Implements the approach proposed by @khalid-hasan in #97 (credited via `Co-authored-by`). Closes #95.

Co-authored-by: khalid-hasan <38977344+khalid-hasan@users.noreply.github.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>