### PR TITLE
feat: cloud fallback when device transport is unreachable at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ All three modes share the same read, render, and upload tools. **Cloud and SSH a
 
 ¹ Folder ops = create folder / move / rename / delete. Upload and folder ops require the `--write` flag (off by default). Deletes move items to the trash and can prompt for confirmation when your client supports elicitation.
 
+### Automatic cloud fallback
+
+If you select a device transport (`--usb` or `--ssh`) but the tablet isn't reachable at startup **and** a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server automatically falls back to cloud mode and logs a warning. This means a single configuration works whether or not the tablet is plugged in — plug in for fast local access, unplug to keep working over the cloud. `remarkable_status` reports the effective transport and a `fell_back_to_cloud` flag when this happens.
+
+Pass `--no-cloud-fallback` (or set `REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) to disable this and fail instead when the device is unreachable.
+
 **📖 Detailed Setup Guides:**
 - [USB Web Interface Setup](docs/usb-web-setup.md) — **recommended** — simple setup, full feature support
 - [SSH Setup Guide](docs/ssh-setup.md) — for advanced users who need filesystem access

--- a/remarkable_mcp/api.py
+++ b/remarkable_mcp/api.py
@@ -3,10 +3,13 @@ reMarkable Cloud API client helpers.
 """
 
 import json as json_module
+import logging
 import os
 import threading
 from pathlib import Path
 from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
 
 # Configuration - check env var first, then fall back to file
 REMARKABLE_TOKEN = os.environ.get("REMARKABLE_TOKEN")
@@ -16,6 +19,18 @@ REMARKABLE_USE_SSH = os.environ.get("REMARKABLE_USE_SSH", "").lower() in (
     "yes",
 )
 REMARKABLE_USE_USB_WEB = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+# When a device transport (USB web / SSH) is selected but the tablet is not
+# reachable at startup, automatically fall back to cloud mode if a cloud token
+# is configured. This lets the *same* configuration work whether or not the
+# physical device is connected. Set REMARKABLE_DISABLE_CLOUD_FALLBACK=1 to
+# keep the strict behaviour (fail instead of falling back).
+REMARKABLE_DISABLE_CLOUD_FALLBACK = os.environ.get(
+    "REMARKABLE_DISABLE_CLOUD_FALLBACK", ""
+).lower() in (
     "1",
     "true",
     "yes",
@@ -32,39 +47,53 @@ _cloud_client = None
 _cloud_client_key = None
 _cloud_client_lock = threading.Lock()
 
+# Process-level cache for the device-transport resolution. Resolving the
+# transport probes the device once (USB/SSH check_connection), so we cache the
+# outcome to avoid re-probing on every tool call. `_fell_back_to_cloud` records
+# that a device transport was selected but unreachable and we switched to cloud.
+_device_client = None
+_fell_back_to_cloud = False
+_device_resolve_lock = threading.Lock()
+
 
 def reset_client_cache() -> None:
-    """Clear the cached cloud client (e.g. after re-registering a token)."""
+    """Clear the cached clients (e.g. after re-registering a token)."""
     global _cloud_client, _cloud_client_key
+    global _device_client, _fell_back_to_cloud
     with _cloud_client_lock:
         _cloud_client = None
         _cloud_client_key = None
+    with _device_resolve_lock:
+        _device_client = None
+        _fell_back_to_cloud = False
 
 
-def get_rmapi():
+def _is_cloud_token_available() -> bool:
+    """Return True if a cloud token is configured (env var or saved file)."""
+    if REMARKABLE_TOKEN:
+        return True
+    return (Path.home() / ".rmapi").exists()
+
+
+def _safe_check_connection(client) -> bool:
+    """Probe a device client's reachability without raising.
+
+    Returns True when the client has no ``check_connection`` (can't probe, so
+    assume usable) or the probe succeeds; False when the probe returns falsy or
+    raises (network/subprocess failure => treat the device as unreachable).
     """
-    Get or initialize the reMarkable API client.
+    check = getattr(client, "check_connection", None)
+    if not callable(check):
+        return True
+    try:
+        return bool(check())
+    except Exception as e:
+        logger.debug("Device connectivity probe failed: %s", e)
+        return False
 
-    Priority order:
-    1. USB web interface (if REMARKABLE_USE_USB_WEB=1)
-    2. SSH (if REMARKABLE_USE_SSH=1)
-    3. Cloud API (default, requires token)
 
-    Returns RemarkableClient, SSHClient, or USBWebClient (all have compatible interfaces).
-    """
-    # Try USB web interface first (no auth required)
-    if REMARKABLE_USE_USB_WEB:
-        from remarkable_mcp.usb_web import create_usb_web_client
-
-        return create_usb_web_client()
-
-    # Check if SSH mode is enabled
-    if REMARKABLE_USE_SSH:
-        from remarkable_mcp.ssh import create_ssh_client
-
-        return create_ssh_client()
-
-    # Cloud API mode
+def _get_cloud_client():
+    """Resolve (and cache) the cloud client from the configured token."""
     from remarkable_mcp.sync import load_client_from_token
 
     # Resolve the token: env var wins, else the saved ~/.rmapi file.
@@ -99,6 +128,86 @@ def get_rmapi():
             _cloud_client = load_client_from_token(token_json)
             _cloud_client_key = token_json
         return _cloud_client
+
+
+def get_rmapi():
+    """
+    Get or initialize the reMarkable API client.
+
+    Priority order:
+    1. USB web interface (if REMARKABLE_USE_USB_WEB=1)
+    2. SSH (if REMARKABLE_USE_SSH=1)
+    3. Cloud API (default, requires token)
+
+    When a device transport (USB/SSH) is selected but the tablet is unreachable
+    at startup, this falls back to cloud mode if a cloud token is configured
+    (unless REMARKABLE_DISABLE_CLOUD_FALLBACK is set), so the same configuration
+    works with or without the physical device connected.
+
+    Returns RemarkableClient, SSHClient, or USBWebClient (all have compatible interfaces).
+    """
+    global _device_client, _fell_back_to_cloud
+
+    # Device transports (USB web / SSH) — probe once, cache the resolution, and
+    # optionally fall back to cloud if the device is unreachable.
+    if REMARKABLE_USE_USB_WEB or REMARKABLE_USE_SSH:
+        with _device_resolve_lock:
+            if _fell_back_to_cloud:
+                return _get_cloud_client()
+            if _device_client is not None:
+                return _device_client
+
+            if REMARKABLE_USE_USB_WEB:
+                from remarkable_mcp.usb_web import create_usb_web_client
+
+                client = create_usb_web_client()
+                mode_label = "USB web interface"
+            else:
+                from remarkable_mcp.ssh import create_ssh_client
+
+                client = create_ssh_client()
+                mode_label = "SSH"
+
+            if _safe_check_connection(client):
+                _device_client = client
+                return client
+
+            # Device unreachable — fall back to cloud if allowed and possible.
+            if not REMARKABLE_DISABLE_CLOUD_FALLBACK and _is_cloud_token_available():
+                logger.warning(
+                    "%s is not reachable; falling back to cloud mode because a "
+                    "cloud token is configured. Set "
+                    "REMARKABLE_DISABLE_CLOUD_FALLBACK=1 to disable this fallback.",
+                    mode_label,
+                )
+                _fell_back_to_cloud = True
+                return _get_cloud_client()
+
+            # No fallback: return the (unreachable) device client so its own
+            # operation errors surface, and don't cache it so a later call
+            # works once the device is connected.
+            return client
+
+    # Cloud API mode (default).
+    return _get_cloud_client()
+
+
+def get_active_transport() -> str:
+    """Return the transport actually in use ("cloud", "ssh", or "usb-web").
+
+    Reflects the resolution performed by get_rmapi(): if a device transport was
+    selected but the tablet was unreachable and we fell back to cloud, this
+    returns "cloud". Note the fallback decision is only made once get_rmapi()
+    has been called, so callers should resolve the client first if they need an
+    accurate post-fallback value.
+    """
+    if _fell_back_to_cloud:
+        return "cloud"
+    if REMARKABLE_USE_USB_WEB:
+        return "usb-web"
+    if REMARKABLE_USE_SSH:
+        return "ssh"
+    return "cloud"
 
 
 def ensure_config_dir():

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -97,6 +97,16 @@ Security Note:
             "Cloud and SSH support all of them; USB web supports upload only."
         ),
     )
+    parser.add_argument(
+        "--no-cloud-fallback",
+        action="store_true",
+        help=(
+            "Disable the automatic cloud fallback. By default, if --usb/--ssh is "
+            "selected but the tablet is unreachable at startup and a cloud token "
+            "is configured, the server falls back to cloud mode so the same "
+            "configuration works with or without the device connected."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -136,6 +146,8 @@ Security Note:
         os.environ["REMARKABLE_USE_USB_WEB"] = "1"
         if args.write:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+        if args.no_cloud_fallback:
+            os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
         from remarkable_mcp.server import run
 
         run()
@@ -146,6 +158,8 @@ Security Note:
             os.environ["REMARKABLE_SSH_KEY"] = args.ssh_key
         if args.write:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+        if args.no_cloud_fallback:
+            os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
         from remarkable_mcp.server import run
 
         run()

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1305,14 +1305,18 @@ async def remarkable_status() -> str:
     """
     import os
 
-    from remarkable_mcp.api import REMARKABLE_USE_SSH, REMARKABLE_USE_USB_WEB
+    from remarkable_mcp.api import (
+        REMARKABLE_USE_SSH,
+        REMARKABLE_USE_USB_WEB,
+        get_active_transport,
+    )
     from remarkable_mcp.write_tools import write_enabled
 
-    # Determine transport mode
+    # Determine the *selected* transport from configuration (pre-fallback).
     if REMARKABLE_USE_USB_WEB:
         from remarkable_mcp.usb_web import DEFAULT_USB_HOST
 
-        transport = "usb-web"
+        selected_transport = "usb-web"
         usb_host = os.environ.get("REMARKABLE_USB_HOST", DEFAULT_USB_HOST)
         connection_info = f"USB web interface at {usb_host}"
     elif REMARKABLE_USE_SSH:
@@ -1322,13 +1326,13 @@ async def remarkable_status() -> str:
             DEFAULT_SSH_USER,
         )
 
-        transport = "ssh"
+        selected_transport = "ssh"
         ssh_host = os.environ.get("REMARKABLE_SSH_HOST", DEFAULT_SSH_HOST)
         ssh_user = os.environ.get("REMARKABLE_SSH_USER", DEFAULT_SSH_USER)
         ssh_port = int(os.environ.get("REMARKABLE_SSH_PORT", str(DEFAULT_SSH_PORT)))
         connection_info = f"SSH to {ssh_user}@{ssh_host}:{ssh_port}"
     else:
-        transport = "cloud"
+        selected_transport = "cloud"
         connection_info = "environment variable" if REMARKABLE_TOKEN else "file (~/.rmapi)"
 
     # What each transport is capable of (independent of whether --write is on).
@@ -1363,16 +1367,19 @@ async def remarkable_status() -> str:
         },
     }
     writes_on = write_enabled()
-    # Effective capabilities for the active transport: write ops only count when
-    # the --write flag is enabled.
-    transport_caps = capability_matrix[transport]
-    effective_caps = {
-        cap: (supported if cap in ("read", "render") else supported and writes_on)
-        for cap, supported in transport_caps.items()
-    }
+    transport = selected_transport
 
     try:
         client = get_rmapi()
+        # Reflect any startup fallback to cloud (device unreachable + token set).
+        transport = get_active_transport()
+        fell_back = transport != selected_transport
+        if fell_back:
+            connection_info = (
+                f"cloud (fell back from {selected_transport}: device unreachable, "
+                "cloud token configured)"
+            )
+
         collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
@@ -1387,6 +1394,14 @@ async def remarkable_status() -> str:
             if _is_within_root(item_path, root):
                 doc_count += 1
 
+        # Effective capabilities for the active transport: write ops only count
+        # when the --write flag is enabled.
+        transport_caps = capability_matrix[transport]
+        effective_caps = {
+            cap: (supported if cap in ("read", "render") else supported and writes_on)
+            for cap, supported in transport_caps.items()
+        }
+
         result = {
             "authenticated": True,
             "transport": transport,
@@ -1397,12 +1412,20 @@ async def remarkable_status() -> str:
             "capabilities": effective_caps,
             "capabilities_by_transport": capability_matrix,
         }
+        if fell_back:
+            result["fell_back_to_cloud"] = True
 
         # Add root path info if configured
         if root != "/":
             result["root_path"] = root
 
         hint_parts = [f"Connected successfully via {transport}. Found {doc_count} documents."]
+        if fell_back:
+            hint_parts.append(
+                f"Note: {selected_transport} was selected but not reachable, so it "
+                "fell back to cloud (a cloud token is configured). Set "
+                "REMARKABLE_DISABLE_CLOUD_FALLBACK=1 to disable this."
+            )
         if root != "/":
             hint_parts.append(f"Filtered to root: {root}")
         if writes_on:
@@ -1426,6 +1449,8 @@ async def remarkable_status() -> str:
 
     except Exception as e:
         error_msg = str(e)
+        # Reflect fallback in the reported transport when one occurred.
+        transport = get_active_transport()
 
         result = {
             "authenticated": False,
@@ -1436,7 +1461,7 @@ async def remarkable_status() -> str:
             "capabilities_by_transport": capability_matrix,
         }
 
-        if REMARKABLE_USE_SSH:
+        if transport == "ssh":
             hint = (
                 "SSH connection failed. Make sure:\n"
                 "1) Developer mode / SSH is enabled on your tablet\n"
@@ -1445,7 +1470,7 @@ async def remarkable_status() -> str:
                 "See: https://remarkable.guide/guide/access/ssh.html\n\n"
                 "Or use cloud mode instead (remove --ssh flag) — no device needed."
             )
-        elif REMARKABLE_USE_USB_WEB:
+        elif transport == "usb-web":
             hint = (
                 "USB web interface not reachable. Make sure:\n"
                 "1) Your reMarkable is connected via USB\n"

--- a/test_server.py
+++ b/test_server.py
@@ -325,6 +325,32 @@ class TestRemarkableStatus:
         # Hint should include registration instructions or SSH mode
         assert "register" in data["_hint"].lower() or "ssh" in data["_hint"].lower()
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_status_reports_cloud_after_fallback(self, mock_get_rmapi, monkeypatch):
+        """When USB/SSH falls back to cloud, status reports the effective transport."""
+        import remarkable_mcp.api as api
+
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", False)
+        # Simulate that get_rmapi() already resolved to a cloud fallback.
+        monkeypatch.setattr(api, "get_active_transport", lambda: "cloud")
+
+        mock_client = Mock()
+        mock_client.get_meta_items.return_value = []
+        mock_get_rmapi.return_value = mock_client
+
+        result = await mcp.call_tool("remarkable_status", {})
+        data = json.loads(result[0][0].text)
+
+        assert data["authenticated"] is True
+        assert data["transport"] == "cloud"
+        assert data["fell_back_to_cloud"] is True
+        # Effective capabilities reflect cloud (full write surface when enabled).
+        assert data["capabilities"]["read"] is True
+        assert "usb-web" in data["_hint"]  # mentions what it fell back from
+        assert "fell back" in data["_hint"].lower()
+
 
 # =============================================================================
 # Test remarkable_browse Tool
@@ -3184,6 +3210,124 @@ class TestCloudClientCache:
         third = api.get_rmapi()
         assert third is not first
         assert len(created) == 2
+
+
+class TestCloudStartupFallback:
+    """USB/SSH selected but unreachable should fall back to cloud when a token exists."""
+
+    @staticmethod
+    def _device_client(reachable):
+        client = Mock(name="device")
+        client.check_connection = Mock(return_value=reachable)
+        return client
+
+    def _setup_cloud(self, monkeypatch, tmp_path, token):
+        """Redirect HOME, set the cloud token, and stub the cloud client loader."""
+        import remarkable_mcp.api as api
+
+        monkeypatch.setattr(api.Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(api, "REMARKABLE_TOKEN", token)
+        cloud = Mock(name="cloud")
+        monkeypatch.setattr("remarkable_mcp.sync.load_client_from_token", lambda token_json: cloud)
+        return api, cloud
+
+    def test_usb_unreachable_falls_back_to_cloud(self, monkeypatch, tmp_path):
+        api, cloud = self._setup_cloud(monkeypatch, tmp_path, '{"devicetoken": "d"}')
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", False)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", False)
+
+        device = self._device_client(reachable=False)
+        creations = []
+
+        def factory():
+            creations.append(1)
+            return device
+
+        monkeypatch.setattr("remarkable_mcp.usb_web.create_usb_web_client", factory)
+
+        api.reset_client_cache()
+        try:
+            result = api.get_rmapi()
+            assert result is cloud
+            assert api.get_active_transport() == "cloud"
+            # Resolution is cached: the device is probed once, later calls return
+            # the cloud client directly without re-probing.
+            assert api.get_rmapi() is cloud
+            assert len(creations) == 1
+            device.check_connection.assert_called_once()
+        finally:
+            api.reset_client_cache()
+
+    def test_ssh_unreachable_falls_back_to_cloud_via_file_token(self, monkeypatch, tmp_path):
+        # Token available via ~/.rmapi file rather than the env var.
+        api, cloud = self._setup_cloud(monkeypatch, tmp_path, None)
+        (tmp_path / ".rmapi").write_text('{"devicetoken": "d"}')
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", False)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", False)
+
+        device = self._device_client(reachable=False)
+        monkeypatch.setattr("remarkable_mcp.ssh.create_ssh_client", lambda: device)
+
+        api.reset_client_cache()
+        try:
+            assert api.get_rmapi() is cloud
+            assert api.get_active_transport() == "cloud"
+        finally:
+            api.reset_client_cache()
+
+    def test_device_reachable_no_fallback(self, monkeypatch, tmp_path):
+        api, cloud = self._setup_cloud(monkeypatch, tmp_path, '{"devicetoken": "d"}')
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", False)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", False)
+
+        device = self._device_client(reachable=True)
+        monkeypatch.setattr("remarkable_mcp.usb_web.create_usb_web_client", lambda: device)
+
+        api.reset_client_cache()
+        try:
+            assert api.get_rmapi() is device
+            assert api.get_active_transport() == "usb-web"
+        finally:
+            api.reset_client_cache()
+
+    def test_no_token_no_fallback_returns_device(self, monkeypatch, tmp_path):
+        # No env token and an empty HOME => no cloud token => cannot fall back.
+        api, cloud = self._setup_cloud(monkeypatch, tmp_path, None)
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", False)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", False)
+
+        device = self._device_client(reachable=False)
+        monkeypatch.setattr("remarkable_mcp.usb_web.create_usb_web_client", lambda: device)
+
+        api.reset_client_cache()
+        try:
+            # Returns the unreachable device client so its own errors surface;
+            # the unreachable client is NOT cached, so a later call can succeed
+            # once the device is connected.
+            assert api.get_rmapi() is device
+            assert api.get_active_transport() == "usb-web"
+        finally:
+            api.reset_client_cache()
+
+    def test_fallback_disabled_returns_device(self, monkeypatch, tmp_path):
+        api, cloud = self._setup_cloud(monkeypatch, tmp_path, '{"devicetoken": "d"}')
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", False)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", True)
+
+        device = self._device_client(reachable=False)
+        monkeypatch.setattr("remarkable_mcp.ssh.create_ssh_client", lambda: device)
+
+        api.reset_client_cache()
+        try:
+            assert api.get_rmapi() is device
+            assert api.get_active_transport() == "ssh"
+        finally:
+            api.reset_client_cache()
 
 
 class TestSSHKeyAuth:


### PR DESCRIPTION
## Summary

Lets the **same configuration work with or without the physical tablet connected**. If you start with `--usb` or `--ssh` but the device isn't reachable at startup, and a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server now probes the device once and transparently **falls back to cloud mode** with a clear warning — instead of failing.

Requested by @SamMorrowDrums: *"schedule a fallback where if the cloud key is provided, and you have an alternative mode selected, on startup it'll revert to cloud rather than fail … so the same configuration can work with and without the physical device."*

## Behaviour

- **Device reachable** → use it (no change).
- **Device unreachable + cloud token present** → fall back to cloud (default), logged as a warning.
- **Device unreachable + no token** → return the device client so its own error surfaces (unchanged from today; not cached, so it works once you plug in).
- **Opt out**: `--no-cloud-fallback` flag or `REMARKABLE_DISABLE_CLOUD_FALLBACK=1` → strict behaviour (fail instead of falling back).

The device probe (`check_connection`) runs **once per process** and the resolution is cached, so there's no per-call latency. `check_connection` already fails fast (USB 10s request timeout / SSH 5s command timeout).

## Changes

- **api.py**: extract `_get_cloud_client()`; add `_is_cloud_token_available()`, `_safe_check_connection()`, and `get_active_transport()`; cache the device-transport resolution + fallback decision; `reset_client_cache()` clears both.
- **tools.py**: `remarkable_status` now reports the **effective** transport after any fallback, adds a `fell_back_to_cloud` flag and an explanatory hint, and picks error hints by effective transport.
- **cli.py**: `--no-cloud-fallback` flag.
- **README**: documents the fallback + opt-out under Connection Modes.
- **tests**: 6 new (5 `get_rmapi` fallback cases — usb/ssh fallback, env vs file token, device reachable, no token, fallback disabled — plus status-after-fallback).

## Validation

`uv run ruff check .`, `uv run ruff format --check .`, `uv run pytest test_server.py` — all green (**145 passed**).