### PR TITLE
feat: opt-in MCP Apps interactive canvas viewer (read-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. Opt-in **write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are also available with the `--write` flag — see [Write Tools](#write-tools-cloud-ssh--usb-web).
+These six tools are **read-only** and return structured JSON with hints for next actions. Opt-in **write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are also available with the `--write` flag — see [Write Tools](#write-tools-cloud-ssh--usb-web). An optional interactive **canvas app** (`remarkable_canvas`) is available with the `--app` flag — see [Interactive Canvas App](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -519,6 +519,41 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 # Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
 ```
+
+---
+
+## Interactive Canvas App (MCP Apps)
+
+An optional interactive page viewer built on the [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) extension (SEP-1865). When enabled, clients that support MCP Apps (such as ChatGPT, Claude, VS Code, and the MCP Inspector) render a canvas in a side panel where you can view a document page and navigate through it. It is **opt-in** and off by default.
+
+Enable it with the `--app` flag (works in any transport):
+
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--app"]
+    }
+  }
+}
+```
+
+This registers one tool:
+
+| Tool | Description |
+|------|-------------|
+| `remarkable_canvas(document, page)` | Open a page in the interactive canvas viewer |
+
+How it behaves:
+
+- **App-capable clients** open the canvas (declared at `ui://remarkable/canvas`, MIME `text/html;profile=mcp-app`) and can page through the document via the MCP Apps postMessage bridge — the server delivers each rendered page in the tool result's `structuredContent`.
+- **Other clients** still get the rendered page back as an embedded PNG image, so the tool is useful everywhere; it just won't open the interactive panel. The capability is negotiated automatically — there is no separate feature gate beyond `--app`.
+
+> **Note:** This phase is a **read-only** viewer (render + page navigation). Pen
+> capture, local undo, and an explicit Save button that writes annotations back
+> to the device are planned as later, device-validated phases. The iframe bridge
+> follows the MCP Apps spec but is best validated against your specific client.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.27.0",
     "rmscene>=0.8.0",
     "pytesseract>=0.3.10",
     "Pillow>=10.0.0",

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -1,0 +1,464 @@
+"""
+Interactive MCP App canvas for reMarkable documents (SEP-1865 "MCP Apps").
+
+This is opt-in and disabled by default. Enable via:
+- CLI flag: remarkable-mcp --app  (works in any transport)
+- Environment variable: REMARKABLE_ENABLE_APP=1
+
+When enabled, the server registers:
+- An HTML app resource at ``ui://remarkable/canvas`` (MIME
+  ``text/html;profile=mcp-app``) that the client renders in a sandboxed iframe.
+- A ``remarkable_canvas`` tool whose ``_meta.ui.resourceUri`` points at that
+  resource, so app-capable clients open the viewer and feed it page data over
+  the MCP Apps postMessage bridge.
+
+This phase is a **read-only** viewer (render + page navigation). Pen capture,
+local undo, and an explicit Save button that writes strokes back to the device
+are tracked as later, device-validated phases and are intentionally not wired
+here. The tool degrades gracefully: clients that do not advertise the MCP Apps
+UI extension still receive the rendered page as an embedded image, so it is
+useful everywhere.
+"""
+
+import base64
+import logging
+import os
+from typing import Optional
+
+from mcp import types
+from mcp.server.fastmcp import Context
+
+from remarkable_mcp.capabilities import APP_UI_MIME, client_supports_apps
+from remarkable_mcp.server import mcp
+
+logger = logging.getLogger(__name__)
+
+# Resource URI for the canvas app (referenced by the tool's _meta.ui.resourceUri).
+CANVAS_RESOURCE_URI = "ui://remarkable/canvas"
+
+# Read-only viewer annotations (no device mutation in this phase).
+CANVAS_ANNOTATIONS = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+
+
+def app_enabled() -> bool:
+    """Check if the interactive MCP App canvas is enabled."""
+    return os.environ.get("REMARKABLE_ENABLE_APP", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+# The canvas app: a self-contained, dependency-free HTML/JS surface that speaks
+# the MCP Apps postMessage bridge (JSON-RPC 2.0). It renders the page PNG that
+# the server delivers in the tool result's structuredContent and lets the user
+# page through the document by calling the remarkable_canvas tool back over the
+# bridge. Kept vanilla on purpose: no build step, no external assets, no CSP
+# headaches. The bridge wiring follows SEP-1865 and still needs validation
+# against a real app host (ChatGPT/Claude/VS Code/Inspector).
+_CANVAS_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>reMarkable Canvas</title>
+<style>
+  :root { color-scheme: light dark; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    display: flex; flex-direction: column; background: #1e1e1e; color: #e8e8e8;
+  }
+  header {
+    display: flex; align-items: center; gap: .5rem; padding: .5rem .75rem;
+    border-bottom: 1px solid rgba(255,255,255,.12); flex: 0 0 auto;
+  }
+  header .title { font-weight: 600; flex: 1 1 auto; overflow: hidden;
+    text-overflow: ellipsis; white-space: nowrap; }
+  button {
+    font: inherit; padding: .35rem .7rem; border-radius: .4rem; cursor: pointer;
+    border: 1px solid rgba(255,255,255,.2); background: #2d2d2d; color: inherit;
+  }
+  button:disabled { opacity: .4; cursor: default; }
+  .pageinfo { font-variant-numeric: tabular-nums; min-width: 5rem; text-align: center; }
+  main { flex: 1 1 auto; overflow: auto; display: flex; align-items: flex-start;
+    justify-content: center; padding: 1rem; }
+  img { max-width: 100%; height: auto; background: #fbfbfb;
+    box-shadow: 0 1px 8px rgba(0,0,0,.4); border-radius: 2px; }
+  .status { padding: 1rem; opacity: .8; }
+  footer { flex: 0 0 auto; padding: .35rem .75rem; font-size: .8rem; opacity: .6;
+    border-top: 1px solid rgba(255,255,255,.12); }
+</style>
+</head>
+<body>
+  <header>
+    <span class="title" id="title">reMarkable Canvas</span>
+    <button id="prev" disabled>&larr; Prev</button>
+    <span class="pageinfo" id="pageinfo">--</span>
+    <button id="next" disabled>Next &rarr;</button>
+    <button id="full">Fullscreen</button>
+  </header>
+  <main><div class="status" id="status">Loading&hellip;</div></main>
+  <footer id="footer">Read-only viewer</footer>
+<script>
+(function () {
+  "use strict";
+  var pending = {}, rpcId = 1;
+  var state = { document: null, page: 1, total: 1, busy: false };
+
+  function post(msg) {
+    try { window.parent.postMessage(msg, "*"); } catch (e) {}
+  }
+  function rpc(method, params) {
+    return new Promise(function (resolve, reject) {
+      var id = rpcId++;
+      pending[id] = { resolve: resolve, reject: reject };
+      post({ jsonrpc: "2.0", id: id, method: method, params: params || {} });
+    });
+  }
+  function notify(method, params) {
+    post({ jsonrpc: "2.0", method: method, params: params || {} });
+  }
+
+  function setStatus(text) {
+    document.querySelector("main").innerHTML =
+      '<div class="status">' + text + "</div>";
+  }
+  function digOut(payload) {
+    // The host may deliver the CallToolResult directly or wrapped in params.
+    if (!payload) return null;
+    if (payload.structuredContent) return payload.structuredContent;
+    if (payload.result && payload.result.structuredContent)
+      return payload.result.structuredContent;
+    if (payload.toolResult && payload.toolResult.structuredContent)
+      return payload.toolResult.structuredContent;
+    return null;
+  }
+  function render(data) {
+    if (!data) return;
+    if (data.error) { setStatus("Error: " + data.error); return; }
+    if (data.document) state.document = data.document;
+    if (data.page) state.page = data.page;
+    if (data.total_pages) state.total = data.total_pages;
+    document.getElementById("title").textContent =
+      data.document_name || data.document || "reMarkable Canvas";
+    document.getElementById("pageinfo").textContent =
+      state.page + " / " + state.total;
+    document.getElementById("prev").disabled = state.busy || state.page <= 1;
+    document.getElementById("next").disabled =
+      state.busy || state.page >= state.total;
+    if (data.png_data_uri) {
+      var m = document.querySelector("main");
+      m.innerHTML = "";
+      var img = document.createElement("img");
+      img.src = data.png_data_uri;
+      img.alt = "Page " + state.page;
+      m.appendChild(img);
+    }
+    notifySize();
+  }
+  function notifySize() {
+    var h = document.body.scrollHeight, w = document.body.scrollWidth;
+    notify("ui/notifications/size-changed", { width: w, height: h });
+  }
+
+  function goto(page) {
+    if (state.busy || !state.document) return;
+    if (page < 1 || page > state.total) return;
+    state.busy = true;
+    render({});
+    rpc("tools/call", {
+      name: "remarkable_canvas",
+      arguments: { document: state.document, page: page },
+    }).then(function (result) {
+      state.busy = false;
+      render(digOut(result) || {});
+    }).catch(function (err) {
+      state.busy = false;
+      setStatus("Failed to load page: " + (err && err.message ? err.message : err));
+    });
+  }
+
+  document.getElementById("prev").onclick = function () { goto(state.page - 1); };
+  document.getElementById("next").onclick = function () { goto(state.page + 1); };
+  document.getElementById("full").onclick = function () {
+    rpc("ui/request-display-mode", { mode: "fullscreen" }).catch(function () {});
+  };
+
+  window.addEventListener("message", function (event) {
+    var msg = event.data;
+    if (!msg || msg.jsonrpc !== "2.0") return;
+    if (msg.id !== undefined && (("result" in msg) || ("error" in msg))) {
+      var p = pending[msg.id];
+      if (p) {
+        delete pending[msg.id];
+        if (msg.error) p.reject(msg.error); else p.resolve(msg.result);
+      }
+      return;
+    }
+    if (msg.method === "ui/notifications/tool-result" ||
+        msg.method === "ui/notifications/tool-input") {
+      render(digOut(msg.params) || {});
+    }
+  });
+
+  // Handshake: announce the app and the display modes it can use, then signal
+  // that we are ready to receive tool input/results.
+  rpc("ui/initialize", {
+    appCapabilities: { availableDisplayModes: ["inline", "fullscreen"] },
+  }).then(function (res) {
+    notify("ui/notifications/initialized", {});
+    var d = digOut(res);
+    if (d) render(d);
+  }).catch(function () {
+    // Some hosts push tool-input/result without a handshake reply; that's fine.
+    notify("ui/notifications/initialized", {});
+  });
+})();
+</script>
+</body>
+</html>
+"""
+
+
+async def _render_canvas_page(document: str, page: int, ctx: Optional[Context]):
+    """Resolve a document, render the requested page, and build the app payload.
+
+    Returns a CallToolResult carrying both an embedded PNG (so non-app clients
+    still see the page) and structuredContent (the data the canvas app reads).
+    On failure returns a make_error JSON string. Mirrors remarkable_image by
+    converting unexpected transport/auth errors into structured guidance rather
+    than letting them surface as a bare exception string.
+    """
+    from remarkable_mcp.responses import make_error
+
+    try:
+        return await _render_canvas_page_impl(document, page, ctx)
+    except Exception as e:
+        logger.exception("Canvas render failed")
+        return make_error(
+            error_type="canvas_failed",
+            message=f"Failed to open canvas for '{document}': {e}",
+            suggestion=(
+                "Check remarkable_status() for connection/auth, then retry. "
+                "You can also use remarkable_image to view the page directly."
+            ),
+        )
+
+
+async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Context]):
+    """Implementation behind _render_canvas_page (see that wrapper for errors)."""
+    # Imported lazily to avoid any import-order coupling with tools.py, which is
+    # imported before this module is registered.
+    import tempfile
+    from pathlib import Path
+
+    from remarkable_mcp.api import (
+        download_raw_file,
+        get_active_transport,
+        get_item_path,
+        get_items_by_id,
+        get_rmapi,
+    )
+    from remarkable_mcp.concurrency import run_blocking
+    from remarkable_mcp.extract import (
+        find_similar_documents,
+        get_background_color,
+        get_document_page_count,
+        render_page_from_document_zip,
+        render_tablet_pdf_page_to_png,
+    )
+    from remarkable_mcp.responses import make_error
+    from remarkable_mcp.tools import (
+        _apply_root_filter,
+        _get_root_path,
+        _is_within_root,
+        _resolve_root_path,
+    )
+
+    background = await run_blocking(get_background_color)
+    client = get_rmapi()
+    collection = await run_blocking(client.get_meta_items)
+    items_by_id = get_items_by_id(collection)
+
+    root = _get_root_path()
+    actual_document = _resolve_root_path(document) if document.startswith("/") else document
+
+    documents = [item for item in collection if not item.is_folder]
+    target_doc = None
+    document_lower = actual_document.lower().strip("/")
+    for doc in documents:
+        doc_path = get_item_path(doc, items_by_id)
+        if not _is_within_root(doc_path, root):
+            continue
+        if doc.VissibleName.lower() == document_lower:
+            target_doc = doc
+            break
+        if doc_path.lower().strip("/") == document_lower:
+            target_doc = doc
+            break
+
+    if not target_doc:
+        filtered_docs = [
+            doc for doc in documents if _is_within_root(get_item_path(doc, items_by_id), root)
+        ]
+        similar = find_similar_documents(document, filtered_docs)
+        search_term = document.split()[0] if document else "notes"
+        return make_error(
+            error_type="document_not_found",
+            message=f"Document not found: '{document}'",
+            suggestion=(
+                f"Try remarkable_browse(query='{search_term}') to search, "
+                "or remarkable_browse('/') to list all files."
+            ),
+            did_you_mean=similar if similar else None,
+        )
+
+    raw_doc = await run_blocking(client.download, target_doc)
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp.write(raw_doc)
+        tmp_path = Path(tmp.name)
+
+    try:
+        total_pages = await run_blocking(get_document_page_count, tmp_path)
+        if total_pages == 0:
+            return make_error(
+                error_type="no_pages",
+                message=f"Document '{target_doc.VissibleName}' has no renderable pages.",
+                suggestion=(
+                    "This may be a PDF/EPUB without annotations. "
+                    "Use remarkable_read() to extract text content instead."
+                ),
+            )
+        if page < 1 or page > total_pages:
+            return make_error(
+                error_type="page_out_of_range",
+                message=f"Page {page} does not exist. Document has {total_pages} page(s).",
+                suggestion=f"Use page=1 to {total_pages} to view different pages.",
+            )
+
+        png_data = await run_blocking(
+            render_page_from_document_zip, tmp_path, page, background_color=background
+        )
+        render_source = "strokes"
+        if png_data is None:
+            pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
+            if pdf_bytes:
+                png_data = await run_blocking(render_tablet_pdf_page_to_png, pdf_bytes, page)
+                if png_data is not None:
+                    render_source = "tablet_pdf"
+
+        if png_data is None:
+            return make_error(
+                error_type="render_failed",
+                message="Failed to render page to image.",
+                suggestion=(
+                    "The page may be empty, or local rendering dependencies may be "
+                    "missing. Try remarkable_read() to extract text instead."
+                ),
+            )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    doc_path = _apply_root_filter(get_item_path(target_doc, items_by_id))
+    png_base64 = base64.b64encode(png_data).decode("utf-8")
+    data_uri = f"data:image/png;base64,{png_base64}"
+
+    width_px = height_px = None
+    try:
+        import io
+
+        from PIL import Image
+
+        with Image.open(io.BytesIO(png_data)) as im:
+            width_px, height_px = im.size
+    except Exception:
+        pass
+
+    structured = {
+        "document": doc_path,
+        "document_name": target_doc.VissibleName,
+        "page": page,
+        "total_pages": total_pages,
+        "png_data_uri": data_uri,
+        "page_width_px": width_px,
+        "page_height_px": height_px,
+        "render_source": render_source,
+        "transport": get_active_transport(),
+        "writable": False,
+    }
+
+    resource_uri = f"remarkableimg:///{doc_path.lstrip('/')}.page-{page}.png"
+    blob = types.BlobResourceContents(uri=resource_uri, mimeType="image/png", blob=png_base64)
+    info = types.TextContent(
+        type="text",
+        text=(
+            f"Page {page}/{total_pages} of '{target_doc.VissibleName}'. "
+            "Open in an MCP Apps-capable client to view the interactive canvas."
+        ),
+    )
+    return types.CallToolResult(
+        content=[info, types.EmbeddedResource(type="resource", resource=blob)],
+        structuredContent=structured,
+    )
+
+
+def register_app_tools():
+    """Register the interactive canvas app resource and tool with the server."""
+
+    @mcp.resource(CANVAS_RESOURCE_URI, mime_type=APP_UI_MIME)
+    def remarkable_canvas_ui() -> str:
+        """HTML for the reMarkable interactive canvas app (MCP Apps surface)."""
+        return _CANVAS_HTML
+
+    @mcp.tool(
+        structured_output=False,
+        annotations=CANVAS_ANNOTATIONS,
+        meta={
+            "ui": {
+                "resourceUri": CANVAS_RESOURCE_URI,
+                "visibility": ["model", "app"],
+                "preferredDisplayMode": "inline",
+            },
+            # ChatGPT/OpenAI Apps SDK legacy alias for the output template.
+            "openai/outputTemplate": CANVAS_RESOURCE_URI,
+        },
+    )
+    async def remarkable_canvas(
+        document: str,
+        page: int = 1,
+        ctx: Optional[Context] = None,
+    ):
+        """
+        <usecase>Open a reMarkable page in an interactive canvas viewer.</usecase>
+        <instructions>
+        Renders a notebook or document page and, in clients that support MCP Apps
+        interactive UI, opens a canvas viewer that lets the user page through the
+        document. This is the entry point for the interactive viewer.
+
+        The canvas is currently a read-only viewer (render + page navigation).
+        For plain image extraction without the interactive surface, use
+        remarkable_image instead.
+
+        Clients that do not support MCP Apps still get the rendered page back as
+        an embedded PNG image, so this tool is useful everywhere; it just won't
+        open the interactive panel.
+        </instructions>
+        <parameters>
+        - document: Document name or path (use remarkable_browse to find documents)
+        - page: Page number to open (default: 1, 1-indexed)
+        </parameters>
+        <examples>
+        - remarkable_canvas("Meeting Notes")
+        - remarkable_canvas("/Work/Sketches/Wireframe", page=3)
+        </examples>
+        """
+        result = await _render_canvas_page(document, page, ctx)
+        # When the client can't render the app, a short note is helpful; the
+        # embedded image is already included for those clients.
+        if isinstance(result, types.CallToolResult) and ctx is not None:
+            if not client_supports_apps(ctx):
+                logger.debug("Client does not advertise MCP Apps UI; returning image only.")
+        return result
+
+    logger.info("Registered interactive canvas app (ui=%s).", CANVAS_RESOURCE_URI)

--- a/remarkable_mcp/capabilities.py
+++ b/remarkable_mcp/capabilities.py
@@ -68,6 +68,17 @@ if TYPE_CHECKING:
     from mcp.types import ClientCapabilities
 
 
+# MCP Apps (SEP-1865) UI extension. Clients that can render interactive HTML
+# app surfaces advertise this extension during the initialize handshake:
+#   capabilities.extensions["io.modelcontextprotocol/ui"] = {
+#       "mimeTypes": ["text/html;profile=mcp-app"]
+#   }
+# The MCP SDK (as of 1.27) has no typed field for this, but ClientCapabilities
+# allows extra fields, so we read it from model_extra.
+APP_UI_EXTENSION_ID = "io.modelcontextprotocol/ui"
+APP_UI_MIME = "text/html;profile=mcp-app"
+
+
 def get_client_capabilities(ctx: "Context") -> Optional["ClientCapabilities"]:
     """Get the client's declared capabilities from the MCP context.
 
@@ -199,3 +210,58 @@ def get_protocol_version(ctx: "Context") -> Optional[str]:
     except (ValueError, AttributeError):
         pass
     return None
+
+
+def get_client_extensions(ctx: "Context") -> dict:
+    """Get the client's declared protocol extensions (SEP-1724).
+
+    Extensions are not a typed field on ClientCapabilities in the current MCP
+    SDK, but the model permits extra fields, so they are read from model_extra.
+
+    Args:
+        ctx: The FastMCP Context object
+
+    Returns:
+        The extensions mapping (extension id -> config dict), or {} if none.
+    """
+    caps = get_client_capabilities(ctx)
+    if caps is None:
+        return {}
+    extra = getattr(caps, "model_extra", None) or {}
+    extensions = extra.get("extensions")
+    return extensions if isinstance(extensions, dict) else {}
+
+
+def client_supports_apps(ctx: "Context") -> bool:
+    """Check if the client can render MCP Apps interactive UI surfaces.
+
+    MCP Apps (SEP-1865) lets a server return an HTML app, rendered by the client
+    in a sandboxed iframe, that talks back to the server over a postMessage
+    bridge. Clients advertise support via the "io.modelcontextprotocol/ui"
+    extension during the initialize handshake.
+
+    A client counts as app-capable when it declares the UI extension and either
+    lists no specific mime types or includes a text/html-based mime type (the
+    app profile is ``text/html;profile=mcp-app``). When the client is not
+    app-capable, app tools should still return a useful text/image fallback.
+
+    Args:
+        ctx: The FastMCP Context object
+
+    Returns:
+        True if the client advertises the MCP Apps UI extension, else False.
+    """
+    extensions = get_client_extensions(ctx)
+    ui = extensions.get(APP_UI_EXTENSION_ID)
+    if not isinstance(ui, dict):
+        return False
+    mime_types = ui.get("mimeTypes")
+    if mime_types is None:
+        # Extension present without a mime-type list: treat as supported.
+        return True
+    if not isinstance(mime_types, list):
+        return False
+    for mime in mime_types:
+        if isinstance(mime, str) and mime.split(";")[0].strip().lower() == "text/html":
+            return True
+    return False

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -107,6 +107,15 @@ Security Note:
             "configuration works with or without the device connected."
         ),
     )
+    parser.add_argument(
+        "--app",
+        action="store_true",
+        help=(
+            "Enable the interactive MCP App canvas (remarkable_canvas). Clients "
+            "that support MCP Apps open an interactive page viewer; others still "
+            "get the rendered page as an image. Works in any transport."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -148,6 +157,8 @@ Security Note:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         if args.no_cloud_fallback:
             os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
+        if args.app:
+            os.environ["REMARKABLE_ENABLE_APP"] = "1"
         from remarkable_mcp.server import run
 
         run()
@@ -160,6 +171,8 @@ Security Note:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         if args.no_cloud_fallback:
             os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
+        if args.app:
+            os.environ["REMARKABLE_ENABLE_APP"] = "1"
         from remarkable_mcp.server import run
 
         run()
@@ -167,6 +180,8 @@ Security Note:
         # Cloud mode (default) - now write-capable via the sync protocol
         if args.write:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+        if args.app:
+            os.environ["REMARKABLE_ENABLE_APP"] = "1"
         from remarkable_mcp.server import run
 
         run()

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -278,6 +278,14 @@ from remarkable_mcp import write_tools as _write_tools  # noqa: E402
 if _write_tools.write_enabled():
     _write_tools.register_write_tools()
 
+# Conditionally register the interactive MCP App canvas (opt-in via --app /
+# REMARKABLE_ENABLE_APP). App-capable clients open an interactive viewer;
+# others still get the rendered page as an embedded image.
+from remarkable_mcp import app_canvas as _app_canvas  # noqa: E402
+
+if _app_canvas.app_enabled():
+    _app_canvas.register_app_tools()
+
 
 def run():
     """Run the MCP server."""

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1310,6 +1310,7 @@ async def remarkable_status() -> str:
         REMARKABLE_USE_USB_WEB,
         get_active_transport,
     )
+    from remarkable_mcp.app_canvas import app_enabled
     from remarkable_mcp.write_tools import write_enabled
 
     # Determine the *selected* transport from configuration (pre-fallback).
@@ -1409,6 +1410,7 @@ async def remarkable_status() -> str:
             "status": "connected",
             "document_count": doc_count,
             "write_enabled": writes_on,
+            "app_enabled": app_enabled(),
             "capabilities": effective_caps,
             "capabilities_by_transport": capability_matrix,
         }
@@ -1440,6 +1442,11 @@ async def remarkable_status() -> str:
                 )
         else:
             hint_parts.append("Read-only. Add the --write flag to enable write tools.")
+        if app_enabled():
+            hint_parts.append(
+                "Interactive canvas app is enabled (remarkable_canvas): "
+                "MCP Apps-capable clients open a page viewer."
+            )
         hint_parts.append(
             "Use remarkable_browse() to see your files, "
             "or remarkable_recent() for recent documents."

--- a/test_server.py
+++ b/test_server.py
@@ -3415,3 +3415,257 @@ class TestSSHKeyAuth:
         from remarkable_mcp.ssh import SSHClient
 
         assert SSHClient().key_path is None
+
+
+# =============================================================================
+# MCP Apps interactive canvas
+# =============================================================================
+
+
+def _ctx_with_extensions(extensions):
+    """Build a mock Context whose client advertises the given extensions."""
+    from mcp.types import ClientCapabilities
+
+    caps = ClientCapabilities.model_validate(
+        {"extensions": extensions} if extensions is not None else {}
+    )
+    ctx = Mock()
+    ctx.session = Mock()
+    ctx.session.client_params = Mock()
+    ctx.session.client_params.capabilities = caps
+    return ctx
+
+
+class TestAppEnabled:
+    """Test the --app / REMARKABLE_ENABLE_APP gate."""
+
+    def test_app_disabled_by_default(self, monkeypatch):
+        from remarkable_mcp.app_canvas import app_enabled
+
+        monkeypatch.delenv("REMARKABLE_ENABLE_APP", raising=False)
+        assert app_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
+    def test_app_enabled_truthy(self, monkeypatch, value):
+        from remarkable_mcp.app_canvas import app_enabled
+
+        monkeypatch.setenv("REMARKABLE_ENABLE_APP", value)
+        assert app_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", ""])
+    def test_app_enabled_falsy(self, monkeypatch, value):
+        from remarkable_mcp.app_canvas import app_enabled
+
+        monkeypatch.setenv("REMARKABLE_ENABLE_APP", value)
+        assert app_enabled() is False
+
+
+class TestClientSupportsApps:
+    """Test MCP Apps UI capability negotiation."""
+
+    def test_supports_when_app_mime_advertised(self):
+        from remarkable_mcp.capabilities import APP_UI_EXTENSION_ID, client_supports_apps
+
+        ctx = _ctx_with_extensions(
+            {APP_UI_EXTENSION_ID: {"mimeTypes": ["text/html;profile=mcp-app"]}}
+        )
+        assert client_supports_apps(ctx) is True
+
+    def test_supports_when_extension_has_no_mimetypes(self):
+        from remarkable_mcp.capabilities import APP_UI_EXTENSION_ID, client_supports_apps
+
+        ctx = _ctx_with_extensions({APP_UI_EXTENSION_ID: {}})
+        assert client_supports_apps(ctx) is True
+
+    def test_not_supported_without_extension(self):
+        from remarkable_mcp.capabilities import client_supports_apps
+
+        ctx = _ctx_with_extensions({})
+        assert client_supports_apps(ctx) is False
+
+    def test_not_supported_with_wrong_mimetype(self):
+        from remarkable_mcp.capabilities import APP_UI_EXTENSION_ID, client_supports_apps
+
+        ctx = _ctx_with_extensions({APP_UI_EXTENSION_ID: {"mimeTypes": ["application/json"]}})
+        assert client_supports_apps(ctx) is False
+
+    def test_not_supported_when_no_capabilities(self):
+        from remarkable_mcp.capabilities import client_supports_apps
+
+        ctx = Mock()
+        ctx.session = None
+        assert client_supports_apps(ctx) is False
+
+
+class TestCanvasResource:
+    """Test the canvas app HTML resource."""
+
+    def test_canvas_html_is_self_contained_bridge(self):
+        from remarkable_mcp.app_canvas import _CANVAS_HTML
+
+        # Self-contained HTML with the MCP Apps postMessage bridge wiring.
+        assert "<!doctype html>" in _CANVAS_HTML.lower()
+        assert "ui/initialize" in _CANVAS_HTML
+        assert "ui/notifications/tool-result" in _CANVAS_HTML
+        assert "tools/call" in _CANVAS_HTML
+        assert "remarkable_canvas" in _CANVAS_HTML
+        assert "png_data_uri" in _CANVAS_HTML
+
+    def test_canvas_resource_uses_app_mime(self):
+        from remarkable_mcp.app_canvas import CANVAS_RESOURCE_URI
+        from remarkable_mcp.capabilities import APP_UI_MIME
+
+        assert CANVAS_RESOURCE_URI == "ui://remarkable/canvas"
+        assert APP_UI_MIME == "text/html;profile=mcp-app"
+
+
+class TestRenderCanvasPage:
+    """Test the read-only canvas page renderer."""
+
+    def _png_bytes(self):
+        import io
+
+        from PIL import Image
+
+        buf = io.BytesIO()
+        Image.new("RGB", (12, 16), "white").save(buf, "PNG")
+        return buf.getvalue()
+
+    def _patch_common(self, monkeypatch, *, page_count=3, png=None, doc_name="Notes"):
+        import remarkable_mcp.api as api
+        import remarkable_mcp.extract as extract
+        import remarkable_mcp.tools as tools
+
+        doc = Mock(VissibleName=doc_name, is_folder=False)
+        client = Mock()
+        client.get_meta_items.return_value = [doc]
+        client.download.return_value = b"PK\x03\x04zip"
+
+        monkeypatch.setattr(api, "get_rmapi", lambda: client)
+        monkeypatch.setattr(api, "get_items_by_id", lambda c: {})
+        monkeypatch.setattr(api, "get_item_path", lambda d, i: "/" + d.VissibleName)
+        monkeypatch.setattr(api, "get_active_transport", lambda: "cloud")
+        monkeypatch.setattr(api, "download_raw_file", lambda c, d, ext: None)
+        monkeypatch.setattr(extract, "get_background_color", lambda: "#FBFBFB")
+        monkeypatch.setattr(extract, "get_document_page_count", lambda p: page_count)
+        monkeypatch.setattr(extract, "render_page_from_document_zip", lambda p, pg, **k: png)
+        monkeypatch.setattr(extract, "find_similar_documents", lambda q, docs: [])
+        monkeypatch.setattr(tools, "_get_root_path", lambda: "/")
+        monkeypatch.setattr(tools, "_is_within_root", lambda path, root: True)
+        monkeypatch.setattr(tools, "_resolve_root_path", lambda p: p)
+        monkeypatch.setattr(tools, "_apply_root_filter", lambda p: p)
+        return doc
+
+    @pytest.mark.asyncio
+    async def test_render_returns_structured_content(self, monkeypatch):
+        from mcp import types
+
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        self._patch_common(monkeypatch, page_count=3, png=self._png_bytes())
+        result = await _render_canvas_page("Notes", 2, None)
+
+        assert isinstance(result, types.CallToolResult)
+        sc = result.structuredContent
+        assert sc["page"] == 2
+        assert sc["total_pages"] == 3
+        assert sc["document_name"] == "Notes"
+        assert sc["png_data_uri"].startswith("data:image/png;base64,")
+        assert sc["writable"] is False
+        assert sc["page_width_px"] == 12
+        assert sc["page_height_px"] == 16
+        # Embedded PNG is included for non-app clients.
+        assert any(isinstance(c, types.EmbeddedResource) for c in result.content)
+
+    @pytest.mark.asyncio
+    async def test_render_document_not_found(self, monkeypatch):
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        self._patch_common(monkeypatch, page_count=3, png=self._png_bytes())
+        result = await _render_canvas_page("Nonexistent", 1, None)
+
+        assert isinstance(result, str)
+        data = json.loads(result)
+        assert data["_error"]["type"] == "document_not_found"
+
+    @pytest.mark.asyncio
+    async def test_render_page_out_of_range(self, monkeypatch):
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        self._patch_common(monkeypatch, page_count=2, png=self._png_bytes())
+        result = await _render_canvas_page("Notes", 99, None)
+
+        assert isinstance(result, str)
+        data = json.loads(result)
+        assert data["_error"]["type"] == "page_out_of_range"
+
+    @pytest.mark.asyncio
+    async def test_render_failed_when_no_png(self, monkeypatch):
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        # render returns None and there's no PDF fallback -> render_failed
+        self._patch_common(monkeypatch, page_count=2, png=None)
+        result = await _render_canvas_page("Notes", 1, None)
+
+        assert isinstance(result, str)
+        data = json.loads(result)
+        assert data["_error"]["type"] == "render_failed"
+
+    @pytest.mark.asyncio
+    async def test_render_wraps_transport_errors(self, monkeypatch):
+        import remarkable_mcp.api as api
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        def _boom():
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(api, "get_rmapi", _boom)
+        result = await _render_canvas_page("Notes", 1, None)
+
+        assert isinstance(result, str)
+        data = json.loads(result)
+        assert data["_error"]["type"] == "canvas_failed"
+
+
+class TestRegisterAppTools:
+    """Test that enabling the app registers the canvas tool + resource."""
+
+    @pytest.mark.asyncio
+    async def test_register_app_tools_adds_canvas(self):
+        from mcp.server.fastmcp import FastMCP
+
+        import remarkable_mcp.app_canvas as app_canvas
+
+        # Register onto a throwaway server to avoid mutating the global one.
+        local = FastMCP("test-app")
+        original = app_canvas.mcp
+        app_canvas.mcp = local
+        try:
+            app_canvas.register_app_tools()
+            tools = await local.list_tools()
+            names = [t.name for t in tools]
+            assert "remarkable_canvas" in names
+            canvas = next(t for t in tools if t.name == "remarkable_canvas")
+            assert canvas.meta["ui"]["resourceUri"] == "ui://remarkable/canvas"
+            # No output schema so we can return either CallToolResult or an error string.
+            assert canvas.outputSchema is None
+            resources = await local.list_resources()
+            assert any(str(r.uri) == "ui://remarkable/canvas" for r in resources)
+        finally:
+            app_canvas.mcp = original
+
+
+class TestStatusReportsApp:
+    """remarkable_status reports whether the app is enabled."""
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_status_includes_app_enabled(self, mock_get_rmapi, monkeypatch):
+        monkeypatch.setenv("REMARKABLE_ENABLE_APP", "1")
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_client.get_meta_items.return_value = []
+
+        result = await mcp.call_tool("remarkable_status", {})
+        data = json.loads(result[0][0].text)
+        assert data["app_enabled"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -802,7 +802,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.23.0"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -820,9 +820,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/1a/9c8a5362e3448d585081d6c7aa95898a64e0ac59d3e26169ae6c3ca5feaf/mcp-1.23.0.tar.gz", hash = "sha256:84e0c29316d0a8cf0affd196fd000487ac512aa3f771b63b2ea864e22961772b", size = 596506, upload-time = "2025-12-02T13:40:02.558Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/b2/28739ce409f98159c0121eab56e69ad71546c4f34ac8b42e58c03f57dccc/mcp-1.23.0-py3-none-any.whl", hash = "sha256:5a645cf111ed329f4619f2629a3f15d9aabd7adc2ea09d600d31467b51ecb64f", size = 231427, upload-time = "2025-12-02T13:40:00.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ requires-dist = [
     { name = "cairosvg", specifier = ">=2.9.0" },
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "google-cloud-vision", marker = "extra == 'ocr'", specifier = ">=3.0.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.27.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pymupdf", specifier = ">=1.26.7" },
     { name = "pytesseract", specifier = ">=0.3.10" },


### PR DESCRIPTION
## Summary

Adds an **opt-in interactive page viewer** built on the [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) extension (SEP-1865). When enabled with `--app` (or `REMARKABLE_ENABLE_APP=1`), clients that support MCP Apps render a canvas in a side panel where you can view a document page and page through it. Works in **any transport** (cloud / SSH / USB web).

This is **Phase 1 + 2** of the MCP Apps plan: opt-in plumbing + capability gating + a **read-only** viewer. Pen capture, local undo, and Save-to-device write-back are planned as later, device-validated phases.

## What's included

- **`capabilities.py`** — `client_supports_apps(ctx)` negotiates the `io.modelcontextprotocol/ui` extension via `ClientCapabilities.model_extra` (the MCP SDK has no typed `extensions` field yet); adds `APP_UI_EXTENSION_ID` / `APP_UI_MIME` constants.
- **`app_canvas.py`** (new) — `app_enabled()` gate, a self-contained vanilla-JS canvas app served at `ui://remarkable/canvas` (MIME `text/html;profile=mcp-app`), and the `remarkable_canvas` tool. The tool renders the requested page and returns a `CallToolResult` with **both** an embedded PNG (so non-app clients still see the image) **and** `structuredContent` the app reads over the postMessage bridge.
- **`server.py`** — conditionally registers the app when enabled (mirrors the write-tools pattern; no change to default behavior).
- **`cli.py`** — `--app` flag, wired into all three transport branches.
- **`tools.py`** — `remarkable_status` reports `app_enabled` + a hint.
- **`pyproject.toml`** — bump `mcp>=1.27` (1.27.0+ accepts the `text/html;profile=mcp-app` resource MIME).
- **README** — new *Interactive Canvas App* section + tool note.

## Behavior

- **App-capable clients** (ChatGPT, Claude, VS Code, Inspector, …) open the canvas and page through the document via the MCP Apps `tools/call` bridge.
- **Other clients** get the rendered page back as an embedded PNG — the tool is useful everywhere; it just won't open the interactive panel. Capability is negotiated automatically; the only operator-facing switch is `--app`.

## Testing

- `uv run ruff check .` ✅  ·  `uv run ruff format --check .` ✅  ·  `uv run pytest test_server.py` ✅ **169 passed**
- New tests cover: the `--app` gate, `client_supports_apps` (advertised / bare / missing / wrong-mime / no-caps), the canvas HTML bridge contents, the renderer (structured content + embedded PNG, not-found, out-of-range, render-failed, transport-error wrapping), tool/resource registration, and `remarkable_status` reporting.
- Default mode (no `--app`) does **not** register the canvas tool — conformance runs the server in default mode, so it's unaffected.

## Not validatable locally

The iframe `postMessage` bridge follows the MCP Apps spec but can't be exercised against a real app host in CI; it's kept self-contained vanilla JS behind the `--app` opt-in and should be validated against your specific client.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>