### PR TITLE
fix(write): refuse delete without confirmation instead of deleting silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ All three modes share the same read, render, and upload tools. **Cloud and SSH a
 | **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ | ✅ PDF | ✅ (to root) | ❌ |
 | **⚡ SSH** | Developer mode | Not required | ✅ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
 
-¹ Folder ops = create folder / move / rename / delete. Upload and folder ops are enabled by default; pass `--read-only` to expose a read-only server. Deletes move items to the trash and can prompt for confirmation when your client supports elicitation.
+¹ Folder ops = create folder / move / rename / delete. Upload and folder ops are enabled by default; pass `--read-only` to expose a read-only server. Deletes move items to the trash and prompt for confirmation when your client supports elicitation, and are refused without it unless `REMARKABLE_SKIP_CONFIRM=1` is set.
 
 ### Automatic cloud fallback
 
@@ -488,7 +488,7 @@ Or set the environment variable:
 
 - **Upload registers in all modes** — cloud, SSH, and USB web.
 - **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
-- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting; otherwise it relies on the host to gate the call. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to bypass the prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
+- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
 - After each write operation in SSH mode, the tablet UI restarts automatically to reflect changes.
 
 ### Examples

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -450,23 +450,53 @@ class _DeleteConfirmation(BaseModel):
 
 
 async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str]:
-    """Ask the user to confirm a delete when the client supports elicitation.
+    """Confirm a destructive delete before it runs.
 
