### PR TITLE
refactor: drop --app flag; register MCP Apps canvas unconditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. Opt-in **write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are also available with the `--write` flag — see [Write Tools](#write-tools-cloud-ssh--usb-web). An optional interactive **canvas app** (`remarkable_canvas`) is available with the `--app` flag — see [Interactive Canvas App](#interactive-canvas-app-mcp-apps).
+These six tools are **read-only** and return structured JSON with hints for next actions. Opt-in **write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are also available with the `--write` flag — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -524,20 +524,9 @@ remarkable_delete("Old Draft")
 
 ## Interactive Canvas App (MCP Apps)
 
-An optional interactive page viewer built on the [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) extension (SEP-1865). When enabled, clients that support MCP Apps (such as ChatGPT, Claude, VS Code, and the MCP Inspector) render a canvas in a side panel where you can view a document page and navigate through it. It is **opt-in** and off by default.
+An interactive page viewer built on the [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) extension (SEP-1865). Clients that support MCP Apps (such as ChatGPT, Claude, VS Code, and the MCP Inspector) render a canvas in a side panel where you can view a document page and navigate through it.
 
-Enable it with the `--app` flag (works in any transport):
-
-```json
-{
-  "servers": {
-    "remarkable": {
-      "command": "uvx",
-      "args": ["remarkable-mcp", "--app"]
-    }
-  }
-}
-```
+There is **no flag to enable it** — the `remarkable_canvas` tool and its `ui://remarkable/canvas` resource are always registered, and the capability is negotiated automatically at the MCP `initialize` handshake. App-capable clients open the interactive canvas; every other client simply receives the rendered page as an image, so the tool is safe and useful everywhere.
 
 This registers one tool:
 
@@ -548,12 +537,14 @@ This registers one tool:
 How it behaves:
 
 - **App-capable clients** open the canvas (declared at `ui://remarkable/canvas`, MIME `text/html;profile=mcp-app`) and can page through the document via the MCP Apps postMessage bridge — the server delivers each rendered page in the tool result's `structuredContent`.
-- **Other clients** still get the rendered page back as an embedded PNG image, so the tool is useful everywhere; it just won't open the interactive panel. The capability is negotiated automatically — there is no separate feature gate beyond `--app`.
+- **Other clients** still get the rendered page back as an embedded PNG image, so the tool is useful everywhere; it just won't open the interactive panel. The `_meta.ui` / `ui://` metadata is inert to clients that don't advertise the MCP Apps UI extension.
 
 > **Note:** This phase is a **read-only** viewer (render + page navigation). Pen
 > capture, local undo, and an explicit Save button that writes annotations back
-> to the device are planned as later, device-validated phases. The iframe bridge
-> follows the MCP Apps spec but is best validated against your specific client.
+> to the device are planned as later, device-validated phases; write-back will
+> ride the existing `--write` gate rather than adding a new flag. The iframe
+> bridge follows the MCP Apps spec but is best validated against your specific
+> client.
 
 ---
 

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -1,28 +1,29 @@
 """
 Interactive MCP App canvas for reMarkable documents (SEP-1865 "MCP Apps").
 
-This is opt-in and disabled by default. Enable via:
-- CLI flag: remarkable-mcp --app  (works in any transport)
-- Environment variable: REMARKABLE_ENABLE_APP=1
-
-When enabled, the server registers:
+The server always registers:
 - An HTML app resource at ``ui://remarkable/canvas`` (MIME
   ``text/html;profile=mcp-app``) that the client renders in a sandboxed iframe.
 - A ``remarkable_canvas`` tool whose ``_meta.ui.resourceUri`` points at that
   resource, so app-capable clients open the viewer and feed it page data over
   the MCP Apps postMessage bridge.
 
+There is no separate feature flag: the MCP Apps capability is negotiated at the
+``initialize`` handshake. Clients that advertise the
+``io.modelcontextprotocol/ui`` extension render the interactive canvas; clients
+that don't simply ignore ``_meta.ui``/``ui://`` and receive the rendered page as
+an embedded image. The tool therefore degrades gracefully and is useful
+everywhere — the canvas is just inert UI metadata to clients that can't use it.
+
 This phase is a **read-only** viewer (render + page navigation). Pen capture,
 local undo, and an explicit Save button that writes strokes back to the device
 are tracked as later, device-validated phases and are intentionally not wired
-here. The tool degrades gracefully: clients that do not advertise the MCP Apps
-UI extension still receive the rendered page as an embedded image, so it is
-useful everywhere.
+here. Write-back, when it lands, will register through the existing ``--write``
+gate alongside the other write tools rather than introducing a new flag.
 """
 
 import base64
 import logging
-import os
 from typing import Optional
 
 from mcp import types
@@ -38,15 +39,6 @@ CANVAS_RESOURCE_URI = "ui://remarkable/canvas"
 
 # Read-only viewer annotations (no device mutation in this phase).
 CANVAS_ANNOTATIONS = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
-
-
-def app_enabled() -> bool:
-    """Check if the interactive MCP App canvas is enabled."""
-    return os.environ.get("REMARKABLE_ENABLE_APP", "").lower() in (
-        "1",
-        "true",
-        "yes",
-    )
 
 
 # The canvas app: a self-contained, dependency-free HTML/JS surface that speaks

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -107,16 +107,6 @@ Security Note:
             "configuration works with or without the device connected."
         ),
     )
