### PR TITLE
feat: enable write tools by default with --read-only opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ AI assistants use the tools to read documents, search content, and more:
 
 ## Connection Modes
 
-All three modes share the same read, render, and upload tools. **Cloud and SSH additionally support full library management** — create folders, move, rename, and delete (with `--write`) — so capability is near-identical and you can genuinely pick whichever matches how your tablet is connected:
+All three modes share the same read, render, and upload tools. **Cloud and SSH additionally support full library management** — create folders, move, rename, and delete (all enabled by default) — so capability is near-identical and you can genuinely pick whichever matches how your tablet is connected:
 
 - **☁️ Cloud** — *device-free, works from anywhere.* Reads your library straight from reMarkable's cloud over Wi‑Fi with a Connect subscription — no cable, no developer mode. Full read/render plus full write (upload, create folder, move, rename, delete → trash). Parallel fetching and an on-disk blob cache make it fast after the first sync. Best for remote/headless setups or when you don't want to plug in.
 - **🔌 USB Web Interface** — *best when the tablet is plugged in.* Enable the web interface in Storage Settings — no subscription, no developer mode. Full read/render plus upload (to your root folder). The tablet's USB web firmware exposes no folder/move/rename/delete endpoints, so for those over a cable use SSH.
@@ -192,7 +192,7 @@ All three modes share the same read, render, and upload tools. **Cloud and SSH a
 | **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ | ✅ PDF | ✅ (to root) | ❌ |
 | **⚡ SSH** | Developer mode | Not required | ✅ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
 
-¹ Folder ops = create folder / move / rename / delete. Upload and folder ops require the `--write` flag (off by default). Deletes move items to the trash and can prompt for confirmation when your client supports elicitation.
+¹ Folder ops = create folder / move / rename / delete. Upload and folder ops are enabled by default; pass `--read-only` to expose a read-only server. Deletes move items to the trash and can prompt for confirmation when your client supports elicitation.
 
 ### Automatic cloud fallback
 
@@ -243,7 +243,7 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. Opt-in **write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are also available with the `--write` flag — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
+These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -416,8 +416,8 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 | Offline | ✅ Yes | ✅ Yes | ❌ No |
 | Subscription | ✅ Not required | ✅ Not required | ❌ Connect required |
 | Raw files | ✅ PDFs, EPUBs | ✅ PDFs | ✅ PDFs, EPUBs |
-| Upload | ✅ With `--write` | ✅ With `--write` | ✅ With `--write` |
-| mkdir/move/rename/delete | ✅ With `--write` | ❌ | ✅ With `--write` |
+| Upload | ✅ (default) | ✅ (default) | ✅ (default) |
+| mkdir/move/rename/delete | ✅ (default) | ❌ | ✅ (default) |
 | Setup | Developer mode | Enable in Settings | One-time code |
 
 📖 **[SSH Setup Guide](docs/ssh-setup.md)**
@@ -426,7 +426,7 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 
 ## Write Tools (Cloud, SSH & USB Web)
 
-Opt-in write tools let you upload, organize, and manage documents on your reMarkable. **Disabled by default** for safety. Cloud and SSH modes support the full set; USB web supports upload only (its firmware exposes no folder operations).
+Write tools let you upload, organize, and manage documents on your reMarkable. **Enabled by default.** Cloud and SSH modes support the full set; USB web supports upload only (its firmware exposes no folder operations). Pass `--read-only` to expose a read-only server.
 
 | Feature | Cloud Mode | SSH Mode | USB Web Mode |
 |---------|:----------:|:--------:|:------------:|
@@ -436,40 +436,28 @@ Opt-in write tools let you upload, organize, and manage documents on your reMark
 | Rename | ✅ | ✅ | ❌ |
 | Delete | ✅ (→ trash) | ✅ | ❌ |
 
-### Enabling Write Tools
+### Disabling Write Tools (read-only mode)
 