-    Returns None to proceed, or a response string (cancellation) to abort.
-    Skips the prompt when elicitation isn't supported or REMARKABLE_SKIP_CONFIRM=1.
+    Returns None to proceed with the delete, or a response string (a
+    cancellation or a refusal) to abort.
+
+    Delete is destructive, so confirmation is required. It is bypassed only when
+    REMARKABLE_SKIP_CONFIRM=1 (for headless automation). When the client cannot
+    show a confirmation prompt — no elicitation support, or elicitation fails at
+    runtime — the delete is REFUSED rather than performed silently, so a client
+    that can't prompt the user cannot delete documents unattended. Write tools
+    are on by default, and most MCP clients don't support elicitation yet, so
+    this refusal path is the common case for unattended setups.
     """
     if os.environ.get("REMARKABLE_SKIP_CONFIRM", "").lower() in ("1", "true", "yes"):
         return None
     if ctx is None or not client_supports_elicitation(ctx):
-        return None
+        return make_error(
+            "confirmation_unavailable",
+            (
+                f"Refused to delete '{document}': this client cannot show a "
+                "confirmation prompt (no MCP elicitation support) and delete is "
+                "a destructive operation."
+            ),
+            (
+                "Confirm the delete from a client that supports elicitation, or "
+                "set REMARKABLE_SKIP_CONFIRM=1 to allow deletes without a prompt "
+                "(e.g. for headless automation)."
+            ),
+        )
     try:
         result = await ctx.elicit(
             message=f"Delete '{document}' from your reMarkable? This moves it to the trash.",
             schema=_DeleteConfirmation,
         )
-    except Exception as e:  # elicitation unsupported at runtime — proceed
-        logger.debug(f"Elicitation failed, proceeding without confirmation: {e}")
-        return None
+    except Exception as e:  # elicitation advertised but failed — refuse, don't delete
+        logger.debug(f"Elicitation failed, refusing delete without confirmation: {e}")
+        return make_error(
+            "confirmation_unavailable",
+            (
+                f"Refused to delete '{document}': the confirmation prompt could "
+                "not be shown and delete is a destructive operation."
+            ),
+            (
+                "Retry from a client that can display confirmation prompts, or "
+                "set REMARKABLE_SKIP_CONFIRM=1 to allow deletes without a prompt."
+            ),
+        )
     if result.action != "accept" or not getattr(result.data, "confirm", False):
         return make_response(
             {"deleted": False, "cancelled": True, "document": document},
@@ -985,8 +1015,9 @@ def register_write_tools():
             USB web interface.
 
             If the client supports elicitation, this tool asks the user to confirm
-            before deleting. Set REMARKABLE_SKIP_CONFIRM=1 to skip the prompt for
-            automation.
+            before deleting. If the client cannot show a confirmation prompt, the
+            delete is refused unless REMARKABLE_SKIP_CONFIRM=1 is set (for headless
+            automation).
             </instructions>
             <parameters>
             - document: Name or path of the document/folder to delete
@@ -1000,9 +1031,9 @@ def register_write_tools():
             if error:
                 return error
 
-            cancelled = await _confirm_delete(ctx, document)
-            if cancelled:
-                return cancelled
+            abort = await _confirm_delete(ctx, document)
+            if abort:
+                return abort
 
             if _is_cloud_mode():
                 return await asyncio.to_thread(_cloud_delete, document)

--- a/test_server.py
+++ b/test_server.py
@@ -2653,7 +2653,10 @@ class TestWriteTools:
                 patch("remarkable_mcp.write_tools.get_rmapi") as mock_get_rmapi,
                 patch("remarkable_mcp.write_tools._write_metadata") as mock_write_meta,
                 patch("remarkable_mcp.write_tools._restart_xochitl"),
-                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+                patch.dict(
+                    os.environ,
+                    {"REMARKABLE_USE_SSH": "1", "REMARKABLE_SKIP_CONFIRM": "1"},
+                ),
             ):
                 import importlib
 
@@ -2946,7 +2949,8 @@ class TestCloudWriteDispatch:
     async def test_cloud_delete_dispatch(self):
         from remarkable_mcp.write_tools import register_write_tools
 
-        with patch.dict(os.environ, self._cloud_env(), clear=True):
+        env = {**self._cloud_env(), "REMARKABLE_SKIP_CONFIRM": "1"}
+        with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
                 target = self._make_item("doc-1", "Old Notes")
@@ -2957,6 +2961,59 @@ class TestCloudWriteDispatch:
                 data = json.loads(result[0][0].text)
                 assert data["deleted"] is True
                 assert data["transport"] == "cloud"
+                client.delete.assert_called_once_with("doc-1")
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_delete_refused_without_elicitation(self):
+        """Default-on writes: a client that can't confirm must NOT delete silently."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        # No REMARKABLE_SKIP_CONFIRM, and the client does not support elicitation.
+        env = {k: v for k, v in self._cloud_env().items() if k != "REMARKABLE_SKIP_CONFIRM"}
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Old Notes")
+                client = Mock(spec=["get_meta_items", "delete"])
+                client.get_meta_items.return_value = [target]
+                with (
+                    patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                    patch(
+                        "remarkable_mcp.write_tools.client_supports_elicitation",
+                        return_value=False,
+                    ),
+                ):
+                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result[0][0].text)
+                assert data["_error"]["type"] == "confirmation_unavailable"
+                client.delete.assert_not_called()
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_delete_skip_confirm_bypasses_elicitation(self):
+        """REMARKABLE_SKIP_CONFIRM=1 allows deletes without a prompt (automation)."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        env = {**self._cloud_env(), "REMARKABLE_SKIP_CONFIRM": "1"}
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Old Notes")
+                client = Mock(spec=["get_meta_items", "delete"])
+                client.get_meta_items.return_value = [target]
+                with (
+                    patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                    patch(
+                        "remarkable_mcp.write_tools.client_supports_elicitation",
+                        return_value=False,
+                    ),
+                ):
+                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result[0][0].text)
+                assert data["deleted"] is True
                 client.delete.assert_called_once_with("doc-1")
             finally:
                 self._cleanup()


### PR DESCRIPTION
## Problem

After #113 flipped write tools to **on by default**, the delete-confirmation fallback became a safety hole.

`_confirm_delete()` returned `None` (= *proceed with the delete*) whenever:
- the client doesn't support MCP elicitation, or
- `ctx` is `None`, or
- `ctx.elicit()` raises at runtime.

With opt-in `--write` that only affected users who deliberately enabled writes. With writes **on by default**, it means **any client without elicitation support — which is most MCP clients today — can delete documents with no confirmation at all.**

## Fix

Flip the unsafe default. When confirmation can't be shown, **refuse** the delete and return an educational `confirmation_unavailable` error instead of silently deleting.

The existing `REMARKABLE_SKIP_CONFIRM=1` escape hatch is checked first and still allows unattended deletes for headless automation, so scripted/CI users are unaffected.

**Scope:** `delete` is the only destructive op gated by `_confirm_delete`. `upload`, `mkdir`, `move` and `rename` are additive/reversible and stay permissive.

## Tests

- `test_cloud_delete_refused_without_elicitation` — no SKIP_CONFIRM + no elicitation → `confirmation_unavailable`, `client.delete` **not** called.
- `test_cloud_delete_skip_confirm_bypasses_elicitation` — SKIP_CONFIRM=1 + no elicitation → deleted.
- Updated the two delete-success dispatch tests to set `REMARKABLE_SKIP_CONFIRM=1` (they exercise delete mechanics, not the confirmation UX).

README + `remarkable_delete` docstring updated to describe refuse-by-default.

✅ 170 tests pass · ruff + format clean.