### PR TITLE
fix(app): spec-compliant MCP Apps bridge + break circular import

### DIFF
--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -30,7 +30,6 @@ from mcp import types
 from mcp.server.fastmcp import Context
 
 from remarkable_mcp.capabilities import APP_UI_MIME, client_supports_apps
-from remarkable_mcp.server import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -188,15 +187,30 @@ _CANVAS_HTML = """<!doctype html>
       }
       return;
     }
-    if (msg.method === "ui/notifications/tool-result" ||
-        msg.method === "ui/notifications/tool-input") {
+    // Input/result asymmetry (per the MCP Apps spec): tool-input params are
+    // wrapped as { arguments: {...} } (the document/page the tool was called
+    // with), while tool-result params are a bare CallToolResult carrying the
+    // rendered page in structuredContent. Handle them separately.
+    if (msg.method === "ui/notifications/tool-input" ||
+        msg.method === "ui/notifications/tool-input-partial") {
+      var args = (msg.params && msg.params.arguments) || {};
+      if (args.document) state.document = args.document;
+      if (args.page) state.page = args.page;
+      return;
+    }
+    if (msg.method === "ui/notifications/tool-result") {
       render(digOut(msg.params) || {});
+      return;
     }
   });
 
-  // Handshake: announce the app and the display modes it can use, then signal
-  // that we are ready to receive tool input/results.
+  // Handshake: announce the app (with protocol version + client info, as the
+  // spec requires) and the display modes it can use, then signal that we are
+  // ready to receive tool input/results.
   rpc("ui/initialize", {
+    protocolVersion: "2026-01-26",
+    capabilities: {},
+    clientInfo: { name: "remarkable-canvas", version: "1" },
     appCapabilities: { availableDisplayModes: ["inline", "fullscreen"] },
   }).then(function (res) {
     notify("ui/notifications/initialized", {});
@@ -396,7 +410,14 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
 
 
 def register_app_tools():
-    """Register the interactive canvas app resource and tool with the server."""
+    """Register the interactive canvas app resource and tool with the server.
+
+    ``mcp`` is imported here rather than at module load so that importing
+    ``app_canvas`` never triggers ``server`` (which imports this module and
+    registers these tools). That avoids a circular import when ``app_canvas``
+    happens to be imported before ``server``.
+    """
+    from remarkable_mcp.server import mcp
 
     @mcp.resource(CANVAS_RESOURCE_URI, mime_type=APP_UI_MIME)
     def remarkable_canvas_ui() -> str:

--- a/test_server.py
+++ b/test_server.py
@@ -3488,6 +3488,18 @@ class TestCanvasResource:
         assert "remarkable_canvas" in _CANVAS_HTML
         assert "png_data_uri" in _CANVAS_HTML
 
+    def test_canvas_bridge_is_spec_compliant(self):
+        from remarkable_mcp.app_canvas import _CANVAS_HTML
+
+        # ui/initialize must carry a protocol version + client info per spec.
+        assert "protocolVersion" in _CANVAS_HTML
+        assert "2026-01-26" in _CANVAS_HTML
+        assert "clientInfo" in _CANVAS_HTML
+        # Input/result asymmetry: tool-input params are wrapped as {arguments},
+        # tool-result params are a bare CallToolResult.
+        assert "ui/notifications/tool-input" in _CANVAS_HTML
+        assert ".arguments" in _CANVAS_HTML
+
     def test_canvas_resource_uses_app_mime(self):
         from remarkable_mcp.app_canvas import CANVAS_RESOURCE_URI
         from remarkable_mcp.capabilities import APP_UI_MIME
@@ -3605,31 +3617,42 @@ class TestRenderCanvasPage:
 
 
 class TestRegisterAppTools:
-    """Test that enabling the app registers the canvas tool + resource."""
+    """Test that registering the app adds the canvas tool + resource."""
 
     @pytest.mark.asyncio
-    async def test_register_app_tools_adds_canvas(self):
+    async def test_register_app_tools_adds_canvas(self, monkeypatch):
         from mcp.server.fastmcp import FastMCP
 
         import remarkable_mcp.app_canvas as app_canvas
+        import remarkable_mcp.server as server_mod
 
-        # Register onto a throwaway server to avoid mutating the global one.
+        # register_app_tools imports mcp from server at call time, so redirect
+        # that global to a throwaway server to avoid mutating the real one.
         local = FastMCP("test-app")
-        original = app_canvas.mcp
-        app_canvas.mcp = local
-        try:
-            app_canvas.register_app_tools()
-            tools = await local.list_tools()
-            names = [t.name for t in tools]
-            assert "remarkable_canvas" in names
-            canvas = next(t for t in tools if t.name == "remarkable_canvas")
-            assert canvas.meta["ui"]["resourceUri"] == "ui://remarkable/canvas"
-            # No output schema so we can return either CallToolResult or an error string.
-            assert canvas.outputSchema is None
-            resources = await local.list_resources()
-            assert any(str(r.uri) == "ui://remarkable/canvas" for r in resources)
-        finally:
-            app_canvas.mcp = original
+        monkeypatch.setattr(server_mod, "mcp", local)
+
+        app_canvas.register_app_tools()
+        tools = await local.list_tools()
+        names = [t.name for t in tools]
+        assert "remarkable_canvas" in names
+        canvas = next(t for t in tools if t.name == "remarkable_canvas")
+        assert canvas.meta["ui"]["resourceUri"] == "ui://remarkable/canvas"
+        # No output schema so we can return either CallToolResult or an error string.
+        assert canvas.outputSchema is None
+        resources = await local.list_resources()
+        assert any(str(r.uri) == "ui://remarkable/canvas" for r in resources)
+
+    def test_app_canvas_importable_standalone(self):
+        """Importing app_canvas before server must not hit a circular import."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import remarkable_mcp.app_canvas"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
 
 
 class TestCanvasRegisteredByDefault:


### PR DESCRIPTION
## What

Two fixes to the MCP Apps interactive canvas viewer shipped in #110/#111.

### 1. Spec-compliant postMessage bridge (per MCP Apps spec `2026-01-26`)
- `ui/initialize` now sends the required `protocolVersion`, `capabilities`, and `clientInfo` — without them a spec-compliant host can reject the handshake.
- Handle the **input/result asymmetry**: `ui/notifications/tool-input` params are wrapped as `{ arguments: {...} }`, while `ui/notifications/tool-result` params are a bare `CallToolResult`. The handler previously ran `digOut()` on both, silently dropping the requested document/page. Now tool-input records `document`/`page` and tool-result renders `structuredContent`.

### 2. Break a latent circular import
After the viewer became unconditional in #111, `import remarkable_mcp.app_canvas` *before* `remarkable_mcp.server` raised `AttributeError: partially initialized module` — `app_canvas` imported `mcp` at module top while `server` imports `app_canvas` and calls `register_app_tools()` at load. Moved the `from remarkable_mcp.server import mcp` into `register_app_tools()` (mirrors the lazy-import pattern already used elsewhere in the module). The normal import path was unaffected, but the standalone import always failed.

## Tests
- Assert the canvas HTML carries `protocolVersion`/`2026-01-26` and reads `.arguments`.
- Subprocess regression test: importing `app_canvas` standalone succeeds.
- `163 passed`; `ruff check` + `ruff format --check` clean; JS `node --check` clean; default server boots with 7 tools + canvas resource.

Source for the bridge shapes: MCP Apps spec `apps.mdx` (2026-01-26), `@modelcontextprotocol/ext-apps` SDK, and `github/github-mcp-server`.