-    parser.add_argument(
-        "--app",
-        action="store_true",
-        help=(
-            "Enable the interactive MCP App canvas (remarkable_canvas). Clients "
-            "that support MCP Apps open an interactive page viewer; others still "
-            "get the rendered page as an image. Works in any transport."
-        ),
-    )
-
     args = parser.parse_args()
 
     if args.register:
@@ -157,8 +147,6 @@ Security Note:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         if args.no_cloud_fallback:
             os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
-        if args.app:
-            os.environ["REMARKABLE_ENABLE_APP"] = "1"
         from remarkable_mcp.server import run
 
         run()
@@ -171,8 +159,6 @@ Security Note:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
         if args.no_cloud_fallback:
             os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
-        if args.app:
-            os.environ["REMARKABLE_ENABLE_APP"] = "1"
         from remarkable_mcp.server import run
 
         run()
@@ -180,8 +166,6 @@ Security Note:
         # Cloud mode (default) - now write-capable via the sync protocol
         if args.write:
             os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
-        if args.app:
-            os.environ["REMARKABLE_ENABLE_APP"] = "1"
         from remarkable_mcp.server import run
 
         run()

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -278,13 +278,13 @@ from remarkable_mcp import write_tools as _write_tools  # noqa: E402
 if _write_tools.write_enabled():
     _write_tools.register_write_tools()
 
-# Conditionally register the interactive MCP App canvas (opt-in via --app /
-# REMARKABLE_ENABLE_APP). App-capable clients open an interactive viewer;
-# others still get the rendered page as an embedded image.
+# Register the interactive MCP App canvas (remarkable_canvas + ui:// resource).
+# There is no feature flag: app-capable clients (those advertising the MCP Apps
+# UI extension at initialize) open an interactive viewer, while other clients
+# ignore the UI metadata and receive the rendered page as an embedded image.
 from remarkable_mcp import app_canvas as _app_canvas  # noqa: E402
 
-if _app_canvas.app_enabled():
-    _app_canvas.register_app_tools()
+_app_canvas.register_app_tools()
 
 
 def run():

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1310,7 +1310,6 @@ async def remarkable_status() -> str:
         REMARKABLE_USE_USB_WEB,
         get_active_transport,
     )
-    from remarkable_mcp.app_canvas import app_enabled
     from remarkable_mcp.write_tools import write_enabled
 
     # Determine the *selected* transport from configuration (pre-fallback).
@@ -1410,7 +1409,6 @@ async def remarkable_status() -> str:
             "status": "connected",
             "document_count": doc_count,
             "write_enabled": writes_on,
-            "app_enabled": app_enabled(),
             "capabilities": effective_caps,
             "capabilities_by_transport": capability_matrix,
         }
@@ -1442,11 +1440,6 @@ async def remarkable_status() -> str:
                 )
         else:
             hint_parts.append("Read-only. Add the --write flag to enable write tools.")
-        if app_enabled():
-            hint_parts.append(
-                "Interactive canvas app is enabled (remarkable_canvas): "
-                "MCP Apps-capable clients open a page viewer."
-            )
         hint_parts.append(
             "Use remarkable_browse() to see your files, "
             "or remarkable_recent() for recent documents."

--- a/test_server.py
+++ b/test_server.py
@@ -101,6 +101,7 @@ class TestMCPServerInitialization:
             "remarkable_search",
             "remarkable_status",
             "remarkable_image",
+            "remarkable_canvas",
         ]
 
         for tool_name in expected_tools:
@@ -108,9 +109,9 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Test that we have exactly 6 intent-based tools."""
+        """Six read-only tools plus the always-on interactive canvas app."""
         tools = await mcp.list_tools()
-        assert len(tools) == 6, f"Expected 6 tools, got {len(tools)}"
+        assert len(tools) == 7, f"Expected 7 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -1131,7 +1132,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 6
+        assert len(tools) == 7
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:
@@ -3436,30 +3437,6 @@ def _ctx_with_extensions(extensions):
     return ctx
 
 
-class TestAppEnabled:
-    """Test the --app / REMARKABLE_ENABLE_APP gate."""
-
-    def test_app_disabled_by_default(self, monkeypatch):
-        from remarkable_mcp.app_canvas import app_enabled
-
-        monkeypatch.delenv("REMARKABLE_ENABLE_APP", raising=False)
-        assert app_enabled() is False
-
-    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
-    def test_app_enabled_truthy(self, monkeypatch, value):
-        from remarkable_mcp.app_canvas import app_enabled
-
-        monkeypatch.setenv("REMARKABLE_ENABLE_APP", value)
-        assert app_enabled() is True
-
-    @pytest.mark.parametrize("value", ["0", "false", "no", ""])
-    def test_app_enabled_falsy(self, monkeypatch, value):
-        from remarkable_mcp.app_canvas import app_enabled
-
-        monkeypatch.setenv("REMARKABLE_ENABLE_APP", value)
-        assert app_enabled() is False
-
-
 class TestClientSupportsApps:
     """Test MCP Apps UI capability negotiation."""
 
@@ -3655,17 +3632,28 @@ class TestRegisterAppTools:
             app_canvas.mcp = original
 
 
-class TestStatusReportsApp:
-    """remarkable_status reports whether the app is enabled."""
+class TestCanvasRegisteredByDefault:
+    """The canvas app is always registered (no feature flag) and degrades gracefully."""
+
+    @pytest.mark.asyncio
+    async def test_canvas_tool_present_on_default_server(self):
+        tools = await mcp.list_tools()
+        names = [t.name for t in tools]
+        assert "remarkable_canvas" in names
+
+    @pytest.mark.asyncio
+    async def test_canvas_resource_present_on_default_server(self):
+        resources = await mcp.list_resources()
+        assert any(str(r.uri) == "ui://remarkable/canvas" for r in resources)
 
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.get_rmapi")
-    async def test_status_includes_app_enabled(self, mock_get_rmapi, monkeypatch):
-        monkeypatch.setenv("REMARKABLE_ENABLE_APP", "1")
+    async def test_status_no_longer_reports_app_enabled(self, mock_get_rmapi):
+        # The app has no on/off gate anymore, so status should not carry the key.
         mock_client = Mock()
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
         result = await mcp.call_tool("remarkable_status", {})
         data = json.loads(result[0][0].text)
-        assert data["app_enabled"] is True
+        assert "app_enabled" not in data


### PR DESCRIPTION
## Summary

Removes the custom `--app` / `REMARKABLE_ENABLE_APP` opt-in for the interactive canvas viewer (added in #110) and registers it unconditionally, relying purely on the **MCP Apps capability handshake** (`io.modelcontextprotocol/ui`) for negotiation.

This follows the maintainer's call that a bespoke viewer gate is redundant: the `_meta.ui` / `ui://` metadata is inert to clients that don't advertise the extension, so the tool already degrades gracefully (app-capable clients open the canvas; everyone else gets the rendered page as an embedded PNG). Aligning with the spec's graceful-degradation model means there's nothing to flip on.

## What changed
- **`cli.py`** — remove the `--app` argument and all `REMARKABLE_ENABLE_APP` wiring.
- **`server.py`** — register `remarkable_canvas` + the `ui://remarkable/canvas` resource unconditionally.
- **`app_canvas.py`** — drop `app_enabled()`; rewrite the module docstring to describe capability-negotiated behavior.
- **`tools.py`** — `remarkable_status` no longer reports `app_enabled` (no gate to report).
- **`README.md`** — document the canvas as always-on / capability-negotiated rather than an opt-in flag.
- **`test_server.py`** — default server now exposes **7** tools; added coverage that the canvas tool + resource register by default and that `app_enabled` is gone from status; removed the obsolete gate tests.

## Forward note
Write-back (pen + Save), when it lands, will ride the **existing `--write` gate** alongside the other write tools — not a new app-specific flag.

## Verification
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest test_server.py` ✅ **161 passed**
- Smoke test of the default `uv run python server.py` path (no env flags) confirms the canvas tool + resource register and the server boots cleanly — this is exactly what the conformance job runs, so the canvas is now validated by conformance for the first time.

Builds on #110.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>