-Add the `--write` flag. It works in any mode (cloud is the default — no flag needed to select it):
+Write tools are on by default in every mode. To run a read-only server, add the `--read-only` flag:
 
 ```json
 {
   "servers": {
     "remarkable": {
       "command": "uvx",
-      "args": ["remarkable-mcp", "--write"]
+      "args": ["remarkable-mcp", "--read-only"]
     }
   }
 }
 ```
 
-For SSH or USB web, combine `--write` with the transport flag:
+It combines with any transport flag (`--ssh`, `--usb`):
 ```json
 {
   "servers": {
     "remarkable": {
       "command": "uvx",
-      "args": ["remarkable-mcp", "--ssh", "--write"]
-    }
-  }
-}
-```
-
-USB web mode (upload only):
-```json
-{
-  "servers": {
-    "remarkable": {
-      "command": "uvx",
-      "args": ["remarkable-mcp", "--usb", "--write"]
+      "args": ["remarkable-mcp", "--ssh", "--read-only"]
     }
   }
 }
@@ -479,10 +467,12 @@ Or set the environment variable:
 ```json
 {
   "env": {
-    "REMARKABLE_ENABLE_WRITE": "1"
+    "REMARKABLE_READ_ONLY": "1"
   }
 }
 ```
+
+> The legacy `--write` flag and `REMARKABLE_ENABLE_WRITE` variable are still accepted for backward compatibility but are now no-ops (write is the default). `--write` and `--read-only` are mutually exclusive.
 
 ### Available Write Tools
 
@@ -542,9 +532,9 @@ How it behaves:
 > **Note:** This phase is a **read-only** viewer (render + page navigation). Pen
 > capture, local undo, and an explicit Save button that writes annotations back
 > to the device are planned as later, device-validated phases; write-back will
-> ride the existing `--write` gate rather than adding a new flag. The iframe
-> bridge follows the MCP Apps spec but is best validated against your specific
-> client.
+> ride the existing write gate (on by default, `--read-only` to disable) rather
+> than adding a new flag. The iframe bridge follows the MCP Apps spec but is best
+> validated against your specific client.
 
 ---
 

--- a/docs/future-plans.md
+++ b/docs/future-plans.md
@@ -6,7 +6,7 @@ This document outlines potential future features for remarkable-mcp. These are i
 
 ### Write Support ([#24](https://github.com/SamMorrowDrums/remarkable-mcp/issues/24))
 
-Currently, remarkable-mcp is read-only. Future versions may add:
+Write tools (upload, create folders, move, rename, delete) are now enabled by default — pass `--read-only` to disable them. Further ideas under consideration:
 
 - **Create documents** — Create new notebooks or upload PDFs
 - **Sync from Obsidian** — Push markdown notes to reMarkable as PDFs

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -13,7 +13,7 @@ This document provides detailed documentation for all MCP tools provided by rema
 | [`remarkable_status`](#remarkable_status) | Check connection status |
 | [`remarkable_image`](#remarkable_image) | Get page images (PNG or SVG) |
 
-All tools are **read-only** and return structured JSON with hints for logical next actions.
+These core tools are **read-only** and return structured JSON with hints for logical next actions. Write tools (upload, mkdir, move, rename, delete) are enabled by default and documented in the [README](../README.md#write-tools-cloud-ssh--usb-web).
 
 ## Root Path Filtering
 
@@ -303,7 +303,7 @@ remarkable_status()
 | `transport` | `"cloud"`, `"ssh"`, or `"usb-web"` |
 | `connection` | Connection details |
 | `document_count` | Total documents in library (filtered by root if configured) |
-| `write_enabled` | Whether write tools are enabled (the `--write` flag) |
+| `write_enabled` | Whether write tools are enabled (the default; `false` only with `--read-only`) |
 | `capabilities` | Effective capabilities for the active transport (read/render/upload/mkdir/move/rename/delete) |
 | `capabilities_by_transport` | The full per-transport capability matrix |
 | `root_path` | Configured root path filter (only present if set) |

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -18,8 +18,9 @@ everywhere — the canvas is just inert UI metadata to clients that can't use it
 This phase is a **read-only** viewer (render + page navigation). Pen capture,
 local undo, and an explicit Save button that writes strokes back to the device
 are tracked as later, device-validated phases and are intentionally not wired
-here. Write-back, when it lands, will register through the existing ``--write``
-gate alongside the other write tools rather than introducing a new flag.
+here. Write-back, when it lands, will ride the existing write gate
+(``write_enabled()`` / ``--read-only``) alongside the other write tools rather
+than introducing a new flag.
 """
 
 import base64

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -29,8 +29,11 @@ Examples:
   # Register and get token (run once)
   uvx remarkable-mcp --register abcd1234
 
-  # Run as MCP server (cloud API)
+  # Run as MCP server (cloud API, write-enabled by default)
   uvx remarkable-mcp
+
+  # Run as a read-only server (no upload/mkdir/move/rename/delete)
+  uvx remarkable-mcp --read-only
 
   # Run with token from environment
   REMARKABLE_TOKEN="your-token" uvx remarkable-mcp
@@ -89,12 +92,22 @@ Security Note:
         action="store_true",
         help="Use USB web interface (connect via USB cable, enable in Storage Settings)",
     )
-    parser.add_argument(
+    write_group = parser.add_mutually_exclusive_group()
+    write_group.add_argument(
         "--write",
         action="store_true",
         help=(
-            "Enable write tools (upload, mkdir, move, rename, delete). "
-            "Cloud and SSH support all of them; USB web supports upload only."
+            "Deprecated no-op. Write tools (upload, mkdir, move, rename, delete) "
+            "are enabled by default, so this flag has no effect. Kept for backward "
+            "compatibility. Mutually exclusive with --read-only."
+        ),
+    )
+    write_group.add_argument(
+        "--read-only",
+        action="store_true",
+        help=(
+            "Disable all write tools (upload, mkdir, move, rename, delete) and "
+            "expose a read-only server. Mutually exclusive with --write."
         ),
     )
     parser.add_argument(
@@ -143,8 +156,8 @@ Security Note:
     elif args.usb:
         # USB web mode - set environment variable and run server
         os.environ["REMARKABLE_USE_USB_WEB"] = "1"
-        if args.write:
-            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+        if args.read_only:
+            os.environ["REMARKABLE_READ_ONLY"] = "1"
         if args.no_cloud_fallback:
             os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
         from remarkable_mcp.server import run
@@ -155,17 +168,17 @@ Security Note:
         os.environ["REMARKABLE_USE_SSH"] = "1"
         if args.ssh_key:
             os.environ["REMARKABLE_SSH_KEY"] = args.ssh_key
-        if args.write:
-            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+        if args.read_only:
+            os.environ["REMARKABLE_READ_ONLY"] = "1"
         if args.no_cloud_fallback:
             os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
         from remarkable_mcp.server import run
 
         run()
     else:
-        # Cloud mode (default) - now write-capable via the sync protocol
-        if args.write:
-            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+        # Cloud mode (default) - write-capable via the sync protocol
+        if args.read_only:
+            os.environ["REMARKABLE_READ_ONLY"] = "1"
         from remarkable_mcp.server import run
 
         run()

--- a/remarkable_mcp/prompts.py
+++ b/remarkable_mcp/prompts.py
@@ -106,8 +106,8 @@ def organize_library_prompt() -> list:
                 "3. Identify any documents that might be misplaced or could be "
                 "better organized\n"
                 "4. Suggest a folder structure that would help me stay organized\n\n"
-                "Note: This server is read-only, so just provide recommendations - "
-                "I'll reorganize manually on my tablet."
+                "Note: Please just provide recommendations - I'll review them "
+                "before making any changes on my tablet."
             ),
         }
     ]

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -68,11 +68,12 @@ def _build_instructions() -> str:
     has_google_vision = bool(os.environ.get("GOOGLE_VISION_API_KEY"))
     ocr_backend = os.environ.get("REMARKABLE_OCR_BACKEND", "auto").lower()
 
-    write_mode = os.environ.get("REMARKABLE_ENABLE_WRITE", "").lower() in (
+    read_only_mode = os.environ.get("REMARKABLE_READ_ONLY", "").lower() in (
         "1",
         "true",
         "yes",
-    ) and (ssh_mode or usb_web_mode)
+    )
+    write_mode = not read_only_mode
 
     read_only_note = "" if write_mode else " All operations are read-only."
 
@@ -157,6 +158,7 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - **Delete is destructive** and immediate — the MCP client should confirm with the user first
 - After each write operation, the tablet UI restarts automatically
 - Use `remarkable_browse()` to verify changes after write operations
+- Run with `--read-only` to disable all write tools
 """
     elif usb_web_mode:
         if write_mode:
@@ -178,6 +180,24 @@ Connected via reMarkable Cloud API. Some features require SSH mode:
 - `content_type="raw"` parameter
 
 For faster access and raw files, consider SSH mode: `uvx remarkable-mcp --ssh`
+"""
+        if write_mode:
+            instructions += """
+## Write Tools (Active)
+
+Write operations are enabled (the default). These tools modify your cloud library
+and sync to all your devices:
+
+- `remarkable_upload(file_path, parent_folder, document_name)` - Upload a PDF/EPUB
+- `remarkable_mkdir(folder_name, parent)` - Create a folder
+- `remarkable_move(document, dest_folder)` - Move a document/folder
+- `remarkable_rename(document, new_name)` - Rename a document/folder
+- `remarkable_delete(document)` - Delete a document/folder (destructive)
+
+### Safety
+- **Delete is destructive** — the MCP client should confirm with the user first
+- Changes sync to your devices; use `remarkable_browse()` to verify them
+- Run with `--read-only` to disable all write tools
 """
 
     # Add OCR instructions based on configuration

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1297,7 +1297,8 @@ async def remarkable_status() -> str:
     - USB web: read, render, and upload (to root) only — the tablet's USB web
       interface firmware exposes no folder/move/rename/delete endpoints. For full
       write parity over a USB cable, use SSH mode pointed at the USB IP.
-    Write tools (upload/mkdir/move/rename/delete) require the --write flag.
+    Write tools (upload/mkdir/move/rename/delete) are enabled by default; run
+    with --read-only (or REMARKABLE_READ_ONLY=1) to expose a read-only server.
     </instructions>
     <examples>
     - remarkable_status()
@@ -1335,7 +1336,7 @@ async def remarkable_status() -> str:
         selected_transport = "cloud"
         connection_info = "environment variable" if REMARKABLE_TOKEN else "file (~/.rmapi)"
 
-    # What each transport is capable of (independent of whether --write is on).
+    # What each transport is capable of (independent of read-only mode).
     # read/render are always available; the booleans below are the write surface.
     capability_matrix = {
         "cloud": {
@@ -1395,7 +1396,7 @@ async def remarkable_status() -> str:
                 doc_count += 1
 
         # Effective capabilities for the active transport: write ops only count
-        # when the --write flag is enabled.
+        # when not in read-only mode.
         transport_caps = capability_matrix[transport]
         effective_caps = {
             cap: (supported if cap in ("read", "render") else supported and writes_on)
@@ -1439,7 +1440,10 @@ async def remarkable_status() -> str:
                     "Write is enabled: upload, mkdir, move, rename, and delete are available."
                 )
         else:
-            hint_parts.append("Read-only. Add the --write flag to enable write tools.")
+            hint_parts.append(
+                "Read-only mode is active (--read-only / REMARKABLE_READ_ONLY=1). "
+                "Restart without it to enable write tools."
+            )
         hint_parts.append(
             "Use remarkable_browse() to see your files, "
             "or remarkable_recent() for recent documents."

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1,10 +1,13 @@
 """
 Write tools for reMarkable tablet via cloud, SSH, or USB web interface.
 
-These tools are opt-in — disabled by default. Enable via:
-- CLI flag: remarkable-mcp --write  (works in the default cloud mode)
-            remarkable-mcp --ssh --write  (or --usb --write)
-- Environment variable: REMARKABLE_ENABLE_WRITE=1
+These tools are enabled by default. Disable them (expose a read-only server) via:
+- CLI flag: remarkable-mcp --read-only  (works in any transport)
+- Environment variable: REMARKABLE_READ_ONLY=1
+
+The legacy --write flag and REMARKABLE_ENABLE_WRITE variable are still accepted
+for backward compatibility but are now no-ops (write is the default). --write and
+--read-only are mutually exclusive.
 
 Write support by transport:
 - Cloud mode: upload, mkdir, move, rename, delete (-> trash)
@@ -49,29 +52,35 @@ RENAME_ANNOTATIONS = WRITE_ANNOTATIONS
 DELETE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
 
 
-def write_enabled() -> bool:
-    """Check if write tools are enabled via environment variable."""
-    return os.environ.get("REMARKABLE_ENABLE_WRITE", "").lower() in (
+def read_only_enabled() -> bool:
+    """Check if read-only mode is enabled via the --read-only flag / env var."""
+    return os.environ.get("REMARKABLE_READ_ONLY", "").lower() in (
         "1",
         "true",
         "yes",
     )
 
 
+def write_enabled() -> bool:
+    """Write tools are enabled by default; disabled only in read-only mode."""
+    return not read_only_enabled()
+
+
 def _require_write_transport() -> Optional[str]:
     """Return an error string if writes are disabled, else None.
 
     Upload works in all three transports (cloud, SSH, USB web). Write tools are
-    only registered when REMARKABLE_ENABLE_WRITE is set, so this is mostly a
+    not registered when REMARKABLE_READ_ONLY is set, so this is mostly a
     defensive check that returns a clear error if writes are somehow disabled.
     """
     if not write_enabled():
         return make_error(
             error_type="write_disabled",
-            message="Write operations are disabled",
+            message="Write operations are disabled (read-only mode)",
             suggestion=(
-                "Enable write tools with the --write flag or REMARKABLE_ENABLE_WRITE=1.\n"
-                "Run with: remarkable-mcp --write  (cloud)  or  --ssh --write / --usb --write"
+                "Write tools are enabled by default. Remove the --read-only flag "
+                "(or unset REMARKABLE_READ_ONLY) and restart the server to enable "
+                "upload, mkdir, move, rename, and delete."
             ),
         )
     return None
@@ -114,7 +123,7 @@ def _require_managed_write_mode() -> Optional[str]:
         suggestion=(
             "mkdir, move, rename and delete work in cloud mode (the "
             "default) and SSH mode. Upload works in all three modes.\n"
-            "Run with: remarkable-mcp --write  (cloud)  or  --ssh --write"
+            "Run with: remarkable-mcp  (cloud)  or  remarkable-mcp --ssh"
         ),
     )
 
@@ -485,7 +494,7 @@ def register_write_tools():
         - USB web: uploaded via POST /upload; lands at the root (the firmware's
           upload endpoint has no folder or rename field)
 
-        Requires --write flag.
+        Requires write mode (the default; disabled with --read-only).
         </instructions>
         <parameters>
         - file_path: Absolute path to the local PDF or EPUB file
@@ -676,7 +685,7 @@ def register_write_tools():
             folder appears after xochitl restarts; in cloud mode it syncs to all
             your devices.
 
-            Works in cloud and SSH modes (requires --write). Not available over the
+            Works in cloud and SSH modes (default; --read-only disables). Not available over the
             USB web interface (the firmware exposes no folder-create endpoint).
             </instructions>
             <parameters>
@@ -767,7 +776,7 @@ def register_write_tools():
             Moves a document or folder by updating its parent reference in the metadata.
             Find the document name with remarkable_browse() first.
 
-            Works in cloud and SSH modes (requires --write). Not available over the
+            Works in cloud and SSH modes (default; --read-only disables). Not available over the
             USB web interface.
             </instructions>
             <parameters>
@@ -887,7 +896,7 @@ def register_write_tools():
             Changes the display name of a document or folder by updating its metadata.
             Find the document name with remarkable_browse() first.
 
-            Works in cloud and SSH modes (requires --write). Not available over the
+            Works in cloud and SSH modes (default; --read-only disables). Not available over the
             USB web interface.
             </instructions>
             <parameters>
@@ -972,7 +981,7 @@ def register_write_tools():
             (recoverable from the device's Trash). In SSH mode it is marked deleted
             in its metadata and disappears from the tablet UI after restart.
 
-            Works in cloud and SSH modes (requires --write). Not available over the
+            Works in cloud and SSH modes (default; --read-only disables). Not available over the
             USB web interface.
 
             If the client supports elicitation, this tool asks the user to confirm

--- a/test_server.py
+++ b/test_server.py
@@ -7,6 +7,7 @@ Tests the 4 intent-based tools using FastMCP's testing capabilities.
 
 import json
 import os
+import sys
 import tempfile
 import zipfile
 from pathlib import Path
@@ -109,9 +110,9 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Six read-only tools plus the always-on interactive canvas app."""
+        """Six read tools + always-on canvas + five write tools (write-on by default)."""
         tools = await mcp.list_tools()
-        assert len(tools) == 7, f"Expected 7 tools, got {len(tools)}"
+        assert len(tools) == 12, f"Expected 12 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -1132,7 +1133,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 7
+        assert len(tools) == 12
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:
@@ -2502,49 +2503,87 @@ class TestRetryBackoff:
 
 
 class TestWriteTools:
-    """Test write tools opt-in behavior and safety checks."""
+    """Test write tools default-on behavior, the read-only gate, and safety checks."""
 
-    def test_write_enabled_default_off(self):
-        """Test that write_enabled() returns False by default."""
-        from remarkable_mcp.write_tools import write_enabled
+    def test_write_enabled_default_on(self):
+        """write_enabled() is True by default (write is the default mode)."""
+        from remarkable_mcp.write_tools import read_only_enabled, write_enabled
 
-        # Ensure env var is not set
-        old = os.environ.pop("REMARKABLE_ENABLE_WRITE", None)
+        old = os.environ.pop("REMARKABLE_READ_ONLY", None)
         try:
-            assert write_enabled() is False
+            assert write_enabled() is True
+            assert read_only_enabled() is False
         finally:
             if old is not None:
-                os.environ["REMARKABLE_ENABLE_WRITE"] = old
+                os.environ["REMARKABLE_READ_ONLY"] = old
 
-    def test_write_enabled_with_env_var(self):
-        """Test that write_enabled() returns True with env var."""
+    def test_read_only_env_var_disables_write(self):
+        """REMARKABLE_READ_ONLY disables write tools; falsy/unset leaves them on."""
+        from remarkable_mcp.write_tools import read_only_enabled, write_enabled
+
+        old = os.environ.get("REMARKABLE_READ_ONLY")
+        try:
+            for truthy in ("1", "true", "yes"):
+                os.environ["REMARKABLE_READ_ONLY"] = truthy
+                assert write_enabled() is False, truthy
+                assert read_only_enabled() is True, truthy
+
+            for falsy in ("0", "", "no"):
+                os.environ["REMARKABLE_READ_ONLY"] = falsy
+                assert write_enabled() is True, falsy
+                assert read_only_enabled() is False, falsy
+        finally:
+            if old is not None:
+                os.environ["REMARKABLE_READ_ONLY"] = old
+            else:
+                os.environ.pop("REMARKABLE_READ_ONLY", None)
+
+    def test_legacy_write_env_var_is_noop(self):
+        """The legacy REMARKABLE_ENABLE_WRITE var no longer affects write_enabled()."""
         from remarkable_mcp.write_tools import write_enabled
 
-        old = os.environ.get("REMARKABLE_ENABLE_WRITE")
+        old_enable = os.environ.get("REMARKABLE_ENABLE_WRITE")
+        old_ro = os.environ.pop("REMARKABLE_READ_ONLY", None)
         try:
-            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
-            assert write_enabled() is True
-
-            os.environ["REMARKABLE_ENABLE_WRITE"] = "true"
-            assert write_enabled() is True
-
-            os.environ["REMARKABLE_ENABLE_WRITE"] = "yes"
-            assert write_enabled() is True
-
+            # Even explicitly "disabling" via the legacy var keeps write on.
             os.environ["REMARKABLE_ENABLE_WRITE"] = "0"
-            assert write_enabled() is False
-
-            os.environ["REMARKABLE_ENABLE_WRITE"] = ""
+            assert write_enabled() is True
+            # Read-only still wins regardless of the legacy var.
+            os.environ["REMARKABLE_ENABLE_WRITE"] = "1"
+            os.environ["REMARKABLE_READ_ONLY"] = "1"
             assert write_enabled() is False
         finally:
-            if old is not None:
-                os.environ["REMARKABLE_ENABLE_WRITE"] = old
+            if old_enable is not None:
+                os.environ["REMARKABLE_ENABLE_WRITE"] = old_enable
             else:
                 os.environ.pop("REMARKABLE_ENABLE_WRITE", None)
+            os.environ.pop("REMARKABLE_READ_ONLY", None)
+            if old_ro is not None:
+                os.environ["REMARKABLE_READ_ONLY"] = old_ro
+
+    def test_read_only_blocks_write_transport(self):
+        """In read-only mode, _require_write_transport returns an educational error."""
+        import json
+
+        from remarkable_mcp.write_tools import _require_write_transport
+
+        old = os.environ.get("REMARKABLE_READ_ONLY")
+        try:
+            os.environ["REMARKABLE_READ_ONLY"] = "1"
+            err = _require_write_transport()
+            assert err is not None
+            payload = json.loads(err)
+            assert payload["_error"]["type"] == "write_disabled"
+            assert "--read-only" in payload["_error"]["suggestion"]
+        finally:
+            if old is not None:
+                os.environ["REMARKABLE_READ_ONLY"] = old
+            else:
+                os.environ.pop("REMARKABLE_READ_ONLY", None)
 
     @pytest.mark.asyncio
-    async def test_write_tools_not_registered_by_default(self):
-        """Test that write tools are NOT registered without --write flag."""
+    async def test_write_tools_registered_by_default(self):
+        """Write tools ARE registered by default (write-on); read-only would skip them."""
         tools = await mcp.list_tools()
         tool_names = [tool.name for tool in tools]
 
@@ -2557,13 +2596,13 @@ class TestWriteTools:
         ]
 
         for tool_name in write_tool_names:
-            assert tool_name not in tool_names, (
-                f"Write tool {tool_name} should not be registered without --write flag"
+            assert tool_name in tool_names, (
+                f"Write tool {tool_name} should be registered by default"
             )
 
     @pytest.mark.asyncio
     async def test_write_tools_registered_when_enabled(self):
-        """Test that write tools ARE registered with REMARKABLE_ENABLE_WRITE=1 in SSH mode."""
+        """Write tools register in SSH mode (default-on, re-registered explicitly here)."""
         from remarkable_mcp.write_tools import register_write_tools
 
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
@@ -2742,7 +2781,7 @@ class TestWriteTools:
 
         env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
         env.pop("REMARKABLE_USE_USB_WEB", None)
-        env["REMARKABLE_ENABLE_WRITE"] = "1"
+        env.pop("REMARKABLE_READ_ONLY", None)  # write is enabled by default
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
@@ -2815,7 +2854,7 @@ class TestCloudWriteDispatch:
     def _cloud_env(self):
         env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
         env.pop("REMARKABLE_USE_USB_WEB", None)
-        env["REMARKABLE_ENABLE_WRITE"] = "1"
+        env.pop("REMARKABLE_READ_ONLY", None)  # write is enabled by default
         return env
 
     def _make_item(self, doc_id, name, parent="", is_folder=False):
@@ -3680,3 +3719,56 @@ class TestCanvasRegisteredByDefault:
         result = await mcp.call_tool("remarkable_status", {})
         data = json.loads(result[0][0].text)
         assert "app_enabled" not in data
+
+
+# =============================================================================
+# Test CLI flag wiring (--write / --read-only)
+# =============================================================================
+
+
+class TestCLIFlags:
+    """CLI flag wiring for the write/read-only gate."""
+
+    def test_write_and_read_only_mutually_exclusive(self):
+        """Passing both --write and --read-only is an argparse error (exit 2)."""
+        from remarkable_mcp.cli import main
+
+        with patch.object(sys, "argv", ["remarkable-mcp", "--write", "--read-only"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 2
+
+    def test_read_only_flag_sets_env(self):
+        """--read-only sets REMARKABLE_READ_ONLY=1 before starting the server."""
+        from remarkable_mcp import cli
+
+        old = os.environ.pop("REMARKABLE_READ_ONLY", None)
+        try:
+            with (
+                patch.object(sys, "argv", ["remarkable-mcp", "--read-only"]),
+                patch("remarkable_mcp.server.run") as mock_run,
+            ):
+                cli.main()
+            mock_run.assert_called_once()
+            assert os.environ.get("REMARKABLE_READ_ONLY") == "1"
+        finally:
+            os.environ.pop("REMARKABLE_READ_ONLY", None)
+            if old is not None:
+                os.environ["REMARKABLE_READ_ONLY"] = old
+
+    def test_write_flag_is_accepted_noop(self):
+        """--write is accepted but does not enable read-only (write stays on)."""
+        from remarkable_mcp import cli
+
+        old = os.environ.pop("REMARKABLE_READ_ONLY", None)
+        try:
+            with (
+                patch.object(sys, "argv", ["remarkable-mcp", "--write"]),
+                patch("remarkable_mcp.server.run") as mock_run,
+            ):
+                cli.main()
+            mock_run.assert_called_once()
+            assert "REMARKABLE_READ_ONLY" not in os.environ
+        finally:
+            if old is not None:
+                os.environ["REMARKABLE_READ_ONLY"] = old


### PR DESCRIPTION
## Summary

Inverts the write gate so write tools are **enabled by default** in every transport, with a new `--read-only` opt-out. This is a single leaf-node change centered on `write_tools.write_enabled()`.

Previously, write tools (`upload`, `mkdir`, `move`, `rename`, `delete`) were opt-in behind `--write` / `REMARKABLE_ENABLE_WRITE`. Now they're on by default; pass `--read-only` (or set `REMARKABLE_READ_ONLY=1`) to expose a read-only server.

## Behavior

- **Default:** write tools active (cloud/SSH: full set; USB web: upload only).
- **`--read-only` / `REMARKABLE_READ_ONLY=1`:** all write tools are skipped → read-only server.
- **`--write`:** still accepted, now a **no-op** (write is the default). Kept for backward compatibility.
- **`REMARKABLE_ENABLE_WRITE`:** honored as an ignored **no-op** for backward compatibility.
- **`--write` and `--read-only` are mutually exclusive** (argparse error, exit code 2).

## Changes

- `write_tools.py`: `write_enabled()` → `not read_only_enabled()`; new `read_only_enabled()` helper; updated the read-only error message and the five tool docstrings.
- `cli.py`: `--read-only` flag (sets `REMARKABLE_READ_ONLY=1` in all run paths), placed in a mutually-exclusive group with `--write`; updated help and epilog examples.
- `server.py`: `_build_instructions()` reflects write-by-default and adds a cloud-mode write section.
- `tools.py`: `remarkable_status` docstring and the read-only hint inverted.
- Docs: `README.md`, `docs/tools.md`, `docs/future-plans.md` synced.

## Tests

- Tool counts updated 7 → 12 (default registers the 5 write tools).
- Rewrote the `TestWriteTools` gate tests around `REMARKABLE_READ_ONLY` (default-on, env toggling, legacy-var no-op, read-only blocks `_require_write_transport`, write tools registered by default).
- New `TestCLIFlags` class: `--write`/`--read-only` mutual exclusion, `--read-only` env wiring, `--write` no-op.

Verified in fresh processes: default → 12 tools / `write_enabled()=True`; `REMARKABLE_READ_ONLY=1` → 7 tools / `write_enabled()=False`.

All three CI gates pass: `uv run ruff check .`, `uv run ruff format --check .`, `uv run pytest test_server.py -v` (168 passed).

## Not in this PR

The larger write features (pen strokes, text-document builders, canvas write-back) remain follow-ups.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>