### PR TITLE
feat: native ink/notebook authoring (remarkable_author) + canvas ＋Page flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,8 +524,7 @@ remarkable_author(method="add_page", document="Ideas")
 # Create a new (blank) notebook — the common case
 remarkable_author(method="create_document", name="Sketches")
 
-# Only seed typed text when explicitly requested. Typed text shows on the
-# device but not in the strokes-only canvas preview.
+# Only seed typed text when the user explicitly requested it.
 remarkable_author(method="create_document", name="Meeting notes", text="Agenda\nFollow-ups")
 ```
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,11 @@ remarkable_author(
 # Append a blank, drawable page to the end of a notebook
 remarkable_author(method="add_page", document="Ideas")
 
-# Create a new notebook, optionally seeding the first page with typed text
+# Create a new (blank) notebook — the common case
+remarkable_author(method="create_document", name="Sketches")
+
+# Only seed typed text when explicitly requested. Typed text shows on the
+# device but not in the strokes-only canvas preview.
 remarkable_author(method="create_document", name="Meeting notes", text="Agenda\nFollow-ups")
 ```
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
+These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, and `remarkable_author` for native ink/notebooks) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -483,6 +483,7 @@ Or set the environment variable:
 | `remarkable_move(document, dest_folder)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name)` | Rename a document or folder (cloud and SSH) |
 | `remarkable_delete(document)` | Delete a document or folder — destructive (cloud and SSH) |
+| `remarkable_author(method, ...)` | Author native ink and notebooks — `draw` (append strokes), `add_page` (append a blank notebook page), `create_document` (new notebook) — **SSH only** |
 
 ### Safety
 
@@ -508,6 +509,20 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 
 # Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
+
+# Author native ink and notebooks (SSH only)
+# Append pen/highlighter strokes to a page (coordinates normalized [0,1] from
+# the page's top-left). The interactive canvas Save button calls this too.
+remarkable_author(
+    method="draw", document="Ideas", page=1,
+    strokes=[{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "highlighter", "color": "yellow"}],
+)
+
+# Append a blank, drawable page to the end of a notebook
+remarkable_author(method="add_page", document="Ideas")
+
+# Create a new notebook, optionally seeding the first page with typed text
+remarkable_author(method="create_document", name="Meeting notes", text="Agenda\nFollow-ups")
 ```
 
 ---
@@ -529,12 +544,15 @@ How it behaves:
 - **App-capable clients** open the canvas (declared at `ui://remarkable/canvas`, MIME `text/html;profile=mcp-app`) and can page through the document via the MCP Apps postMessage bridge — the server delivers each rendered page in the tool result's `structuredContent`.
 - **Other clients** still get the rendered page back as an embedded PNG image, so the tool is useful everywhere; it just won't open the interactive panel. The `_meta.ui` / `ui://` metadata is inert to clients that don't advertise the MCP Apps UI extension.
 
-> **Note:** This phase is a **read-only** viewer (render + page navigation). Pen
-> capture, local undo, and an explicit Save button that writes annotations back
-> to the device are planned as later, device-validated phases; write-back will
-> ride the existing write gate (on by default, `--read-only` to disable) rather
-> than adding a new flag. The iframe bridge follows the MCP Apps spec but is best
-> validated against your specific client.
+### Drawing and authoring from the canvas
+
+When write mode is on (the default) **and** the active transport is SSH, the canvas becomes a write surface:
+
+- **Draw** — pick a pen or highlighter and colour, draw over the page, and **Save** writes the strokes back to the device as native `.rm` ink. Strokes are buffered locally per page (with **Undo** and **Cancel**) and only touch the device on Save.
+- **＋ Page** (native notebooks only) — queues a new blank page locally that you can navigate to and draw on immediately. **Save** materializes the queued page(s) on the device first, then writes any cached strokes.
+- One source of truth: the canvas calls the **same** `remarkable_author` tool a model would call (`method="draw"` on Save, `method="add_page"` for ＋Page), so the human path and the model path produce byte-identical results.
+
+The Save / Draw / ＋Page controls are hidden when the page isn't writable (read-only mode, or a non-SSH transport), and the canvas falls back to a plain image viewer. The iframe bridge follows the MCP Apps spec but is best validated against your specific client.
 
 ---
 

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -124,6 +124,7 @@ _CANVAS_HTML = """<!doctype html>
   var pending = {}, rpcId = 1;
   var state = { document: null, page: 1, total: 1, busy: false,
                 displayMode: "inline", displayModes: [],
+                appReady: false, fullscreenUnsupported: false,
                 writable: false, drawing: false, cache: {}, cur: null,
                 img: null, canvas: null };
 
@@ -222,13 +223,12 @@ _CANVAS_HTML = """<!doctype html>
     notify("ui/notifications/size-changed", { width: w, height: h });
   }
   function updateDisplayModeButton() {
-    // Per the MCP Apps spec, the View must only request a display mode the host
-    // advertises in hostContext.availableDisplayModes. Hide the control entirely
-    // when the host does not support fullscreen, rather than showing a button
-    // whose request the host silently declines.
+    // Offer the control in any app host once the handshake completes. We attempt
+    // the request optimistically (some hosts honor fullscreen without advertising
+    // it in availableDisplayModes) and self-correct: a declined request sets
+    // fullscreenUnsupported, hiding the button so we never leave a dead control.
     var btn = document.getElementById("full");
-    var canFull = state.displayModes.indexOf("fullscreen") !== -1;
-    btn.hidden = !canFull;
+    btn.hidden = !(state.appReady && !state.fullscreenUnsupported);
     btn.textContent = state.displayMode === "fullscreen" ? "Exit fullscreen" : "Fullscreen";
   }
   function applyHostContext(hc) {
@@ -373,8 +373,11 @@ _CANVAS_HTML = """<!doctype html>
   function refreshControls() {
     var w = !!state.writable;
     var dirty = totalCached() > 0;
-    document.getElementById("prev").disabled = state.busy || state.page <= 1;
-    document.getElementById("next").disabled = state.busy || state.page >= state.total;
+    // Lock page navigation while drawing so strokes can't be stranded on a page
+    // the user has navigated away from. They click "Done drawing" to move pages.
+    var navLock = state.busy || state.drawing;
+    document.getElementById("prev").disabled = navLock || state.page <= 1;
+    document.getElementById("next").disabled = navLock || state.page >= state.total;
     var drawBtn = document.getElementById("draw");
     drawBtn.hidden = !w;
     drawBtn.textContent = state.drawing ? "Done drawing" : "Draw";
@@ -421,12 +424,23 @@ _CANVAS_HTML = """<!doctype html>
   document.getElementById("cancel").onclick = cancelEdits;
   document.getElementById("full").onclick = function () {
     var want = state.displayMode === "fullscreen" ? "inline" : "fullscreen";
-    if (want === "fullscreen" && state.displayModes.indexOf("fullscreen") === -1) return;
     rpc("ui/request-display-mode", { mode: want }).then(function (res) {
       // Host returns the mode actually set (may differ from the request).
       if (res && res.mode) state.displayMode = res.mode;
+      if (want === "fullscreen" && state.displayMode !== "fullscreen") {
+        // Host accepted the call but didn't switch -> treat as unsupported.
+        state.fullscreenUnsupported = true;
+        document.getElementById("footer").textContent =
+          "This client does not support fullscreen.";
+      }
       updateDisplayModeButton();
-    }).catch(function () {});
+      sizeOverlay(); redrawOverlay(); notifySize();
+    }).catch(function () {
+      state.fullscreenUnsupported = true;
+      document.getElementById("footer").textContent =
+        "This client does not support fullscreen.";
+      updateDisplayModeButton();
+    });
   };
 
   window.addEventListener("message", function (event) {
@@ -481,15 +495,19 @@ _CANVAS_HTML = """<!doctype html>
     clientInfo: { name: "remarkable-canvas", version: "1" },
     appCapabilities: { availableDisplayModes: ["inline", "fullscreen"] },
   }).then(function (res) {
+    state.appReady = true;
     notify("ui/notifications/initialized", {});
     // Capture host context (theme, supported display modes, dimensions) so the
     // fullscreen control is only offered when the host actually supports it.
     if (res && res.hostContext) applyHostContext(res.hostContext);
+    updateDisplayModeButton();
     var d = digOut(res);
     if (d) render(d);
   }).catch(function () {
     // Some hosts push tool-input/result without a handshake reply; that's fine.
+    state.appReady = true;
     notify("ui/notifications/initialized", {});
+    updateDisplayModeButton();
   });
 })();
 </script>

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -130,7 +130,8 @@ _CANVAS_HTML = """<!doctype html>
                 appReady: false, fullscreenUnsupported: false,
                 writable: false, drawing: false, cache: {}, cur: null,
                 img: null, canvas: null, fileType: "", pendingPages: 0,
-                stageEl: null, natW: 0, natH: 0, paperW: 1404, paperH: 1872 };
+                stageEl: null, natW: 0, natH: 0, paperW: 1404, paperH: 1872,
+                transport: "", writeMode: false };
 
   function post(msg) {
     try { window.parent.postMessage(msg, "*"); } catch (e) {}
@@ -182,6 +183,8 @@ _CANVAS_HTML = """<!doctype html>
     if (data.total_pages) state.total = data.total_pages;
     if (typeof data.writable === "boolean") state.writable = data.writable;
     if (typeof data.file_type === "string") state.fileType = data.file_type;
+    if (typeof data.transport === "string") state.transport = data.transport;
+    if (typeof data.write_mode === "boolean") state.writeMode = data.write_mode;
     if (data.paper_size && data.paper_size.length === 2) {
       state.paperW = data.paper_size[0]; state.paperH = data.paper_size[1];
     }
@@ -464,7 +467,15 @@ _CANVAS_HTML = """<!doctype html>
     cancel.disabled = state.busy || !dirty;
     var footer = document.getElementById("footer");
     if (!w) {
-      footer.textContent = "Read-only viewer";
+      // Distinguish the two reasons a page isn't writable so the canvas message
+      // matches what the draw tool would return: read-only MODE vs non-SSH
+      // TRANSPORT (write is on, but native write-back needs the SSH transport).
+      if (state.writeMode && state.transport && state.transport !== "ssh") {
+        footer.textContent =
+          "View-only over this connection — connect via SSH (USB cable + SSH enabled) to draw.";
+      } else {
+        footer.textContent = "Read-only viewer";
+      }
     } else if (dirty) {
       var parts = [];
       if (state.pendingPages > 0) parts.push(state.pendingPages + " new page(s)");
@@ -776,9 +787,13 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     from remarkable_mcp.write_tools import write_enabled
 
     transport = get_active_transport()
+    write_mode = bool(write_enabled())
     # The canvas can write strokes back only over SSH (the filesystem transport),
-    # and only when write mode is on. Surface that so the app shows/hides Save.
-    writable = bool(write_enabled()) and transport == "ssh"
+    # and only when write mode is on. Surface both the combined `writable` flag
+    # (Save/Draw/＋Page visibility) AND its two inputs (`write_mode`, `transport`)
+    # so the app can explain WHY a page isn't writable — distinguishing read-only
+    # mode from a non-SSH transport, mirroring the draw tool's own error.
+    writable = write_mode and transport == "ssh"
 
     structured = {
         "document": doc_path,
@@ -792,6 +807,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         "render_source": render_source,
         "file_type": file_type,
         "transport": transport,
+        "write_mode": write_mode,
         "writable": writable,
     }
 

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -56,7 +56,7 @@ _CANVAS_HTML = """<!doctype html>
 <title>reMarkable Canvas</title>
 <style>
   :root { color-scheme: light dark; }
-  html, body { margin: 0; height: 100%; }
+  html, body { margin: 0; }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     display: flex; flex-direction: column; background: #1e1e1e; color: #e8e8e8;
@@ -64,6 +64,7 @@ _CANVAS_HTML = """<!doctype html>
   header {
     display: flex; align-items: center; gap: .5rem; padding: .5rem .75rem;
     border-bottom: 1px solid rgba(255,255,255,.12); flex: 0 0 auto;
+    position: sticky; top: 0; background: #1e1e1e; z-index: 2; flex-wrap: wrap;
   }
   header .title { font-weight: 600; flex: 1 1 auto; overflow: hidden;
     text-overflow: ellipsis; white-space: nowrap; }
@@ -73,9 +74,9 @@ _CANVAS_HTML = """<!doctype html>
   }
   button:disabled { opacity: .4; cursor: default; }
   .pageinfo { font-variant-numeric: tabular-nums; min-width: 5rem; text-align: center; }
-  main { flex: 1 1 auto; overflow: auto; display: flex; align-items: flex-start;
+  main { flex: 1 1 auto; display: flex; align-items: flex-start;
     justify-content: center; padding: 1rem; }
-  img { max-width: 100%; height: auto; background: #fbfbfb;
+  img { display: block; max-width: 100%; height: auto; background: #fbfbfb;
     box-shadow: 0 1px 8px rgba(0,0,0,.4); border-radius: 2px; }
   .status { padding: 1rem; opacity: .8; }
   .stage { position: relative; display: inline-block; line-height: 0; }
@@ -201,7 +202,23 @@ _CANVAS_HTML = """<!doctype html>
     notifySize();
   }
   function notifySize() {
-    var h = document.body.scrollHeight, w = document.body.scrollWidth;
+    // Report an explicit height derived from the host-given width and the
+    // page image's natural aspect ratio. Using document.body.scrollHeight is
+    // circular here (the image is max-width:100%, so its height depends on the
+    // width the host gives us, which the host is in turn deriving from our
+    // reported height) and collapses the view to a thin strip in some hosts.
+    var w = document.body.scrollWidth || document.documentElement.clientWidth;
+    var h = document.body.scrollHeight;
+    var img = state.img;
+    if (img && img.naturalWidth && img.naturalHeight) {
+      var head = document.querySelector("header");
+      var foot = document.getElementById("footer");
+      var chrome = (head ? head.offsetHeight : 0) + (foot ? foot.offsetHeight : 0);
+      var availW = Math.max(80, (document.body.clientWidth || w) - 32); // main padding
+      var dispW = Math.min(availW, img.naturalWidth);
+      var dispH = img.naturalHeight * (dispW / img.naturalWidth);
+      h = Math.ceil(chrome + dispH + 32);
+    }
     notify("ui/notifications/size-changed", { width: w, height: h });
   }
   function updateDisplayModeButton() {
@@ -453,7 +470,7 @@ _CANVAS_HTML = """<!doctype html>
     }
   });
 
-  window.addEventListener("resize", function () { sizeOverlay(); redrawOverlay(); });
+  window.addEventListener("resize", function () { sizeOverlay(); redrawOverlay(); notifySize(); });
 
   // Handshake: announce the app (with protocol version + client info, as the
   // spec requires) and the display modes it can use, then signal that we are

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -542,7 +542,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         find_similar_documents,
         get_background_color,
         get_document_page_count,
-        render_page_from_document_zip,
+        render_page_full_page_from_document_zip,
         render_tablet_pdf_page_to_png,
     )
     from remarkable_mcp.responses import make_error
@@ -614,10 +614,20 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
                 suggestion=f"Use page=1 to {total_pages} to view different pages.",
             )
 
-        png_data = await run_blocking(
-            render_page_from_document_zip, tmp_path, page, background_color=background
+        # Full-page render addressed by cPages index (coherent with the write
+        # tool) so the overlay's normalized coordinates map exactly onto stroke
+        # space and blank pages still render. paper_size is the page's own
+        # coordinate extent, surfaced so the model can draw in-bounds.
+        paper_size = None
+        full = await run_blocking(
+            render_page_full_page_from_document_zip, tmp_path, page, background_color=background
         )
         render_source = "strokes"
+        if full is not None:
+            png_data, paper_wh = full
+            paper_size = [round(paper_wh[0]), round(paper_wh[1])]
+        else:
+            png_data = None
         if png_data is None:
             pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
             if pdf_bytes:
@@ -667,6 +677,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         "png_data_uri": data_uri,
         "page_width_px": width_px,
         "page_height_px": height_px,
+        "paper_size": paper_size,
         "render_source": render_source,
         "transport": transport,
         "writable": writable,
@@ -677,14 +688,31 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     # Audience split (MCP content annotations): the rendered page image is for the
     # USER (it's large base64 the model never needs to read), while a lean text
     # digest carries the page/doc/writable facts the model may want — keeping the
-    # model's context free of the image blob.
+    # model's context free of the image blob. When the page is writable we also
+    # give the model the drawable geometry + coordinate convention so it can
+    # compose in-bounds strokes for remarkable_canvas_write without seeing the
+    # image (it draws blind, so these bounds are how it stays on the page).
+    digest = (
+        f"Page {page}/{total_pages} of '{target_doc.VissibleName}' "
+        f"(transport={transport}, writable={'yes' if writable else 'no'})."
+    )
+    if writable and paper_size:
+        digest += (
+            f" Drawable page area is {paper_size[0]}x{paper_size[1]} in the page's own"
+            " coordinate units. To draw, call remarkable_canvas_write(document, page, strokes)"
+            " where each stroke's points are normalized [0,1] from the page's TOP-LEFT"
+            " (x rightwards, y downwards); they map onto this exact page. Pass many strokes"
+            " in one call."
+        )
+    elif writable:
+        digest += (
+            " To draw, call remarkable_canvas_write(document, page, strokes) with points"
+            " normalized [0,1] from the page's TOP-LEFT."
+        )
+    digest += " Rendered in the interactive canvas; the page image is shown to the user."
     info = types.TextContent(
         type="text",
-        text=(
-            f"Page {page}/{total_pages} of '{target_doc.VissibleName}' "
-            f"(transport={transport}, writable={'yes' if writable else 'no'}). "
-            "Rendered in the interactive canvas; the page image is shown to the user."
-        ),
+        text=digest,
         annotations=types.Annotations(audience=["assistant"]),
     )
     image = types.EmbeddedResource(

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -78,6 +78,8 @@ _CANVAS_HTML = """<!doctype html>
     justify-content: center; padding: 1rem; }
   img { display: block; max-width: 100%; height: auto; background: #fbfbfb;
     box-shadow: 0 1px 8px rgba(0,0,0,.4); border-radius: 2px; }
+  .blankpage { display: block; max-width: 100%; background: #fbfbfb;
+    box-shadow: 0 1px 8px rgba(0,0,0,.4); border-radius: 2px; }
   .status { padding: 1rem; opacity: .8; }
   .stage { position: relative; display: inline-block; line-height: 0; }
   .stage canvas.ink { position: absolute; left: 0; top: 0;
@@ -97,6 +99,7 @@ _CANVAS_HTML = """<!doctype html>
     <button id="prev" disabled>&larr; Prev</button>
     <span class="pageinfo" id="pageinfo">--</span>
     <button id="next" disabled>Next &rarr;</button>
+    <button id="addpage" hidden>+ Page</button>
     <button id="full" hidden>Fullscreen</button>
     <button id="draw" hidden>Draw</button>
     <span class="tools" id="tools" hidden>
@@ -126,7 +129,8 @@ _CANVAS_HTML = """<!doctype html>
                 displayMode: "inline", displayModes: [],
                 appReady: false, fullscreenUnsupported: false,
                 writable: false, drawing: false, cache: {}, cur: null,
-                img: null, canvas: null };
+                img: null, canvas: null, fileType: "", pendingPages: 0,
+                stageEl: null, natW: 0, natH: 0, paperW: 1404, paperH: 1872 };
 
   function post(msg) {
     try { window.parent.postMessage(msg, "*"); } catch (e) {}
@@ -177,10 +181,12 @@ _CANVAS_HTML = """<!doctype html>
     if (data.page) state.page = data.page;
     if (data.total_pages) state.total = data.total_pages;
     if (typeof data.writable === "boolean") state.writable = data.writable;
+    if (typeof data.file_type === "string") state.fileType = data.file_type;
+    if (data.paper_size && data.paper_size.length === 2) {
+      state.paperW = data.paper_size[0]; state.paperH = data.paper_size[1];
+    }
     document.getElementById("title").textContent =
       data.document_name || data.document || "reMarkable Canvas";
-    document.getElementById("pageinfo").textContent =
-      state.page + " / " + state.total;
     if (data.png_data_uri) {
       var m = document.querySelector("main");
       m.innerHTML = "";
@@ -194,30 +200,61 @@ _CANVAS_HTML = """<!doctype html>
       stage.appendChild(cv);
       m.appendChild(stage);
       state.img = img;
+      state.stageEl = img;
       state.canvas = cv;
       bindDrawing(cv);
-      img.onload = function () { sizeOverlay(); redrawOverlay(); notifySize(); };
+      img.onload = function () {
+        state.natW = img.naturalWidth; state.natH = img.naturalHeight;
+        sizeOverlay(); redrawOverlay(); notifySize();
+      };
       img.src = data.png_data_uri;
     }
     refreshControls();
     notifySize();
   }
+  function effectiveTotal() { return state.total + state.pendingPages; }
+  function isPending(page) { return page > state.total; }
+  function renderPending() {
+    // A locally-added page that does not exist on the device yet. We render a
+    // blank page sized to the document's paper aspect ratio so the user can draw
+    // on it immediately; Save materializes it (remarkable_author add_page) and
+    // then writes the cached strokes. Nothing touches the device until Save.
+    var m = document.querySelector("main");
+    m.innerHTML = "";
+    var stage = document.createElement("div");
+    stage.className = "stage";
+    var page = document.createElement("div");
+    page.className = "blankpage";
+    page.style.width = state.paperW + "px";
+    page.style.aspectRatio = state.paperW + " / " + state.paperH;
+    var cv = document.createElement("canvas");
+    cv.className = "ink";
+    stage.appendChild(page);
+    stage.appendChild(cv);
+    m.appendChild(stage);
+    state.img = null;
+    state.stageEl = page;
+    state.natW = state.paperW; state.natH = state.paperH;
+    state.canvas = cv;
+    bindDrawing(cv);
+    sizeOverlay(); redrawOverlay(); notifySize();
+    refreshControls();
+  }
   function notifySize() {
     // Report an explicit height derived from the host-given width and the
-    // page image's natural aspect ratio. Using document.body.scrollHeight is
-    // circular here (the image is max-width:100%, so its height depends on the
-    // width the host gives us, which the host is in turn deriving from our
+    // page's natural aspect ratio. Using document.body.scrollHeight is
+    // circular here (the page box is max-width:100%, so its height depends on
+    // the width the host gives us, which the host is in turn deriving from our
     // reported height) and collapses the view to a thin strip in some hosts.
     var w = document.body.scrollWidth || document.documentElement.clientWidth;
     var h = document.body.scrollHeight;
-    var img = state.img;
-    if (img && img.naturalWidth && img.naturalHeight) {
+    if (state.natW && state.natH) {
       var head = document.querySelector("header");
       var foot = document.getElementById("footer");
       var chrome = (head ? head.offsetHeight : 0) + (foot ? foot.offsetHeight : 0);
       var availW = Math.max(80, (document.body.clientWidth || w) - 32); // main padding
-      var dispW = Math.min(availW, img.naturalWidth);
-      var dispH = img.naturalHeight * (dispW / img.naturalWidth);
+      var dispW = Math.min(availW, state.natW);
+      var dispH = state.natH * (dispW / state.natW);
       h = Math.ceil(chrome + dispH + 32);
     }
     notify("ui/notifications/size-changed", { width: w, height: h });
@@ -240,7 +277,7 @@ _CANVAS_HTML = """<!doctype html>
 
   // ---- Drawing: a client-side per-page stroke cache (the transaction buffer).
   // Strokes accumulate locally; nothing touches the device until Save flushes
-  // them through remarkable_canvas_write. Cancel discards the cache.
+  // them through remarkable_author(method:"draw"). Cancel discards the cache.
   function pageStrokes() {
     if (!state.cache[state.page]) state.cache[state.page] = [];
     return state.cache[state.page];
@@ -263,9 +300,9 @@ _CANVAS_HTML = """<!doctype html>
     return [Math.max(0, Math.min(1, nx)), Math.max(0, Math.min(1, ny))];
   }
   function sizeOverlay() {
-    var img = state.img, cv = state.canvas;
-    if (!img || !cv) return;
-    var w = img.clientWidth, h = img.clientHeight;
+    var el = state.stageEl, cv = state.canvas;
+    if (!el || !cv) return;
+    var w = el.clientWidth, h = el.clientHeight;
     cv.width = w; cv.height = h;
     cv.style.width = w + "px"; cv.style.height = h + "px";
     cv.style.pointerEvents = state.drawing ? "auto" : "none";
@@ -326,11 +363,20 @@ _CANVAS_HTML = """<!doctype html>
   function cancelEdits() {
     state.cache = {};
     state.cur = null;
+    var wasPending = isPending(state.page);
+    state.pendingPages = 0;
+    if (wasPending) {
+      // We were viewing a discarded pending page; fall back to the last real page.
+      goto(state.total);
+      return;
+    }
     redrawOverlay();
     refreshControls();
   }
   function saveEdits() {
-    if (state.busy || totalCached() === 0) return;
+    if (state.busy) return;
+    if (totalCached() === 0 && state.pendingPages === 0) return;
+    var pendingToAdd = state.pendingPages;
     var pages = [];
     for (var k in state.cache) {
       if (state.cache[k] && state.cache[k].length) pages.push(parseInt(k, 10));
@@ -338,46 +384,74 @@ _CANVAS_HTML = """<!doctype html>
     pages.sort(function (a, b) { return a - b; });
     state.busy = true;
     refreshControls();
-    var i = 0;
-    function step() {
+    function fail(msg) {
+      state.busy = false;
+      setStatus("Save failed: " + msg);
+      refreshControls();
+    }
+    // Phase B: write the cached strokes for every dirty page.
+    function drawNext(i) {
       if (i >= pages.length) {
         state.cache = {};
         state.busy = false;
         goto(state.page); // re-render to show the strokes baked by the device render
         return;
       }
-      var pg = pages[i++];
+      var pg = pages[i];
       rpc("tools/call", {
-        name: "remarkable_canvas_write",
+        name: "remarkable_author",
         arguments: {
+          method: "draw",
           document: state.document, page: pg,
           strokes: state.cache[pg], ui_submitted: true,
         },
       }).then(function (result) {
         var out = digText(result);
-        if (out && out._error) {
-          state.busy = false;
-          setStatus("Save failed: " + out._error.message);
-          refreshControls();
-          return;
-        }
-        step();
+        if (out && out._error) { fail(out._error.message); return; }
+        drawNext(i + 1);
       }).catch(function (err) {
-        state.busy = false;
-        setStatus("Save failed: " + (err && err.message ? err.message : err));
-        refreshControls();
+        fail(err && err.message ? err.message : err);
       });
     }
-    step();
+    // Phase A: materialize the locally-added blank pages on the device first, so
+    // the page numbers the strokes target actually exist before we draw on them.
+    var added = 0;
+    function addNext() {
+      if (added >= pendingToAdd) {
+        state.total += pendingToAdd;
+        state.pendingPages = 0;
+        drawNext(0);
+        return;
+      }
+      added++;
+      rpc("tools/call", {
+        name: "remarkable_author",
+        arguments: { method: "add_page", document: state.document, ui_submitted: true },
+      }).then(function (result) {
+        var out = digText(result);
+        if (out && out._error) { fail(out._error.message); return; }
+        addNext();
+      }).catch(function (err) {
+        fail(err && err.message ? err.message : err);
+      });
+    }
+    addNext();
   }
   function refreshControls() {
     var w = !!state.writable;
-    var dirty = totalCached() > 0;
+    var dirty = totalCached() > 0 || state.pendingPages > 0;
+    var total = effectiveTotal();
+    document.getElementById("pageinfo").textContent =
+      state.page + " / " + total + (isPending(state.page) ? " (new)" : "");
     // Lock page navigation while drawing so strokes can't be stranded on a page
     // the user has navigated away from. They click "Done drawing" to move pages.
     var navLock = state.busy || state.drawing;
     document.getElementById("prev").disabled = navLock || state.page <= 1;
-    document.getElementById("next").disabled = navLock || state.page >= state.total;
+    document.getElementById("next").disabled = navLock || state.page >= total;
+    var addBtn = document.getElementById("addpage");
+    // +Page only applies to native notebooks (PDFs/EPUBs have fixed pages).
+    addBtn.hidden = !(w && state.fileType === "notebook");
+    addBtn.disabled = state.busy || state.drawing;
     var drawBtn = document.getElementById("draw");
     drawBtn.hidden = !w;
     drawBtn.textContent = state.drawing ? "Done drawing" : "Draw";
@@ -392,16 +466,32 @@ _CANVAS_HTML = """<!doctype html>
     if (!w) {
       footer.textContent = "Read-only viewer";
     } else if (dirty) {
-      footer.innerHTML = '<span class="dirty">' + totalCached() +
-        " unsaved stroke(s) — Save writes them to your reMarkable.</span>";
+      var parts = [];
+      if (state.pendingPages > 0) parts.push(state.pendingPages + " new page(s)");
+      if (totalCached() > 0) parts.push(totalCached() + " stroke(s)");
+      footer.innerHTML = '<span class="dirty">' + parts.join(" + ") +
+        " unsaved — Save writes them to your reMarkable.</span>";
     } else {
       footer.textContent = "Draw mode — strokes are saved to your reMarkable on Save.";
     }
   }
 
+  function addPage() {
+    if (state.busy || state.drawing) return;
+    if (!(state.writable && state.fileType === "notebook")) return;
+    state.pendingPages++;
+    goto(effectiveTotal()); // navigate to the newly added (pending) page
+  }
+
   function goto(page) {
     if (state.busy || !state.document) return;
-    if (page < 1 || page > state.total) return;
+    if (page < 1 || page > effectiveTotal()) return;
+    if (isPending(page)) {
+      // A locally-added page that isn't on the device yet — render it blank.
+      state.page = page;
+      renderPending();
+      return;
+    }
     state.busy = true;
     render({});
     rpc("tools/call", {
@@ -418,6 +508,7 @@ _CANVAS_HTML = """<!doctype html>
 
   document.getElementById("prev").onclick = function () { goto(state.page - 1); };
   document.getElementById("next").onclick = function () { goto(state.page + 1); };
+  document.getElementById("addpage").onclick = addPage;
   document.getElementById("draw").onclick = function () { setDrawing(!state.drawing); };
   document.getElementById("undo").onclick = undo;
   document.getElementById("save").onclick = saveEdits;
@@ -559,6 +650,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     from remarkable_mcp.extract import (
         find_similar_documents,
         get_background_color,
+        get_document_file_type,
         get_document_page_count,
         render_page_full_page_from_document_zip,
         render_tablet_pdf_page_to_png,
@@ -616,6 +708,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
 
     try:
         total_pages = await run_blocking(get_document_page_count, tmp_path)
+        file_type = await run_blocking(get_document_file_type, tmp_path)
         if total_pages == 0:
             return make_error(
                 error_type="no_pages",
@@ -697,6 +790,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         "page_height_px": height_px,
         "paper_size": paper_size,
         "render_source": render_source,
+        "file_type": file_type,
         "transport": transport,
         "writable": writable,
     }
@@ -708,8 +802,9 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     # digest carries the page/doc/writable facts the model may want — keeping the
     # model's context free of the image blob. When the page is writable we also
     # give the model the drawable geometry + coordinate convention so it can
-    # compose in-bounds strokes for remarkable_canvas_write without seeing the
-    # image (it draws blind, so these bounds are how it stays on the page).
+    # compose in-bounds strokes for remarkable_author(method="draw") without
+    # seeing the image (it draws blind, so these bounds are how it stays on the
+    # page).
     digest = (
         f"Page {page}/{total_pages} of '{target_doc.VissibleName}' "
         f"(transport={transport}, writable={'yes' if writable else 'no'})."
@@ -717,15 +812,20 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     if writable and paper_size:
         digest += (
             f" Drawable page area is {paper_size[0]}x{paper_size[1]} in the page's own"
-            " coordinate units. To draw, call remarkable_canvas_write(document, page, strokes)"
-            " where each stroke's points are normalized [0,1] from the page's TOP-LEFT"
-            " (x rightwards, y downwards); they map onto this exact page. Pass many strokes"
-            " in one call."
+            ' coordinate units. To draw, call remarkable_author(method="draw", document,'
+            " page, strokes) where each stroke's points are normalized [0,1] from the"
+            " page's TOP-LEFT (x rightwards, y downwards); they map onto this exact page."
+            " Pass many strokes in one call."
         )
     elif writable:
         digest += (
-            " To draw, call remarkable_canvas_write(document, page, strokes) with points"
-            " normalized [0,1] from the page's TOP-LEFT."
+            ' To draw, call remarkable_author(method="draw", document, page, strokes)'
+            " with points normalized [0,1] from the page's TOP-LEFT."
+        )
+    if writable and file_type == "notebook":
+        digest += (
+            " To append a blank page to this notebook, call"
+            ' remarkable_author(method="add_page", document).'
         )
     digest += " Rendered in the interactive canvas; the page image is shown to the user."
     info = types.TextContent(

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -78,8 +78,16 @@ _CANVAS_HTML = """<!doctype html>
   img { max-width: 100%; height: auto; background: #fbfbfb;
     box-shadow: 0 1px 8px rgba(0,0,0,.4); border-radius: 2px; }
   .status { padding: 1rem; opacity: .8; }
+  .stage { position: relative; display: inline-block; line-height: 0; }
+  .stage canvas.ink { position: absolute; left: 0; top: 0;
+    touch-action: none; cursor: crosshair; }
+  .tools { display: flex; align-items: center; gap: .4rem; }
+  .tools[hidden] { display: none; }
+  select { font: inherit; padding: .3rem; border-radius: .4rem;
+    background: #2d2d2d; color: inherit; border: 1px solid rgba(255,255,255,.2); }
   footer { flex: 0 0 auto; padding: .35rem .75rem; font-size: .8rem; opacity: .6;
     border-top: 1px solid rgba(255,255,255,.12); }
+  footer .dirty { color: #ffd479; }
 </style>
 </head>
 <body>
@@ -88,7 +96,24 @@ _CANVAS_HTML = """<!doctype html>
     <button id="prev" disabled>&larr; Prev</button>
     <span class="pageinfo" id="pageinfo">--</span>
     <button id="next" disabled>Next &rarr;</button>
-    <button id="full">Fullscreen</button>
+    <button id="full" hidden>Fullscreen</button>
+    <button id="draw" hidden>Draw</button>
+    <span class="tools" id="tools" hidden>
+      <select id="tool" title="Pen">
+        <option value="fineliner">Pen</option>
+        <option value="highlighter">Highlighter</option>
+      </select>
+      <select id="color" title="Color">
+        <option value="black">Black</option>
+        <option value="gray">Gray</option>
+        <option value="red">Red</option>
+        <option value="blue">Blue</option>
+        <option value="yellow">Yellow</option>
+      </select>
+      <button id="undo" disabled>Undo</button>
+    </span>
+    <button id="save" hidden disabled>Save</button>
+    <button id="cancel" hidden disabled>Cancel</button>
   </header>
   <main><div class="status" id="status">Loading&hellip;</div></main>
   <footer id="footer">Read-only viewer</footer>
@@ -96,7 +121,10 @@ _CANVAS_HTML = """<!doctype html>
 (function () {
   "use strict";
   var pending = {}, rpcId = 1;
-  var state = { document: null, page: 1, total: 1, busy: false };
+  var state = { document: null, page: 1, total: 1, busy: false,
+                displayMode: "inline", displayModes: [],
+                writable: false, drawing: false, cache: {}, cur: null,
+                img: null, canvas: null };
 
   function post(msg) {
     try { window.parent.postMessage(msg, "*"); } catch (e) {}
@@ -126,32 +154,229 @@ _CANVAS_HTML = """<!doctype html>
       return payload.toolResult.structuredContent;
     return null;
   }
+  function digText(payload) {
+    // Tools that return a string (make_response / make_error) put JSON in the
+    // first text content block. Parse it so the app can read success / _error.
+    try {
+      var r = payload && (payload.result || payload.toolResult || payload);
+      var c = r && r.content;
+      if (c && c.length) {
+        for (var i = 0; i < c.length; i++) {
+          if (c[i] && c[i].type === "text" && c[i].text) return JSON.parse(c[i].text);
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
   function render(data) {
     if (!data) return;
     if (data.error) { setStatus("Error: " + data.error); return; }
     if (data.document) state.document = data.document;
     if (data.page) state.page = data.page;
     if (data.total_pages) state.total = data.total_pages;
+    if (typeof data.writable === "boolean") state.writable = data.writable;
     document.getElementById("title").textContent =
       data.document_name || data.document || "reMarkable Canvas";
     document.getElementById("pageinfo").textContent =
       state.page + " / " + state.total;
-    document.getElementById("prev").disabled = state.busy || state.page <= 1;
-    document.getElementById("next").disabled =
-      state.busy || state.page >= state.total;
     if (data.png_data_uri) {
       var m = document.querySelector("main");
       m.innerHTML = "";
+      var stage = document.createElement("div");
+      stage.className = "stage";
       var img = document.createElement("img");
-      img.src = data.png_data_uri;
       img.alt = "Page " + state.page;
-      m.appendChild(img);
+      var cv = document.createElement("canvas");
+      cv.className = "ink";
+      stage.appendChild(img);
+      stage.appendChild(cv);
+      m.appendChild(stage);
+      state.img = img;
+      state.canvas = cv;
+      bindDrawing(cv);
+      img.onload = function () { sizeOverlay(); redrawOverlay(); notifySize(); };
+      img.src = data.png_data_uri;
     }
+    refreshControls();
     notifySize();
   }
   function notifySize() {
     var h = document.body.scrollHeight, w = document.body.scrollWidth;
     notify("ui/notifications/size-changed", { width: w, height: h });
+  }
+  function updateDisplayModeButton() {
+    // Per the MCP Apps spec, the View must only request a display mode the host
+    // advertises in hostContext.availableDisplayModes. Hide the control entirely
+    // when the host does not support fullscreen, rather than showing a button
+    // whose request the host silently declines.
+    var btn = document.getElementById("full");
+    var canFull = state.displayModes.indexOf("fullscreen") !== -1;
+    btn.hidden = !canFull;
+    btn.textContent = state.displayMode === "fullscreen" ? "Exit fullscreen" : "Fullscreen";
+  }
+  function applyHostContext(hc) {
+    if (!hc) return;
+    if (Array.isArray(hc.availableDisplayModes)) state.displayModes = hc.availableDisplayModes;
+    if (hc.displayMode) state.displayMode = hc.displayMode;
+    updateDisplayModeButton();
+  }
+
+  // ---- Drawing: a client-side per-page stroke cache (the transaction buffer).
+  // Strokes accumulate locally; nothing touches the device until Save flushes
+  // them through remarkable_canvas_write. Cancel discards the cache.
+  function pageStrokes() {
+    if (!state.cache[state.page]) state.cache[state.page] = [];
+    return state.cache[state.page];
+  }
+  function totalCached() {
+    var n = 0;
+    for (var k in state.cache) { if (state.cache[k]) n += state.cache[k].length; }
+    return n;
+  }
+  function penTool() { return document.getElementById("tool").value; }
+  function penColor() { return document.getElementById("color").value; }
+  function colorCss(c) {
+    return ({ black: "#111", gray: "#888", red: "#e23", blue: "#36c",
+      yellow: "rgba(240,220,60,.45)" })[c] || "#111";
+  }
+  function ptOf(e) {
+    var r = state.canvas.getBoundingClientRect();
+    var nx = (e.clientX - r.left) / r.width;
+    var ny = (e.clientY - r.top) / r.height;
+    return [Math.max(0, Math.min(1, nx)), Math.max(0, Math.min(1, ny))];
+  }
+  function sizeOverlay() {
+    var img = state.img, cv = state.canvas;
+    if (!img || !cv) return;
+    var w = img.clientWidth, h = img.clientHeight;
+    cv.width = w; cv.height = h;
+    cv.style.width = w + "px"; cv.style.height = h + "px";
+    cv.style.pointerEvents = state.drawing ? "auto" : "none";
+  }
+  function drawPoly(ctx, stroke, w, h) {
+    var pts = stroke.points;
+    if (!pts || !pts.length) return;
+    ctx.lineJoin = ctx.lineCap = "round";
+    ctx.strokeStyle = colorCss(stroke.color);
+    ctx.lineWidth = stroke.tool === "highlighter" ? 16 : 2.5;
+    ctx.beginPath();
+    for (var i = 0; i < pts.length; i++) {
+      var x = pts[i][0] * w, y = pts[i][1] * h;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+  function redrawOverlay() {
+    var cv = state.canvas;
+    if (!cv) return;
+    var ctx = cv.getContext("2d");
+    ctx.clearRect(0, 0, cv.width, cv.height);
+    var list = state.cache[state.page] || [];
+    for (var i = 0; i < list.length; i++) drawPoly(ctx, list[i], cv.width, cv.height);
+    if (state.cur) drawPoly(ctx, state.cur, cv.width, cv.height);
+  }
+  function bindDrawing(cv) {
+    cv.onpointerdown = function (e) {
+      if (!state.drawing || state.busy) return;
+      try { cv.setPointerCapture(e.pointerId); } catch (err) {}
+      state.cur = { points: [ptOf(e)], tool: penTool(), color: penColor() };
+      e.preventDefault();
+    };
+    cv.onpointermove = function (e) {
+      if (!state.cur) return;
+      state.cur.points.push(ptOf(e));
+      redrawOverlay();
+    };
+    function endStroke() {
+      if (!state.cur) return;
+      if (state.cur.points.length >= 2) pageStrokes().push(state.cur);
+      state.cur = null;
+      redrawOverlay();
+      refreshControls();
+    }
+    cv.onpointerup = endStroke;
+    cv.onpointercancel = endStroke;
+  }
+  function setDrawing(on) {
+    state.drawing = on;
+    if (state.canvas) state.canvas.style.pointerEvents = on ? "auto" : "none";
+    refreshControls();
+  }
+  function undo() {
+    var list = pageStrokes();
+    if (list.length) { list.pop(); redrawOverlay(); refreshControls(); }
+  }
+  function cancelEdits() {
+    state.cache = {};
+    state.cur = null;
+    redrawOverlay();
+    refreshControls();
+  }
+  function saveEdits() {
+    if (state.busy || totalCached() === 0) return;
+    var pages = [];
+    for (var k in state.cache) {
+      if (state.cache[k] && state.cache[k].length) pages.push(parseInt(k, 10));
+    }
+    pages.sort(function (a, b) { return a - b; });
+    state.busy = true;
+    refreshControls();
+    var i = 0;
+    function step() {
+      if (i >= pages.length) {
+        state.cache = {};
+        state.busy = false;
+        goto(state.page); // re-render to show the strokes baked by the device render
+        return;
+      }
+      var pg = pages[i++];
+      rpc("tools/call", {
+        name: "remarkable_canvas_write",
+        arguments: {
+          document: state.document, page: pg,
+          strokes: state.cache[pg], ui_submitted: true,
+        },
+      }).then(function (result) {
+        var out = digText(result);
+        if (out && out._error) {
+          state.busy = false;
+          setStatus("Save failed: " + out._error.message);
+          refreshControls();
+          return;
+        }
+        step();
+      }).catch(function (err) {
+        state.busy = false;
+        setStatus("Save failed: " + (err && err.message ? err.message : err));
+        refreshControls();
+      });
+    }
+    step();
+  }
+  function refreshControls() {
+    var w = !!state.writable;
+    var dirty = totalCached() > 0;
+    document.getElementById("prev").disabled = state.busy || state.page <= 1;
+    document.getElementById("next").disabled = state.busy || state.page >= state.total;
+    var drawBtn = document.getElementById("draw");
+    drawBtn.hidden = !w;
+    drawBtn.textContent = state.drawing ? "Done drawing" : "Draw";
+    document.getElementById("tools").hidden = !(w && state.drawing);
+    document.getElementById("undo").disabled = state.busy || pageStrokes().length === 0;
+    var save = document.getElementById("save");
+    var cancel = document.getElementById("cancel");
+    save.hidden = cancel.hidden = !w;
+    save.disabled = state.busy || !dirty;
+    cancel.disabled = state.busy || !dirty;
+    var footer = document.getElementById("footer");
+    if (!w) {
+      footer.textContent = "Read-only viewer";
+    } else if (dirty) {
+      footer.innerHTML = '<span class="dirty">' + totalCached() +
+        " unsaved stroke(s) — Save writes them to your reMarkable.</span>";
+    } else {
+      footer.textContent = "Draw mode — strokes are saved to your reMarkable on Save.";
+    }
   }
 
   function goto(page) {
@@ -173,8 +398,18 @@ _CANVAS_HTML = """<!doctype html>
 
   document.getElementById("prev").onclick = function () { goto(state.page - 1); };
   document.getElementById("next").onclick = function () { goto(state.page + 1); };
+  document.getElementById("draw").onclick = function () { setDrawing(!state.drawing); };
+  document.getElementById("undo").onclick = undo;
+  document.getElementById("save").onclick = saveEdits;
+  document.getElementById("cancel").onclick = cancelEdits;
   document.getElementById("full").onclick = function () {
-    rpc("ui/request-display-mode", { mode: "fullscreen" }).catch(function () {});
+    var want = state.displayMode === "fullscreen" ? "inline" : "fullscreen";
+    if (want === "fullscreen" && state.displayModes.indexOf("fullscreen") === -1) return;
+    rpc("ui/request-display-mode", { mode: want }).then(function (res) {
+      // Host returns the mode actually set (may differ from the request).
+      if (res && res.mode) state.displayMode = res.mode;
+      updateDisplayModeButton();
+    }).catch(function () {});
   };
 
   window.addEventListener("message", function (event) {
@@ -186,6 +421,13 @@ _CANVAS_HTML = """<!doctype html>
         delete pending[msg.id];
         if (msg.error) p.reject(msg.error); else p.resolve(msg.result);
       }
+      return;
+    }
+    // Host-initiated request: the spec sends ui/resource-teardown before
+    // removing the View. We can't persist async work mid-teardown, so just
+    // acknowledge so the host isn't left waiting. (The View cannot close itself.)
+    if (msg.id !== undefined && msg.method === "ui/resource-teardown") {
+      post({ jsonrpc: "2.0", id: msg.id, result: {} });
       return;
     }
     // Input/result asymmetry (per the MCP Apps spec): tool-input params are
@@ -203,7 +445,15 @@ _CANVAS_HTML = """<!doctype html>
       render(digOut(msg.params) || {});
       return;
     }
+    if (msg.method === "ui/notifications/host-context-changed") {
+      // Host pushes partial context updates (theme, displayMode, available
+      // modes, resize). Merge display-mode fields and refresh the control.
+      applyHostContext(msg.params || {});
+      return;
+    }
   });
+
+  window.addEventListener("resize", function () { sizeOverlay(); redrawOverlay(); });
 
   // Handshake: announce the app (with protocol version + client info, as the
   // spec requires) and the display modes it can use, then signal that we are
@@ -215,6 +465,9 @@ _CANVAS_HTML = """<!doctype html>
     appCapabilities: { availableDisplayModes: ["inline", "fullscreen"] },
   }).then(function (res) {
     notify("ui/notifications/initialized", {});
+    // Capture host context (theme, supported display modes, dimensions) so the
+    // fullscreen control is only offered when the host actually supports it.
+    if (res && res.hostContext) applyHostContext(res.hostContext);
     var d = digOut(res);
     if (d) render(d);
   }).catch(function () {
@@ -382,6 +635,13 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     except Exception:
         pass
 
+    from remarkable_mcp.write_tools import write_enabled
+
+    transport = get_active_transport()
+    # The canvas can write strokes back only over SSH (the filesystem transport),
+    # and only when write mode is on. Surface that so the app shows/hides Save.
+    writable = bool(write_enabled()) and transport == "ssh"
+
     structured = {
         "document": doc_path,
         "document_name": target_doc.VissibleName,
@@ -391,21 +651,32 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         "page_width_px": width_px,
         "page_height_px": height_px,
         "render_source": render_source,
-        "transport": get_active_transport(),
-        "writable": False,
+        "transport": transport,
+        "writable": writable,
     }
 
     resource_uri = f"remarkableimg:///{doc_path.lstrip('/')}.page-{page}.png"
     blob = types.BlobResourceContents(uri=resource_uri, mimeType="image/png", blob=png_base64)
+    # Audience split (MCP content annotations): the rendered page image is for the
+    # USER (it's large base64 the model never needs to read), while a lean text
+    # digest carries the page/doc/writable facts the model may want — keeping the
+    # model's context free of the image blob.
     info = types.TextContent(
         type="text",
         text=(
-            f"Page {page}/{total_pages} of '{target_doc.VissibleName}'. "
-            "Open in an MCP Apps-capable client to view the interactive canvas."
+            f"Page {page}/{total_pages} of '{target_doc.VissibleName}' "
+            f"(transport={transport}, writable={'yes' if writable else 'no'}). "
+            "Rendered in the interactive canvas; the page image is shown to the user."
         ),
+        annotations=types.Annotations(audience=["assistant"]),
+    )
+    image = types.EmbeddedResource(
+        type="resource",
+        resource=blob,
+        annotations=types.Annotations(audience=["user"]),
     )
     return types.CallToolResult(
-        content=[info, types.EmbeddedResource(type="resource", resource=blob)],
+        content=[info, image],
         structuredContent=structured,
     )
 

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -10,7 +10,7 @@ import time
 import zipfile
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,11 @@ REMARKABLE_BACKGROUND_COLOR = get_background_color()
 
 # Margin around content when using content-based bounding box (in pixels)
 CONTENT_MARGIN = 50
+
+# Target long-edge resolution (px) for a full-page canvas render. The page is
+# rasterised at this resolution preserving the page aspect; the displayed image
+# is then scaled by the host, so this only sets crispness, not layout.
+FULL_PAGE_TARGET_LONG_EDGE = 1872
 
 # Cache TTL in seconds (5 minutes)
 CACHE_TTL_SECONDS = 300
@@ -462,22 +467,48 @@ def _render_rm_v5_to_svg(rm_file_path: Path) -> Optional[str]:
         return None
 
 
-def _render_rm_v6_to_svg(rm_file_path: Path) -> Optional[str]:
-    """
-    Render a v6 .rm file to SVG using rmscene to parse the CRDT block format.
-
-    This handles newer reMarkable firmware that uses the v6 format with
-    scene tree blocks, including proper highlighter and color support.
-    """
+def _v6_blocks(rm_file_path: Path) -> Optional[list]:
+    """Read v6 .rm scene blocks, or None if the file is not v6 / unreadable."""
     try:
         from rmscene import read_blocks
     except ImportError:
         return None
+    try:
+        with open(rm_file_path, "rb") as f:
+            header = f.read(43)
+            if b"version=6" not in header:
+                return None
+            f.seek(0)
+            return list(read_blocks(f))
+    except Exception:
+        return None
 
-    # Use integer values for pen/color matching (rmscene exposes ints on blocks)
+
+def _v6_paper_size(blocks: list) -> Tuple[float, float]:
+    """Page extent (W, H) in stroke units, read from SceneInfo.paper_size.
+
+    This is the authoritative stroke-coordinate extent for the page and the
+    same value the write path (``strokes.page_geometry``) maps normalized
+    coordinates into. Building a full-page render from it therefore makes the
+    displayed image share ONE coordinate space with written strokes (so the
+    drawing overlay and the write tool land ink in the same place). Falls back
+    to the standard reMarkable page when no SceneInfo is present.
+    """
+    for b in blocks:
+        ps = getattr(b, "paper_size", None)
+        if ps and len(ps) == 2 and ps[0] and ps[1]:
+            try:
+                return float(ps[0]), float(ps[1])
+            except (TypeError, ValueError):
+                continue
+    return float(REMARKABLE_WIDTH), float(REMARKABLE_HEIGHT)
+
+
+def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
+    """Build SVG ``<path>`` strings + a flat coordinate list from v6 blocks."""
+    # Integer pen/color values (rmscene exposes ints on blocks).
     HIGHLIGHTER_PENS = {5, 18}  # HIGHLIGHTER_1, HIGHLIGHTER_2
     ERASER_PENS = {6, 8}  # ERASER, ERASER_AREA
-
     COLOR_MAP = {
         0: "black",  # BLACK
         1: "#808080",  # GRAY
@@ -495,63 +526,71 @@ def _render_rm_v6_to_svg(rm_file_path: Path) -> Optional[str]:
         13: "#FFD700",  # YELLOW_2
     }
 
-    try:
-        with open(rm_file_path, "rb") as f:
-            header = f.read(43)
-            if b"version=6" not in header:
-                return None
-            f.seek(0)
-            blocks = list(read_blocks(f))
+    paths: list = []
+    all_coords: list = []
+    for block in blocks:
+        if not hasattr(block, "item") or not hasattr(block.item, "value"):
+            continue
+        line = block.item.value
+        if not hasattr(line, "points") or not line.points:
+            continue
 
-        paths = []
-        all_coords = []
-        for block in blocks:
-            if not hasattr(block, "item") or not hasattr(block.item, "value"):
-                continue
-            line = block.item.value
-            if not hasattr(line, "points") or not line.points:
-                continue
+        tool = line.tool if hasattr(line, "tool") else None
+        color = line.color if hasattr(line, "color") else 0
+        # Convert enums to int if needed
+        tool = tool.value if hasattr(tool, "value") else tool
+        color = color.value if hasattr(color, "value") else color
 
-            tool = line.tool if hasattr(line, "tool") else None
-            color = line.color if hasattr(line, "color") else 0
-            # Convert enums to int if needed
-            tool = tool.value if hasattr(tool, "value") else tool
-            color = color.value if hasattr(color, "value") else color
+        if tool in ERASER_PENS:
+            continue
 
-            if tool in ERASER_PENS:
-                continue
+        is_highlighter = tool in HIGHLIGHTER_PENS
+        stroke_color = COLOR_MAP.get(color, "black")
 
-            is_highlighter = tool in HIGHLIGHTER_PENS
-            stroke_color = COLOR_MAP.get(color, "black")
-
-            if is_highlighter:
-                avg_width = (
-                    sum(p.width for p in line.points) / len(line.points)
-                    if all(hasattr(p, "width") for p in line.points)
-                    else 20.0
-                )
-                stroke_width = max(10.0, min(avg_width * 2.0, 40.0))
-                opacity = ' opacity="0.35"'
-            else:
-                avg_width = (
-                    sum(p.width for p in line.points) / len(line.points)
-                    if all(hasattr(p, "width") for p in line.points)
-                    else 2.0
-                )
-                stroke_width = max(0.5, min(avg_width * 0.8, 5.0))
-                opacity = ""
-
-            d = f"M {line.points[0].x:.1f} {line.points[0].y:.1f}"
-            d += "".join(f" L {p.x:.1f} {p.y:.1f}" for p in line.points[1:])
-            all_coords.extend((p.x, p.y) for p in line.points)
-
-            paths.append(
-                f'<path d="{d}" stroke="{stroke_color}" '
-                f'stroke-width="{stroke_width:.1f}" '
-                f'fill="none" stroke-linecap="round" '
-                f'stroke-linejoin="round"{opacity}/>'
+        if is_highlighter:
+            avg_width = (
+                sum(p.width for p in line.points) / len(line.points)
+                if all(hasattr(p, "width") for p in line.points)
+                else 20.0
             )
+            stroke_width = max(10.0, min(avg_width * 2.0, 40.0))
+            opacity = ' opacity="0.35"'
+        else:
+            avg_width = (
+                sum(p.width for p in line.points) / len(line.points)
+                if all(hasattr(p, "width") for p in line.points)
+                else 2.0
+            )
+            stroke_width = max(0.5, min(avg_width * 0.8, 5.0))
+            opacity = ""
 
+        d = f"M {line.points[0].x:.1f} {line.points[0].y:.1f}"
+        d += "".join(f" L {p.x:.1f} {p.y:.1f}" for p in line.points[1:])
+        all_coords.extend((p.x, p.y) for p in line.points)
+
+        paths.append(
+            f'<path d="{d}" stroke="{stroke_color}" '
+            f'stroke-width="{stroke_width:.1f}" '
+            f'fill="none" stroke-linecap="round" '
+            f'stroke-linejoin="round"{opacity}/>'
+        )
+    return paths, all_coords
+
+
+def _render_rm_v6_to_svg(rm_file_path: Path) -> Optional[str]:
+    """
+    Render a v6 .rm file to a content-cropped SVG (read-only viewing).
+
+    This handles newer reMarkable firmware that uses the v6 format with
+    scene tree blocks, including proper highlighter and color support. The
+    viewBox is cropped to the ink bounding box; for a full-page render that
+    shares the page's own coordinate space, see ``render_rm_file_full_page_png``.
+    """
+    blocks = _v6_blocks(rm_file_path)
+    if blocks is None:
+        return None
+    try:
+        paths, all_coords = _v6_paths_from_blocks(blocks)
         return _svg_from_paths(paths, all_coords)
     except Exception:
         return None
@@ -672,6 +711,79 @@ def render_rm_file_to_png(
             tmp_png_path.unlink(missing_ok=True)
         if tmp_raw_path:
             tmp_raw_path.unlink(missing_ok=True)
+
+
+def _svg_full_page(paths: list, paper_w: float, paper_h: float) -> str:
+    """Wrap paths in an SVG whose viewBox spans the WHOLE page in stroke units.
+
+    The page coordinate system is center-origin in X (x in [-W/2, W/2]) and
+    top-origin in Y (y in [0, H]) — the same mapping ``strokes._map_point``
+    uses (``rm_x = (nx-0.5)*W``, ``rm_y = ny*H``). So a point drawn at
+    normalized (nx, ny) over the rendered image lands at exactly the stroke
+    coordinate the write tool will use. Empty ``paths`` yields a blank page.
+    """
+    min_x = -paper_w / 2.0
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="{min_x:.0f} 0 {paper_w:.0f} {paper_h:.0f}" '
+        f'width="{paper_w:.0f}" height="{paper_h:.0f}">'
+        f"{''.join(paths)}</svg>"
+    )
+
+
+def _svg_string_to_png(
+    svg: str, output_width: int, output_height: int, background_color: Optional[str]
+) -> Optional[bytes]:
+    """Rasterize an in-memory SVG string to PNG bytes via cairosvg."""
+    try:
+        import cairosvg
+    except ImportError:
+        return None
+    try:
+        return cairosvg.svg2png(
+            bytestring=svg.encode("utf-8"),
+            output_width=output_width,
+            output_height=output_height,
+            background_color=background_color,
+        )
+    except Exception:
+        return None
+
+
+def render_rm_file_full_page_png(
+    rm_file_path: Path, background_color: Optional[str] = None
+) -> Optional[Tuple[bytes, Tuple[float, float]]]:
+    """Render a v6 .rm page to a FULL-PAGE PNG (not cropped to ink).
+
+    Unlike ``render_rm_file_to_png`` (which crops the viewBox to the ink
+    bounding box), this renders the whole page using a viewBox derived from the
+    page's own ``SceneInfo.paper_size``. That makes the displayed image map
+    linearly to the page's coordinate system, so the interactive drawing
+    overlay places strokes exactly where the write tool will, and blank pages
+    render as a blank page instead of returning ``None``.
+
+    Returns ``(png_bytes, (paper_w, paper_h))`` or ``None`` if the file is not
+    v6 or rendering dependencies are unavailable (callers should fall back).
+    """
+    blocks = _v6_blocks(rm_file_path)
+    if blocks is None:
+        return None
+    try:
+        paths, _ = _v6_paths_from_blocks(blocks)
+        paper_w, paper_h = _v6_paper_size(blocks)
+    except Exception:
+        return None
+
+    svg = _svg_full_page(paths, paper_w, paper_h)
+    scale = FULL_PAGE_TARGET_LONG_EDGE / max(paper_w, paper_h)
+    output_width = max(1, round(paper_w * scale))
+    output_height = max(1, round(paper_h * scale))
+
+    png = _svg_string_to_png(svg, output_width, output_height, background_color)
+    if png is None:
+        return None
+    return png, (paper_w, paper_h)
 
 
 def render_rm_file_to_svg(
@@ -878,6 +990,77 @@ def render_page_from_document_zip(
         # Render the requested page
         target_rm_file = rm_files[page - 1]
         return render_rm_file_to_png(target_rm_file, background_color=background_color)
+
+
+def _document_paper_size(rm_files: List[Path]) -> Tuple[float, float]:
+    """Best-effort page extent for a document by scanning its .rm files.
+
+    Used to render a blank page (one with no .rm of its own) at the same size
+    as the rest of the document. Falls back to the standard reMarkable page.
+    """
+    for p in rm_files:
+        blocks = _v6_blocks(p)
+        if blocks:
+            return _v6_paper_size(blocks)
+    return float(REMARKABLE_WIDTH), float(REMARKABLE_HEIGHT)
+
+
+def render_page_full_page_from_document_zip(
+    zip_path: Path, page: int = 1, background_color: Optional[str] = None
+) -> Optional[Tuple[bytes, Tuple[float, float]]]:
+    """Full-page render of a page, addressed by cPages index.
+
+    This is the render used by the interactive canvas. It differs from
+    ``render_page_from_document_zip`` in two ways that matter for write-back:
+
+    1. Pages are addressed by the ``.content`` cPages order — the SAME index
+       the write tool (``_page_ids_from_content``) uses — so "page N" means the
+       same page in the viewer and the writer even when blank pages (which may
+       have no ``.rm`` file) are present.
+    2. The page is rendered full-bleed using its own ``SceneInfo.paper_size``,
+       so the overlay's normalized coordinates map exactly onto stroke space.
+
+    Returns ``(png_bytes, (paper_w, paper_h))`` or ``None`` (caller falls back
+    to PDF rasterization or an error).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmpdir_path)
+
+        rm_glob = list(tmpdir_path.glob("**/*.rm"))
+
+        entries = _read_cpages_entries(tmpdir_path)
+        page_ids = [e.get("id") for e in entries if isinstance(e, dict) and e.get("id")]
+
+        if page_ids:
+            if page < 1 or page > len(page_ids):
+                return None
+            page_id = page_ids[page - 1]
+            rm_file = next((p for p in rm_glob if p.stem == page_id), None)
+        else:
+            # No cPages metadata: fall back to filesystem/page order of .rm files.
+            ordered = _get_ordered_rm_files(tmpdir_path)
+            if page < 1 or page > len(ordered):
+                return None
+            rm_file = ordered[page - 1]
+
+        if rm_file is not None and rm_file.exists():
+            return render_rm_file_full_page_png(rm_file, background_color=background_color)
+
+        # The page exists in cPages but has no .rm layer yet (a blank page):
+        # render a blank full page at the document's paper size so the viewer
+        # still shows it. (The write tool will return no_page_layer until the
+        # page has a drawable layer / has been added via remarkable_add_page.)
+        paper_w, paper_h = _document_paper_size(rm_glob)
+        svg = _svg_full_page([], paper_w, paper_h)
+        scale = FULL_PAGE_TARGET_LONG_EDGE / max(paper_w, paper_h)
+        png = _svg_string_to_png(
+            svg, max(1, round(paper_w * scale)), max(1, round(paper_h * scale)), background_color
+        )
+        if png is None:
+            return None
+        return png, (paper_w, paper_h)
 
 
 def document_zip_has_pdf_underlay(zip_path: Path) -> bool:

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1426,6 +1426,28 @@ def get_document_page_count(zip_path: Path) -> int:
         return len(list(tmpdir_path.glob("**/*.rm")))
 
 
+def get_document_file_type(zip_path: Path) -> str:
+    """
+    Read the ``fileType`` from a document zip's ``.content`` file.
+
+    Returns one of "notebook", "pdf", "epub", or "" when it cannot be
+    determined. Reads only the ``.content`` entry from the zip (no full
+    extraction) so it is cheap to call alongside get_document_page_count.
+    """
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            for name in zf.namelist():
+                if name.endswith(".content"):
+                    try:
+                        data = json.loads(zf.read(name).decode("utf-8"))
+                    except Exception:
+                        return ""
+                    return str(data.get("fileType", "") or "")
+    except Exception:
+        pass
+    return ""
+
+
 def extract_text_from_document_zip(
     zip_path: Path, include_ocr: bool = False, doc_id: Optional[str] = None
 ) -> Dict[str, Any]:

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -11,6 +11,7 @@ import zipfile
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from xml.sax.saxutils import escape as _xml_escape
 
 logger = logging.getLogger(__name__)
 
@@ -577,6 +578,88 @@ def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
     return paths, all_coords
 
 
+# reMarkable typed-text layout, in stroke/screen units. Mirrors the rmc
+# exporter (github.com/ricklupton/rmc) so typed text (a RootTextBlock) renders
+# in the full-page view at the same place the device draws it. rmc lays text
+# out in a 72/226-DPI point space; our full-page SVG works in raw screen units,
+# so point font sizes are converted to screen units via _PT_TO_SCREEN.
+_TEXT_TOP_Y = -88
+_PT_TO_SCREEN = 226.0 / 72.0
+
+
+def _v6_text_svg_elements(blocks: list) -> list:
+    """Build SVG ``<text>`` strings for typed text (a RootTextBlock) on a page.
+
+    Returns an empty list when the page has no typed text (the common case for
+    handwritten notebooks) or when rmscene's text helpers are unavailable.
+    Coordinates are in the page's own stroke/screen units (center-origin X),
+    matching :func:`_svg_full_page`, so text lands where the device shows it.
+    """
+    try:
+        from rmscene.scene_items import ParagraphStyle, Text
+        from rmscene.text import TextDocument
+    except ImportError:
+        return []
+
+    text_item = next(
+        (b.value for b in blocks if isinstance(getattr(b, "value", None), Text)),
+        None,
+    )
+    if text_item is None:
+        return []
+
+    # Blank pages we synthesize carry an empty RootTextBlock; skip them so we
+    # neither emit empty <text> nodes nor trigger rmscene's empty-item warning.
+    try:
+        if not any(isinstance(v, str) and v.strip() for v in text_item.items.values()):
+            return []
+    except Exception:
+        pass
+
+    line_heights = {
+        ParagraphStyle.PLAIN: 70,
+        ParagraphStyle.HEADING: 150,
+        ParagraphStyle.BOLD: 70,
+        ParagraphStyle.BULLET: 35,
+        ParagraphStyle.BULLET2: 35,
+        ParagraphStyle.CHECKBOX: 35,
+        ParagraphStyle.CHECKBOX_CHECKED: 35,
+    }
+    font_sizes = {
+        ParagraphStyle.HEADING: 14 * _PT_TO_SCREEN,
+        ParagraphStyle.BOLD: 8 * _PT_TO_SCREEN,
+    }
+    default_font = 7 * _PT_TO_SCREEN
+
+    try:
+        doc = TextDocument.from_scene_item(text_item)
+    except Exception:
+        return []
+
+    pos_x = float(getattr(text_item, "pos_x", 0.0) or 0.0)
+    pos_y = float(getattr(text_item, "pos_y", 0.0) or 0.0)
+
+    elements: list = []
+    y_offset = _TEXT_TOP_Y
+    for para in doc.contents:
+        style = para.style.value if getattr(para, "style", None) is not None else None
+        y_offset += line_heights.get(style, 70)
+        text = str(para).strip()
+        if not text:
+            continue
+        size = font_sizes.get(style, default_font)
+        family = "serif" if style == ParagraphStyle.HEADING else "sans-serif"
+        weight = (
+            ' font-weight="bold"' if style in (ParagraphStyle.BOLD, ParagraphStyle.HEADING) else ""
+        )
+        elements.append(
+            f'<text x="{pos_x:.1f}" y="{pos_y + y_offset:.1f}" '
+            f'font-family="{family}" font-size="{size:.1f}"{weight} '
+            f'fill="black" xml:space="preserve">{_xml_escape(text)}</text>'
+        )
+    return elements
+
+
 def _render_rm_v6_to_svg(rm_file_path: Path) -> Optional[str]:
     """
     Render a v6 .rm file to a content-cropped SVG (read-only viewing).
@@ -771,11 +854,14 @@ def render_rm_file_full_page_png(
         return None
     try:
         paths, _ = _v6_paths_from_blocks(blocks)
+        text_elements = _v6_text_svg_elements(blocks)
         paper_w, paper_h = _v6_paper_size(blocks)
     except Exception:
         return None
 
-    svg = _svg_full_page(paths, paper_w, paper_h)
+    # Typed text is drawn first so handwritten strokes layer on top of it,
+    # matching the device's compositing order.
+    svg = _svg_full_page(text_elements + paths, paper_w, paper_h)
     scale = FULL_PAGE_TARGET_LONG_EDGE / max(paper_w, paper_h)
     output_width = max(1, round(paper_w * scale))
     output_height = max(1, round(paper_h * scale))

--- a/remarkable_mcp/notebooks.py
+++ b/remarkable_mcp/notebooks.py
@@ -1,0 +1,208 @@
+"""Pure-logic builders for new reMarkable notebooks, pages, and text documents.
+
+There is no transport / SSH here. These functions produce the bytes and JSON
+dicts that the SSH write path uploads to the tablet:
+
+- A drawable ``.rm`` page (blank, or seeded with typed text).
+- A ``.content`` file describing a native notebook (the ``cPages`` page index).
+- A ``.metadata`` file describing the document.
+- Helpers to append a page entry to an existing notebook's ``.content``.
+
+Pages are built with rmscene's blessed :func:`simple_text_document` builder so
+every generated page contains a real drawable layer node. This is the same
+mechanism validated by :mod:`remarkable_mcp.strokes` (``find_target_layer``
+succeeds on the output, so strokes can be appended immediately afterwards).
+``simple_text_document`` emits no ``SceneInfo`` block, so the page renders and
+writes at the default paper size (see :data:`DEFAULT_PAPER`).
+"""
+
+from __future__ import annotations
+
+import io
+import time
+import uuid as _uuid
+from typing import Optional
+
+from rmscene import simple_text_document, write_blocks
+
+from remarkable_mcp.strokes import WRITE_VERSION
+
+# reMarkable 1/2 portrait stroke space. simple_text_document emits no SceneInfo,
+# so render + write both fall back to this; keep them consistent.
+DEFAULT_PAPER = (1404, 1872)
+
+
+def new_uuid() -> str:
+    """Return a fresh lowercase UUID string for a document or page id."""
+    return str(_uuid.uuid4())
+
+
+def _author_uuid(author_uuid: Optional[str]):
+    """Coerce an author uuid (str/UUID/None) into a ``uuid.UUID``.
+
+    A fresh author uuid is generated when none is supplied so the ``.rm``
+    ``AuthorIdsBlock`` and the ``.content`` ``cPages.uuids`` entry can be kept
+    consistent by the caller.
+    """
+    if author_uuid is None:
+        return _uuid.uuid4()
+    if isinstance(author_uuid, _uuid.UUID):
+        return author_uuid
+    return _uuid.UUID(str(author_uuid))
+
+
+def page_rm_bytes(text: str = "", author_uuid: Optional[str] = None) -> bytes:
+    """Return serialized ``.rm`` bytes for a single drawable page.
+
+    With ``text=""`` this is a blank page; with text it is seeded with typed
+    paragraphs (split on newlines). The result always contains a drawable layer
+    node, so :func:`remarkable_mcp.strokes.append_strokes` works on it.
+    """
+    au = _author_uuid(author_uuid)
+    blocks = list(simple_text_document(text, author_uuid=au))
+    buf = io.BytesIO()
+    write_blocks(buf, blocks, options={"version": WRITE_VERSION})
+    return buf.getvalue()
+
+
+def blank_page_rm_bytes(author_uuid: Optional[str] = None) -> bytes:
+    """Return serialized ``.rm`` bytes for a blank drawable page."""
+    return page_rm_bytes("", author_uuid=author_uuid)
+
+
+def next_page_idx(existing_idx_values: list[str]) -> str:
+    """Return a fractional ``idx.value`` that sorts after all existing ones.
+
+    reMarkable orders pages by these lexicographically-sorted keys (the first
+    pages of a notebook are ``ba``, ``bb``, ``bc``, ...). To append at the end
+    we take the current maximum and produce the next strictly-greater key by
+    incrementing its trailing character (or appending ``a`` when it is already
+    ``z``, which still sorts after the original as a longer prefix-extension).
+    """
+    values = [v for v in existing_idx_values if isinstance(v, str) and v]
+    if not values:
+        return "ba"
+    last = max(values)
+    tail = last[-1]
+    if tail < "z":
+        return last[:-1] + chr(ord(tail) + 1)
+    return last + "a"
+
+
+def _page_entry(page_id: str, idx_value: str, template: str = "Blank") -> dict:
+    """Build a single ``cPages.pages[]`` entry."""
+    return {
+        "id": page_id,
+        "idx": {"timestamp": "1:2", "value": idx_value},
+        "template": {"timestamp": "1:2", "value": template},
+    }
+
+
+def new_notebook_content(
+    page_ids: list[str],
+    author_uuid: str,
+    paper: tuple[int, int] = DEFAULT_PAPER,
+) -> dict:
+    """Build a ``.content`` dict for a brand-new native notebook.
+
+    Mirrors the schema xochitl itself writes (``formatVersion`` 2, ``cPages``
+    page index, portrait zoom defaults). ``author_uuid`` must match the uuid
+    used to build the page ``.rm`` bytes so CRDT author ids line up.
+    """
+    width, height = paper
+    pages = []
+    idx_values: list[str] = []
+    for page_id in page_ids:
+        idx_value = next_page_idx(idx_values)
+        idx_values.append(idx_value)
+        pages.append(_page_entry(page_id, idx_value))
+
+    return {
+        "cPages": {
+            "lastOpened": {"timestamp": "1:1", "value": page_ids[0] if page_ids else ""},
+            "original": {"timestamp": "0:0", "value": -1},
+            "pages": pages,
+            "uuids": [{"first": str(author_uuid), "second": 1}],
+        },
+        "coverPageNumber": -1,
+        "customZoomCenterX": 0,
+        "customZoomCenterY": height // 2,
+        "customZoomOrientation": "portrait",
+        "customZoomPageHeight": height,
+        "customZoomPageWidth": width,
+        "customZoomScale": 1,
+        "documentMetadata": {},
+        "extraMetadata": {},
+        "fileType": "notebook",
+        "fontName": "",
+        "formatVersion": 2,
+        "lineHeight": -1,
+        "margins": 125,
+        "orientation": "portrait",
+        "pageCount": len(page_ids),
+        "pageTags": [],
+        "sizeInBytes": "0",
+        "tags": [],
+        "textAlignment": "justify",
+        "textScale": 1,
+        "zoomMode": "bestFit",
+    }
+
+
+def new_document_metadata(visible_name: str, parent: str = "") -> dict:
+    """Build a ``.metadata`` dict for a new document.
+
+    Includes the sync flags (``metadatamodified``/``modified``/``synced``/
+    ``version``) so a freshly created document is picked up and synced, matching
+    the proven ``remarkable_upload`` SSH path.
+    """
+    now = str(int(time.time() * 1000))
+    return {
+        "visibleName": visible_name,
+        "type": "DocumentType",
+        "parent": parent or "",
+        "createdTime": now,
+        "lastModified": now,
+        "lastOpened": now,
+        "lastOpenedPage": 0,
+        "pinned": False,
+        "deleted": False,
+        "metadatamodified": True,
+        "modified": True,
+        "synced": False,
+        "version": 0,
+    }
+
+
+def append_page_to_content(content_data: dict, new_page_id: str) -> dict:
+    """Append a blank page entry to an existing notebook's ``.content`` dict.
+
+    Returns ``{"content": <updated dict>, "idx": <new idx value>,
+    "page_index": <1-based index>, "total_pages": <new count>}``. The input
+    dict is updated in place. Raises :class:`ValueError` if the document is not
+    a native ``cPages`` notebook (e.g. a PDF/EPUB with a flat ``pages`` list).
+    """
+    cpages = content_data.get("cPages")
+    if not isinstance(cpages, dict) or not isinstance(cpages.get("pages"), list):
+        raise ValueError(
+            "Document is not a native notebook (no cPages page index); "
+            "pages can only be added to notebooks."
+        )
+
+    pages = cpages["pages"]
+    existing_idx = [
+        p.get("idx", {}).get("value")
+        for p in pages
+        if isinstance(p, dict) and isinstance(p.get("idx"), dict)
+    ]
+    idx_value = next_page_idx([v for v in existing_idx if isinstance(v, str)])
+    pages.append(_page_entry(new_page_id, idx_value))
+
+    total = len(pages)
+    content_data["pageCount"] = total
+    return {
+        "content": content_data,
+        "idx": idx_value,
+        "page_index": total,
+        "total_pages": total,
+    }

--- a/remarkable_mcp/strokes.py
+++ b/remarkable_mcp/strokes.py
@@ -65,9 +65,9 @@ DEFAULT_PAPER_SIZE = (1404, 1872)
 # Stroke defaults.
 DEFAULT_TOOL = "fineliner"
 DEFAULT_COLOR = "black"
-DEFAULT_WIDTH = 80
 DEFAULT_PRESSURE = 90
-DEFAULT_THICKNESS_SCALE = 1.0
+DEFAULT_WIDTH = 16
+DEFAULT_THICKNESS_SCALE = 2.0
 
 
 class StrokeError(ValueError):
@@ -112,6 +112,32 @@ def _color_aliases() -> dict[str, int]:
 
 PEN_IDS = _pen_aliases()
 COLOR_IDS = _color_aliases()
+
+
+# Per-tool brush values measured from real hand-drawn strokes on the device
+# (.rm files on a reMarkable Paper Pro): each pen stores a near-constant
+# Point.width plus a Line.thickness_scale. A flat default (e.g. width 80) renders
+# roughly 5x too thick versus a real fineliner, so synthesized strokes must use
+# the pen's own values to look identical to hand drawing. Maps Pen id ->
+# (point_width, thickness_scale).
+_TOOL_BRUSH: dict[int, tuple[int, float]] = {
+    int(Pen.FINELINER_2.value): (16, 2.0),
+    int(Pen.FINELINER_1.value): (16, 2.0),
+    int(Pen.BALLPOINT_2.value): (12, 2.0),
+    int(Pen.BALLPOINT_1.value): (12, 2.0),
+    int(Pen.CALIGRAPHY.value): (9, 2.2),
+    int(Pen.HIGHLIGHTER_2.value): (30, 2.0),
+    int(Pen.HIGHLIGHTER_1.value): (30, 2.0),
+}
+
+
+def tool_brush(tool_id: int) -> tuple[int, float]:
+    """Return the (point_width, thickness_scale) a given pen renders with.
+
+    Falls back to the generic fineliner-ish default for pens we have not
+    measured, so any tool still produces a sensibly thin stroke.
+    """
+    return _TOOL_BRUSH.get(int(tool_id), (DEFAULT_WIDTH, DEFAULT_THICKNESS_SCALE))
 
 
 def resolve_tool(tool) -> int:
@@ -270,7 +296,12 @@ def build_line_block(
     if len(raw_points) < 1:
         raise StrokeError("A stroke needs at least one point.")
 
+    tool_id = resolve_tool(stroke.get("tool"))
+    base_width, base_scale = tool_brush(tool_id)
+
     width = stroke.get("width")
+    if width is None:
+        width = base_width
     pts: list[Point] = []
     for rp in raw_points:
         if len(rp) >= 3:
@@ -281,9 +312,9 @@ def build_line_block(
 
     line = Line(
         color=PenColor(resolve_color(stroke.get("color"))),
-        tool=Pen(resolve_tool(stroke.get("tool"))),
+        tool=Pen(tool_id),
         points=pts,
-        thickness_scale=float(stroke.get("thickness_scale") or DEFAULT_THICKNESS_SCALE),
+        thickness_scale=float(stroke.get("thickness_scale") or base_scale),
         starting_length=0.0,
         move_id=None,
     )

--- a/remarkable_mcp/strokes.py
+++ b/remarkable_mcp/strokes.py
@@ -1,0 +1,351 @@
+"""Pure ``.rm`` composition: append pen strokes onto an existing page.
+
+This module is deliberately decoupled from any transport (no SSH/cloud/USB).
+It takes the *original raw bytes* of a reMarkable v6 ``.rm`` page plus a list of
+plain stroke dicts and returns new raw bytes with the strokes appended.
+
+Why append-only?
+----------------
+On newer firmware (Paper Pro and friends) a full ``read_blocks`` ->
+``write_blocks`` round-trip is *lossy*: rmscene does not understand every field
+of the ``SceneInfo`` block and silently drops a few bytes, which can corrupt the
+page. Instead we:
+
+1. Parse the original bytes only to *discover* the target layer, paper size and
+   the highest CRDT id already in use (read-only).
+2. Serialize *only the new* ``SceneLineItemBlock``s with ``write_blocks``.
+3. Strip the 43-byte ``HEADER_V6`` prefix from that fresh serialization.
+4. Concatenate the headerless new-block bytes onto the *untouched* original
+   bytes.
+
+The original bytes are preserved exactly as a prefix, so nothing the device
+wrote is ever rewritten. See ``test_server.py`` for the regression guard that
+asserts this property (and that a naive round-trip does *not* byte-match).
+
+Coordinate model
+----------------
+The canvas / model speaks normalized coordinates with a top-left origin in the
+range ``[0, 1]``. ``.rm`` uses a center-origin X axis and a top origin Y axis,
+both in *logical page units* given by the page's own ``SceneInfo.paper_size``
+(falling back to the rM1/rM2 default ``1404 x 1872`` when absent). The mapping
+is::
+
+    rm_x = (nx - 0.5) * paper_width
+    rm_y =  ny        * paper_height
+
+This is device-agnostic: the page carries its own ``paper_size``, so a notebook
+authored on a Paper Pro maps correctly even when edited from another device.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Iterable, Optional
+
+from rmscene import HEADER_V6, read_blocks, write_blocks
+from rmscene.scene_items import Line, Pen, PenColor, Point
+from rmscene.scene_stream import (
+    CrdtSequenceItem,
+    SceneGroupItemBlock,
+    SceneInfo,
+    SceneLineItemBlock,
+    TreeNodeBlock,
+)
+from rmscene.tagged_block_common import CrdtId
+
+logger = logging.getLogger(__name__)
+
+# rmscene write option that matches the v6 ("3.x") on-device format.
+WRITE_VERSION = "3.1"
+
+# Default logical page size when a page has no SceneInfo block (rM1/rM2).
+DEFAULT_PAPER_SIZE = (1404, 1872)
+
+# Stroke defaults.
+DEFAULT_TOOL = "fineliner"
+DEFAULT_COLOR = "black"
+DEFAULT_WIDTH = 80
+DEFAULT_PRESSURE = 90
+DEFAULT_THICKNESS_SCALE = 1.0
+
+
+class StrokeError(ValueError):
+    """Raised when strokes cannot be composed onto a page."""
+
+
+def _pen_aliases() -> dict[str, int]:
+    out: dict[str, int] = {}
+    for pen in Pen:
+        out[pen.name.lower()] = int(pen.value)
+    # Friendly aliases -> the "v2" tools the modern firmware uses by default.
+    out.update(
+        {
+            "fineliner": int(Pen.FINELINER_2.value),
+            "ballpoint": int(Pen.BALLPOINT_2.value),
+            "marker": int(Pen.MARKER_2.value),
+            "pencil": int(Pen.PENCIL_2.value),
+            "mechanical_pencil": int(Pen.MECHANICAL_PENCIL_2.value),
+            "mechanicalpencil": int(Pen.MECHANICAL_PENCIL_2.value),
+            "paintbrush": int(Pen.PAINTBRUSH_2.value),
+            "brush": int(Pen.PAINTBRUSH_2.value),
+            "highlighter": int(Pen.HIGHLIGHTER_2.value),
+            "calligraphy": int(Pen.CALIGRAPHY.value),
+            "pen": int(Pen.FINELINER_2.value),
+        }
+    )
+    return out
+
+
+def _color_aliases() -> dict[str, int]:
+    out: dict[str, int] = {}
+    for color in PenColor:
+        out[color.name.lower()] = int(color.value)
+    out.update(
+        {
+            "grey": int(PenColor.GRAY.value),
+            "highlight": int(PenColor.HIGHLIGHT.value),
+        }
+    )
+    return out
+
+
+PEN_IDS = _pen_aliases()
+COLOR_IDS = _color_aliases()
+
+
+def resolve_tool(tool) -> int:
+    """Resolve a pen tool name or int to a valid Pen id."""
+    if tool is None:
+        return PEN_IDS[DEFAULT_TOOL]
+    if isinstance(tool, int):
+        return int(Pen(tool).value)
+    key = str(tool).strip().lower().replace(" ", "_").replace("-", "_")
+    if key in PEN_IDS:
+        return PEN_IDS[key]
+    raise StrokeError(
+        f"Unknown pen tool {tool!r}. Valid names include: "
+        "fineliner, ballpoint, marker, pencil, mechanical_pencil, paintbrush, "
+        "highlighter, calligraphy."
+    )
+
+
+def resolve_color(color) -> int:
+    """Resolve a color name or int to a valid PenColor id."""
+    if color is None:
+        return COLOR_IDS[DEFAULT_COLOR]
+    if isinstance(color, int):
+        return int(PenColor(color).value)
+    key = str(color).strip().lower().replace(" ", "_").replace("-", "_")
+    if key in COLOR_IDS:
+        return COLOR_IDS[key]
+    raise StrokeError(
+        f"Unknown color {color!r}. Valid names include: black, gray/grey, white, "
+        "yellow, green, pink, blue, red, cyan, magenta, highlight."
+    )
+
+
+def get_paper_size(blocks: Iterable[object]) -> tuple[int, int]:
+    """Return the page's logical ``(width, height)`` from its SceneInfo block.
+
+    Falls back to ``DEFAULT_PAPER_SIZE`` when no SceneInfo / paper_size exists
+    (e.g. pages created from scratch that have no SceneInfo block yet).
+    """
+    for b in blocks:
+        if isinstance(b, SceneInfo):
+            size = getattr(b, "paper_size", None)
+            if size:
+                try:
+                    w, h = size
+                    if w and h:
+                        return (int(w), int(h))
+                except (TypeError, ValueError):
+                    pass
+    return DEFAULT_PAPER_SIZE
+
+
+def _iter_crdt_ids(blocks: Iterable[object]):
+    """Yield every CrdtId referenced by a block list (best effort)."""
+    for b in blocks:
+        for attr in ("tree_id", "node_id", "parent_id", "block_id"):
+            v = getattr(b, attr, None)
+            if isinstance(v, CrdtId):
+                yield v
+        item = getattr(b, "item", None)
+        if item is not None:
+            iid = getattr(item, "item_id", None)
+            if isinstance(iid, CrdtId):
+                yield iid
+            val = getattr(item, "value", None)
+            if isinstance(val, CrdtId):
+                yield val
+        group = getattr(b, "group", None)
+        if group is not None:
+            gid = getattr(group, "node_id", None)
+            if isinstance(gid, CrdtId):
+                yield gid
+
+
+def find_target_layer(blocks: list) -> CrdtId:
+    """Find the layer node that new strokes should hang off, dynamically.
+
+    Strategy (most-specific first):
+      1. The ``parent_id`` of the last existing ``SceneLineItemBlock`` — joins
+         new strokes onto the same layer the page already draws into.
+      2. The ``item.value`` (a layer node CrdtId) of the last
+         ``SceneGroupItemBlock`` — these parent the visible layers under root.
+      3. The ``node_id`` of the last labeled ``TreeNodeBlock`` (a layer group).
+
+    Raises StrokeError with actionable guidance if no layer can be found, rather
+    than guessing a hardcoded id that only happens to work on one device.
+    """
+    for b in reversed(blocks):
+        if isinstance(b, SceneLineItemBlock) and isinstance(b.parent_id, CrdtId):
+            return b.parent_id
+    for b in reversed(blocks):
+        if isinstance(b, SceneGroupItemBlock):
+            val = getattr(b.item, "value", None)
+            if isinstance(val, CrdtId):
+                return val
+    for b in reversed(blocks):
+        if isinstance(b, TreeNodeBlock):
+            group = getattr(b, "group", None)
+            node_id = getattr(group, "node_id", None)
+            label = getattr(group, "label", None)
+            if isinstance(node_id, CrdtId) and label is not None:
+                return node_id
+    raise StrokeError(
+        "Could not find a layer to draw on in this page. The .rm file may be "
+        "empty or in an unsupported format. Open the page once on the device "
+        "(which creates a default layer) and try again."
+    )
+
+
+def allocate_ids(blocks: list, count: int) -> list[CrdtId]:
+    """Allocate ``count`` fresh, monotonically-increasing CrdtIds.
+
+    Picks an id strictly greater (by ``part2``) than anything already present so
+    the new sequence items never collide with existing content.
+    """
+    max_id = CrdtId(0, 0)
+    for cid in _iter_crdt_ids(blocks):
+        if (cid.part1, cid.part2) > (max_id.part1, max_id.part2):
+            max_id = cid
+    part1 = max_id.part1 if max_id.part1 else 0
+    base = max_id.part2
+    return [CrdtId(part1, base + 1 + i) for i in range(count)]
+
+
+def _map_point(nx: float, ny: float, pressure, width, paper_w: int, paper_h: int) -> Point:
+    nx = min(1.0, max(0.0, float(nx)))
+    ny = min(1.0, max(0.0, float(ny)))
+    rm_x = (nx - 0.5) * paper_w
+    rm_y = ny * paper_h
+    p = DEFAULT_PRESSURE if pressure is None else int(pressure)
+    p = min(255, max(0, p))
+    w = DEFAULT_WIDTH if width is None else int(width)
+    return Point(x=rm_x, y=rm_y, speed=0, direction=0, width=w, pressure=p)
+
+
+def build_line_block(
+    layer_id: CrdtId,
+    item_id: CrdtId,
+    stroke: dict,
+    paper_w: int,
+    paper_h: int,
+) -> SceneLineItemBlock:
+    """Build a single ``SceneLineItemBlock`` from a plain stroke dict.
+
+    Stroke dict contract::
+
+        {
+          "points": [[nx, ny], [nx, ny, pressure], ...],  # normalized [0,1] TL
+          "tool":   "fineliner" | int | None,
+          "color":  "black" | int | None,
+          "width":  int | None,
+          "thickness_scale": float | None,
+        }
+    """
+    raw_points = stroke.get("points") or []
+    if len(raw_points) < 1:
+        raise StrokeError("A stroke needs at least one point.")
+
+    width = stroke.get("width")
+    pts: list[Point] = []
+    for rp in raw_points:
+        if len(rp) >= 3:
+            nx, ny, pressure = rp[0], rp[1], rp[2]
+        else:
+            nx, ny, pressure = rp[0], rp[1], None
+        pts.append(_map_point(nx, ny, pressure, width, paper_w, paper_h))
+
+    line = Line(
+        color=PenColor(resolve_color(stroke.get("color"))),
+        tool=Pen(resolve_tool(stroke.get("tool"))),
+        points=pts,
+        thickness_scale=float(stroke.get("thickness_scale") or DEFAULT_THICKNESS_SCALE),
+        starting_length=0.0,
+        move_id=None,
+    )
+    item = CrdtSequenceItem(
+        item_id=item_id,
+        left_id=CrdtId(0, 0),
+        right_id=CrdtId(0, 0),
+        deleted_length=0,
+        value=line,
+    )
+    return SceneLineItemBlock(
+        parent_id=layer_id,
+        item=item,
+        extra_data=b"",
+        extra_value_data=b"",
+    )
+
+
+def serialize_new_blocks(blocks: list) -> bytes:
+    """Serialize blocks with write_blocks and strip the HEADER_V6 prefix."""
+    buf = io.BytesIO()
+    write_blocks(buf, blocks, options={"version": WRITE_VERSION})
+    data = buf.getvalue()
+    if data.startswith(HEADER_V6):
+        return data[len(HEADER_V6) :]
+    return data
+
+
+def append_strokes(original_bytes: bytes, strokes: list[dict]) -> bytes:
+    """Append ``strokes`` to an existing page, returning new raw ``.rm`` bytes.
+
+    The original bytes are preserved verbatim as a prefix of the result.
+    """
+    if not strokes:
+        raise StrokeError("No strokes provided to write.")
+
+    blocks = list(read_blocks(io.BytesIO(original_bytes)))
+    layer_id = find_target_layer(blocks)
+    paper_w, paper_h = get_paper_size(blocks)
+    ids = allocate_ids(blocks, len(strokes))
+
+    new_blocks = [
+        build_line_block(layer_id, ids[i], stroke, paper_w, paper_h)
+        for i, stroke in enumerate(strokes)
+    ]
+    appended = serialize_new_blocks(new_blocks)
+    return original_bytes + appended
+
+
+def page_geometry(original_bytes: bytes) -> dict:
+    """Return paper size + center-origin info for an existing page (read-only)."""
+    blocks = list(read_blocks(io.BytesIO(original_bytes)))
+    w, h = get_paper_size(blocks)
+    has_scene_info = any(isinstance(b, SceneInfo) for b in blocks)
+    layer: Optional[CrdtId] = None
+    try:
+        layer = find_target_layer(blocks)
+    except StrokeError:
+        layer = None
+    return {
+        "paper_width": w,
+        "paper_height": h,
+        "has_scene_info": has_scene_info,
+        "has_layer": layer is not None,
+    }

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -807,6 +807,10 @@ def _author_create_document(name: str, text: Optional[str], folder: Optional[str
         "transport": "ssh",
     }
     hint = f"Created notebook '{name}'. Call remarkable_canvas('{name}', 1) to view or draw on it."
+    if text:
+        hint += (
+            " Note: the typed text shows on the device but not in the strokes-only canvas preview."
+        )
     return make_response(result, hint)
 
 
@@ -855,9 +859,12 @@ def register_write_tools():
           notebooks support this (PDF/EPUB pages already exist).
 
         - method="create_document": requires `name`. Creates a new native notebook
-          in `folder` (default root). Pass `text` to seed the first page with typed
-          paragraphs (split on newlines); omit it for a blank page. Returns the new
-          document id and first-page geometry.
+          in `folder` (default root). Leave `text` EMPTY for a blank notebook —
+          that is the default and the correct choice. Only pass `text` when the
+          user EXPLICITLY asks for specific typed content; never invent a title,
+          placeholder, or "created by" line. (Typed text renders on the device but
+          not in the strokes-only canvas preview.) Returns the new document id and
+          first-page geometry.
 
         The interactive canvas calls this exact tool via the MCP Apps bridge,
         passing ui_submitted=true for draw (the human already chose Save). A model
@@ -873,7 +880,10 @@ def register_write_tools():
              "color": "black" | "yellow" | ...,
              "width": <optional float>, "thickness_scale": <optional float>}
         - name: Title of the new notebook (create_document).
-        - text: Optional text to seed the first page with (create_document).
+        - text: Optional typed text for the first page (create_document). Omit it
+            unless the user explicitly requested specific content; never fabricate
+            placeholder text. Paragraphs split on newlines. Note: typed text shows
+            on the device but not in the strokes-only canvas preview.
         - folder: Destination folder path (create_document; default "/").
         - ui_submitted: Set by the canvas app when the user clicked Save. Models omit it.
         </parameters>
@@ -881,8 +891,9 @@ def register_write_tools():
         - remarkable_author(method="draw", document="Ideas", page=1,
             strokes=[{"points": [[0.1,0.2],[0.8,0.2]], "tool": "highlighter", "color": "yellow"}])
         - remarkable_author(method="add_page", document="Ideas")
+        - remarkable_author(method="create_document", name="Sketches")
         - remarkable_author(method="create_document", name="Meeting notes",
-            text="Agenda\nFollow-ups")
+            text="Agenda\nFollow-ups")  # only when the user supplied that text
         </examples>
         """
 

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -197,6 +197,51 @@ def _restart_xochitl(ssh_client: SSHClient) -> None:
     ssh_client._ssh_command("systemctl restart xochitl", timeout=15)
 
 
+def _page_ids_from_content(content_data: dict) -> list:
+    """Return ordered page ids from a parsed ``.content`` file.
+
+    Handles both the modern ``cPages.pages[].id`` schema (native notebooks) and
+    the legacy flat ``pages`` UUID list (PDF/EPUB-backed documents).
+    """
+    cpages = content_data.get("cPages")
+    if isinstance(cpages, dict) and isinstance(cpages.get("pages"), list):
+        ids = [p.get("id") for p in cpages["pages"] if isinstance(p, dict) and p.get("id")]
+        if ids:
+            return ids
+    pages = content_data.get("pages")
+    if isinstance(pages, list) and all(isinstance(p, str) for p in pages):
+        return list(pages)
+    return []
+
+
+def _read_remote_bytes(ssh_client: SSHClient, remote_path: str) -> Optional[bytes]:
+    """Download a remote file's bytes, or None if it does not exist / fails."""
+    try:
+        return ssh_client._scp_download(remote_path)
+    except Exception as e:
+        logger.debug(f"Remote read failed for {remote_path}: {e}")
+        return None
+
+
+def _remote_file_exists(ssh_client: SSHClient, remote_path: str) -> bool:
+    """Return True if a file exists on the tablet."""
+    out = ssh_client._ssh_command(f"test -f '{remote_path}' && echo yes || echo no")
+    return out.strip().endswith("yes")
+
+
+def _write_remote_bytes(ssh_client: SSHClient, remote_path: str, data: bytes) -> None:
+    """Write bytes to a remote path by staging a local temp file and uploading."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(data)
+        tmp_path = tmp.name
+    try:
+        _upload_file_bytes(ssh_client, tmp_path, remote_path)
+    finally:
+        os.unlink(tmp_path)
+
+
 def _upload_via_usb_web(local_path: str) -> dict:
     """Upload a file to the tablet via USB web interface POST /upload.
 
@@ -507,6 +552,184 @@ async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str
 
 def register_write_tools():
     """Register all write tools with the MCP server."""
+
+    @mcp.tool(annotations=WRITE_ANNOTATIONS)
+    async def remarkable_canvas_write(
+        document: str,
+        page: int,
+        strokes: list,
+        ui_submitted: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        <usecase>Append pen/highlighter strokes to an existing page of a reMarkable
+        document as native .rm ink. This is the single, composable write primitive
+        behind the interactive canvas Save button AND model-driven markup
+        (highlighting, underlining, marking) — the model composes the strokes.</usecase>
+        <instructions>
+        Strokes are APPENDED to the page's existing ink (non-destructive; the
+        original page is backed up to {pageId}.rm.bak on the device the first time).
+        Each stroke is a dict with normalized [0,1] top-left coordinates so the same
+        payload works on any device — the tool maps them to the page's own paper_size.
+
+        Requires SSH mode (the default tablet-filesystem transport for write-back).
+        Requires write mode (the default; disabled with --read-only).
+
+        The interactive canvas calls this exact tool via the MCP Apps bridge, passing
+        ui_submitted=true (the human already chose Save in the app). A model calling
+        it directly should omit ui_submitted. Appending ink is non-destructive, so no
+        confirmation prompt is required either way.
+
+        Coordinates: points are [nx, ny] or [nx, ny, pressure] with nx, ny in [0,1]
+        measured from the TOP-LEFT of the page. Native notebook pages map exactly via
+        paper_size. (PDF-backed pages currently use the same map; precise PDF overlay
+        placement is a follow-up.)
+        </instructions>
+        <parameters>
+        - document: Name or path of the target document (id or visibleName).
+        - page: 1-based page number to append to.
+        - strokes: List of stroke dicts. Each:
+            {"points": [[nx, ny], [nx, ny, pressure], ...],
+             "tool": "fineliner" | "highlighter" | int,
+             "color": "black" | "yellow" | ...,
+             "width": <optional float>, "thickness_scale": <optional float>}
+        - ui_submitted: Set by the canvas app when the user clicked Save. Models omit it.
+        </parameters>
+        <examples>
+        - remarkable_canvas_write("Ideas", 1,
+            [{"points": [[0.1,0.2],[0.8,0.2]], "tool": "highlighter", "color": "yellow"}])
+        </examples>
+        """
+
+        def _impl() -> str:
+            error = _require_write_transport()
+            if error:
+                return error
+            if not _is_ssh_mode():
+                return make_error(
+                    error_type="unsupported_transport",
+                    message="Writing strokes back currently requires SSH mode.",
+                    suggestion=(
+                        "Run with: remarkable-mcp --ssh (USB cable + SSH enabled). "
+                        "Stroke write-back over cloud/USB-web is not supported yet — "
+                        "for those, render and re-upload a flattened PDF instead."
+                    ),
+                )
+            if not strokes:
+                return make_error(
+                    error_type="no_strokes",
+                    message="No strokes provided to write.",
+                    suggestion=(
+                        "Pass a non-empty list of stroke dicts, e.g. "
+                        '[{"points": [[0.1,0.2],[0.8,0.2]], "tool": "fineliner", '
+                        '"color": "black"}].'
+                    ),
+                )
+
+            from remarkable_mcp import strokes as strokes_mod
+
+            ssh_client = _get_ssh_client()
+            collection = ssh_client.get_meta_items()
+            items_by_id = get_items_by_id(collection)
+            target = _resolve_document(document, collection, items_by_id)
+            if not target:
+                from remarkable_mcp.extract import find_similar_documents
+
+                similar = find_similar_documents(document, collection)
+                return make_error(
+                    error_type="document_not_found",
+                    message=f"Document not found: '{document}'",
+                    suggestion="Use remarkable_browse() to find the correct name.",
+                    did_you_mean=similar or None,
+                )
+
+            doc_uuid = target.ID
+            content_raw = _read_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}.content")
+            try:
+                content_data = json.loads(content_raw) if content_raw else {}
+            except (ValueError, TypeError):
+                content_data = {}
+            page_ids = _page_ids_from_content(content_data)
+            if not page_ids:
+                return make_error(
+                    error_type="no_pages",
+                    message=f"Could not read the page list for '{target.VissibleName}'.",
+                    suggestion="The document may have no pages, or an unexpected .content format.",
+                )
+            if page < 1 or page > len(page_ids):
+                return make_error(
+                    error_type="page_out_of_range",
+                    message=f"Page {page} does not exist. Document has {len(page_ids)} page(s).",
+                    suggestion=f"Use page=1 to {len(page_ids)}.",
+                )
+
+            page_id = page_ids[page - 1]
+            file_type = str(content_data.get("fileType", "") or "")
+            rm_path = f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm"
+            original = _read_remote_bytes(ssh_client, rm_path)
+            if original is None:
+                return make_error(
+                    error_type="no_page_layer",
+                    message=f"Page {page} has no existing ink layer (.rm) to append to.",
+                    suggestion=(
+                        "v1 appends to pages that already contain a drawable layer "
+                        "(native notebook pages, or PDF/EPUB pages that have been "
+                        "annotated at least once). Open the page and make one mark on "
+                        "the tablet first, or use remarkable_add_page to add a blank page."
+                    ),
+                )
+
+            try:
+                geom = strokes_mod.page_geometry(original)
+                new_bytes = strokes_mod.append_strokes(original, strokes)
+            except strokes_mod.StrokeError as e:
+                return make_error(
+                    error_type="stroke_write_failed",
+                    message=str(e),
+                    suggestion=(
+                        "Check the stroke format (points normalized [0,1]) and that "
+                        "the page has a drawable layer."
+                    ),
+                )
+            except Exception as e:  # noqa: BLE001 - surface as structured guidance
+                return make_error(
+                    error_type="stroke_write_failed",
+                    message=f"Failed to build strokes for page {page}: {e}",
+                    suggestion="Verify the stroke payload and retry.",
+                )
+
+            # Preserve the pristine original once, then write the appended bytes.
+            bak_path = rm_path + ".bak"
+            if not _remote_file_exists(ssh_client, bak_path):
+                _write_remote_bytes(ssh_client, bak_path, original)
+            _write_remote_bytes(ssh_client, rm_path, new_bytes)
+            _restart_xochitl(ssh_client)
+
+            result = {
+                "written": True,
+                "document": target.VissibleName,
+                "page": page,
+                "total_pages": len(page_ids),
+                "strokes_added": len(strokes),
+                "paper_size": [geom["paper_width"], geom["paper_height"]],
+                "file_type": file_type or "notebook",
+                "writable": True,
+                "transport": "ssh",
+                "ui_submitted": bool(ui_submitted),
+            }
+            if file_type.lower() == "epub":
+                result["caveat"] = (
+                    "This is a reflowable EPUB; annotations are anchored to the "
+                    "current layout and may shift if the font size or layout changes."
+                )
+            hint = (
+                f"Appended {len(strokes)} stroke(s) to page {page} of "
+                f"'{target.VissibleName}'. Call remarkable_canvas(document, page) to "
+                "view the updated page."
+            )
+            return make_response(result, hint)
+
+        return await asyncio.to_thread(_impl)
 
     @mcp.tool(annotations=UPLOAD_ANNOTATIONS)
     async def remarkable_upload(

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -807,10 +807,6 @@ def _author_create_document(name: str, text: Optional[str], folder: Optional[str
         "transport": "ssh",
     }
     hint = f"Created notebook '{name}'. Call remarkable_canvas('{name}', 1) to view or draw on it."
-    if text:
-        hint += (
-            " Note: the typed text shows on the device but not in the strokes-only canvas preview."
-        )
     return make_response(result, hint)
 
 
@@ -862,8 +858,7 @@ def register_write_tools():
           in `folder` (default root). Leave `text` EMPTY for a blank notebook —
           that is the default and the correct choice. Only pass `text` when the
           user EXPLICITLY asks for specific typed content; never invent a title,
-          placeholder, or "created by" line. (Typed text renders on the device but
-          not in the strokes-only canvas preview.) Returns the new document id and
+          placeholder, or "created by" line. Returns the new document id and
           first-page geometry.
 
         The interactive canvas calls this exact tool via the MCP Apps bridge,
@@ -882,8 +877,7 @@ def register_write_tools():
         - name: Title of the new notebook (create_document).
         - text: Optional typed text for the first page (create_document). Omit it
             unless the user explicitly requested specific content; never fabricate
-            placeholder text. Paragraphs split on newlines. Note: typed text shows
-            on the device but not in the strokes-only canvas preview.
+            placeholder text. Paragraphs split on newlines.
         - folder: Destination folder path (create_document; default "/").
         - ui_submitted: Set by the canvas app when the user clicked Save. Models omit it.
         </parameters>

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -550,54 +550,339 @@ async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str
     return None
 
 
+def _author_draw(document: str, page: int, strokes: list, ui_submitted: bool) -> str:
+    """Append strokes to a page, auto-creating a blank drawable layer if absent."""
+    if not document or page is None:
+        return make_error(
+            error_type="missing_parameter",
+            message="draw requires 'document' and 'page'.",
+            suggestion=(
+                'Call remarkable_author(method="draw", document=..., page=1, strokes=[...]).'
+            ),
+        )
+    if not strokes:
+        return make_error(
+            error_type="no_strokes",
+            message="No strokes provided to write.",
+            suggestion=(
+                "Pass a non-empty list of stroke dicts, e.g. "
+                '[{"points": [[0.1,0.2],[0.8,0.2]], "tool": "fineliner", "color": "black"}].'
+            ),
+        )
+
+    from remarkable_mcp import notebooks as nb
+    from remarkable_mcp import strokes as strokes_mod
+
+    ssh_client = _get_ssh_client()
+    collection = ssh_client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        from remarkable_mcp.extract import find_similar_documents
+
+        similar = find_similar_documents(document, collection)
+        return make_error(
+            error_type="document_not_found",
+            message=f"Document not found: '{document}'",
+            suggestion="Use remarkable_browse() to find the correct name.",
+            did_you_mean=similar or None,
+        )
+
+    doc_uuid = target.ID
+    content_raw = _read_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}.content")
+    try:
+        content_data = json.loads(content_raw) if content_raw else {}
+    except (ValueError, TypeError):
+        content_data = {}
+    page_ids = _page_ids_from_content(content_data)
+    if not page_ids:
+        return make_error(
+            error_type="no_pages",
+            message=f"Could not read the page list for '{target.VissibleName}'.",
+            suggestion="The document may have no pages, or an unexpected .content format.",
+        )
+    if page < 1 or page > len(page_ids):
+        return make_error(
+            error_type="page_out_of_range",
+            message=f"Page {page} does not exist. Document has {len(page_ids)} page(s).",
+            suggestion=f"Use page=1 to {len(page_ids)}.",
+        )
+
+    page_id = page_ids[page - 1]
+    file_type = str(content_data.get("fileType", "") or "")
+    rm_path = f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm"
+    original = _read_remote_bytes(ssh_client, rm_path)
+    # A native notebook page that has never been drawn on (or a PDF/EPUB page
+    # with no annotation overlay yet) has no .rm file. Seed a blank drawable
+    # layer so the strokes have somewhere to land.
+    page_existed = original is not None
+    if not page_existed:
+        original = nb.blank_page_rm_bytes()
+
+    try:
+        geom = strokes_mod.page_geometry(original)
+        new_bytes = strokes_mod.append_strokes(original, strokes)
+    except strokes_mod.StrokeError as e:
+        return make_error(
+            error_type="stroke_write_failed",
+            message=str(e),
+            suggestion=(
+                "Check the stroke format (points normalized [0,1]) and that "
+                "the page has a drawable layer."
+            ),
+        )
+    except Exception as e:  # noqa: BLE001 - surface as structured guidance
+        return make_error(
+            error_type="stroke_write_failed",
+            message=f"Failed to build strokes for page {page}: {e}",
+            suggestion="Verify the stroke payload and retry.",
+        )
+
+    # Preserve the pristine original once (only if the page pre-existed), then
+    # write the appended bytes.
+    if page_existed:
+        bak_path = rm_path + ".bak"
+        if not _remote_file_exists(ssh_client, bak_path):
+            _write_remote_bytes(ssh_client, bak_path, original)
+    _write_remote_bytes(ssh_client, rm_path, new_bytes)
+    _restart_xochitl(ssh_client)
+
+    result = {
+        "written": True,
+        "document": target.VissibleName,
+        "page": page,
+        "total_pages": len(page_ids),
+        "strokes_added": len(strokes),
+        "paper_size": [geom["paper_width"], geom["paper_height"]],
+        "file_type": file_type or "notebook",
+        "created_overlay": not page_existed,
+        "writable": True,
+        "transport": "ssh",
+        "ui_submitted": bool(ui_submitted),
+    }
+    if file_type.lower() == "epub":
+        result["caveat"] = (
+            "This is a reflowable EPUB; annotations are anchored to the "
+            "current layout and may shift if the font size or layout changes."
+        )
+    hint = (
+        f"Appended {len(strokes)} stroke(s) to page {page} of "
+        f"'{target.VissibleName}'. Call remarkable_canvas(document, page) to "
+        "view the updated page."
+    )
+    return make_response(result, hint)
+
+
+def _author_add_page(document: str) -> str:
+    """Append a blank, drawable page to the end of a native notebook."""
+    if not document:
+        return make_error(
+            error_type="missing_parameter",
+            message="add_page requires 'document'.",
+            suggestion='Call remarkable_author(method="add_page", document=...).',
+        )
+
+    from remarkable_mcp import notebooks as nb
+
+    ssh_client = _get_ssh_client()
+    collection = ssh_client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        from remarkable_mcp.extract import find_similar_documents
+
+        similar = find_similar_documents(document, collection)
+        return make_error(
+            error_type="document_not_found",
+            message=f"Document not found: '{document}'",
+            suggestion="Use remarkable_browse() to find the correct name.",
+            did_you_mean=similar or None,
+        )
+
+    doc_uuid = target.ID
+    content_raw = _read_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}.content")
+    try:
+        content_data = json.loads(content_raw) if content_raw else {}
+    except (ValueError, TypeError):
+        content_data = {}
+    if not content_data:
+        return make_error(
+            error_type="no_content",
+            message=f"Could not read the .content file for '{target.VissibleName}'.",
+            suggestion="The document may be missing or have an unexpected format.",
+        )
+
+    # Reuse the notebook's existing author uuid so CRDT author ids stay aligned.
+    author_uuid = None
+    uuids = content_data.get("cPages", {}).get("uuids")
+    if isinstance(uuids, list) and uuids and isinstance(uuids[0], dict):
+        author_uuid = uuids[0].get("first")
+
+    new_page_id = nb.new_uuid()
+    try:
+        updated = nb.append_page_to_content(content_data, new_page_id)
+    except ValueError as e:
+        return make_error(
+            error_type="not_a_notebook",
+            message=str(e),
+            suggestion=(
+                "Pages can only be added to native notebooks. PDF/EPUB pages "
+                "already exist — open the page and draw on it directly."
+            ),
+        )
+
+    try:
+        page_bytes = nb.blank_page_rm_bytes(author_uuid=author_uuid)
+    except (ValueError, TypeError):
+        page_bytes = nb.blank_page_rm_bytes()
+
+    _write_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}/{new_page_id}.rm", page_bytes)
+    _write_content_file(ssh_client, doc_uuid, updated["content"])
+    _restart_xochitl(ssh_client)
+    _invalidate_client_cache(ssh_client)
+
+    result = {
+        "added": True,
+        "document": target.VissibleName,
+        "page_added": updated["page_index"],
+        "total_pages": updated["total_pages"],
+        "paper_size": list(nb.DEFAULT_PAPER),
+        "transport": "ssh",
+    }
+    hint = (
+        f"Added a blank page (now page {updated['page_index']} of "
+        f"{updated['total_pages']}). Call remarkable_canvas('{target.VissibleName}', "
+        f"{updated['page_index']}) to draw on it."
+    )
+    return make_response(result, hint)
+
+
+def _author_create_document(name: str, text: Optional[str], folder: Optional[str]) -> str:
+    """Create a new native notebook (blank, or seeded with typed text)."""
+    if not name:
+        return make_error(
+            error_type="missing_parameter",
+            message="create_document requires 'name'.",
+            suggestion='Call remarkable_author(method="create_document", name="My notes").',
+        )
+
+    from remarkable_mcp import notebooks as nb
+
+    ssh_client = _get_ssh_client()
+    collection = ssh_client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    parent_id = _resolve_parent_id(folder or "/", items_by_id, collection)
+    if parent_id is None:
+        folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+        return make_error(
+            error_type="folder_not_found",
+            message=f"Folder not found: '{folder}'",
+            suggestion="Use remarkable_browse('/') to see available folders.",
+            did_you_mean=folders[:5] if folders else None,
+        )
+
+    doc_uuid = nb.new_uuid()
+    page_id = nb.new_uuid()
+    author_uuid = nb.new_uuid()
+    page_bytes = nb.page_rm_bytes(text or "", author_uuid=author_uuid)
+    content_data = nb.new_notebook_content([page_id], author_uuid)
+    metadata = nb.new_document_metadata(name, parent=parent_id)
+
+    ssh_client._ssh_command(f"mkdir -p '{XOCHITL_PATH}/{doc_uuid}'")
+    _write_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm", page_bytes)
+    _write_content_file(ssh_client, doc_uuid, content_data)
+    _write_metadata(ssh_client, doc_uuid, metadata)
+    _restart_xochitl(ssh_client)
+    _invalidate_client_cache(ssh_client)
+
+    result = {
+        "created": True,
+        "document": name,
+        "document_id": doc_uuid,
+        "page_id": page_id,
+        "total_pages": 1,
+        "paper_size": list(nb.DEFAULT_PAPER),
+        "has_text": bool(text),
+        "folder": folder or "/",
+        "transport": "ssh",
+    }
+    hint = f"Created notebook '{name}'. Call remarkable_canvas('{name}', 1) to view or draw on it."
+    return make_response(result, hint)
+
+
 def register_write_tools():
     """Register all write tools with the MCP server."""
 
     @mcp.tool(annotations=WRITE_ANNOTATIONS)
-    async def remarkable_canvas_write(
-        document: str,
-        page: int,
-        strokes: list,
+    async def remarkable_author(
+        method: str,
+        document: Optional[str] = None,
+        page: Optional[int] = None,
+        strokes: Optional[list] = None,
+        name: Optional[str] = None,
+        text: Optional[str] = None,
+        folder: Optional[str] = None,
         ui_submitted: bool = False,
         ctx: Context = None,
     ) -> str:
         """
-        <usecase>Append pen/highlighter strokes to an existing page of a reMarkable
-        document as native .rm ink. This is the single, composable write primitive
-        behind the interactive canvas Save button AND model-driven markup
+        <usecase>Author native reMarkable ink and notebooks. ONE compound write
+        primitive with three methods: "draw" appends pen/highlighter strokes to a
+        page, "add_page" appends a blank drawable page to a notebook, and
+        "create_document" creates a new notebook (optionally seeded with typed
+        text). This is the single tool behind the interactive canvas (Save → draw,
+        ＋Page → add_page, new notebook → create_document) AND model-driven markup
         (highlighting, underlining, marking) — the model composes the strokes.</usecase>
         <instructions>
-        Strokes are APPENDED to the page's existing ink (non-destructive; the
-        original page is backed up to {pageId}.rm.bak on the device the first time).
-        Each stroke is a dict with normalized [0,1] top-left coordinates so the same
-        payload works on any device — the tool maps them to the page's own paper_size.
+        Requires SSH mode (the default tablet-filesystem transport for write-back)
+        and write mode (the default; disabled with --read-only). All methods are
+        non-destructive (draw appends to existing ink and backs the page up to
+        {pageId}.rm.bak the first time), so no confirmation prompt is required.
 
-        Requires SSH mode (the default tablet-filesystem transport for write-back).
-        Requires write mode (the default; disabled with --read-only).
+        Pick the method, then pass only that method's parameters:
 
-        The interactive canvas calls this exact tool via the MCP Apps bridge, passing
-        ui_submitted=true (the human already chose Save in the app). A model calling
-        it directly should omit ui_submitted. Appending ink is non-destructive, so no
-        confirmation prompt is required either way.
+        - method="draw": requires `document` + `page` + `strokes`. Strokes are
+          APPENDED to the page's ink. If the page has no ink layer yet (a fresh
+          notebook page, or a PDF/EPUB page never annotated), a blank drawable
+          layer is created automatically. Coordinates: each point is [nx, ny] or
+          [nx, ny, pressure] with nx, ny in [0,1] from the page's TOP-LEFT; the
+          tool maps them to the page's own paper_size so the same payload works on
+          any device. (PDF-backed pages currently use the same map; precise PDF
+          overlay placement is a follow-up.)
 
-        Coordinates: points are [nx, ny] or [nx, ny, pressure] with nx, ny in [0,1]
-        measured from the TOP-LEFT of the page. Native notebook pages map exactly via
-        paper_size. (PDF-backed pages currently use the same map; precise PDF overlay
-        placement is a follow-up.)
+        - method="add_page": requires `document`. Appends one blank page to the END
+          of a native notebook and returns its 1-based page number. Only native
+          notebooks support this (PDF/EPUB pages already exist).
+
+        - method="create_document": requires `name`. Creates a new native notebook
+          in `folder` (default root). Pass `text` to seed the first page with typed
+          paragraphs (split on newlines); omit it for a blank page. Returns the new
+          document id and first-page geometry.
+
+        The interactive canvas calls this exact tool via the MCP Apps bridge,
+        passing ui_submitted=true for draw (the human already chose Save). A model
+        calling it directly should omit ui_submitted.
         </instructions>
         <parameters>
-        - document: Name or path of the target document (id or visibleName).
-        - page: 1-based page number to append to.
-        - strokes: List of stroke dicts. Each:
+        - method: "draw" | "add_page" | "create_document".
+        - document: Target document name/path/id (draw, add_page).
+        - page: 1-based page number (draw).
+        - strokes: List of stroke dicts (draw). Each:
             {"points": [[nx, ny], [nx, ny, pressure], ...],
              "tool": "fineliner" | "highlighter" | int,
              "color": "black" | "yellow" | ...,
              "width": <optional float>, "thickness_scale": <optional float>}
+        - name: Title of the new notebook (create_document).
+        - text: Optional text to seed the first page with (create_document).
+        - folder: Destination folder path (create_document; default "/").
         - ui_submitted: Set by the canvas app when the user clicked Save. Models omit it.
         </parameters>
         <examples>
-        - remarkable_canvas_write("Ideas", 1,
-            [{"points": [[0.1,0.2],[0.8,0.2]], "tool": "highlighter", "color": "yellow"}])
+        - remarkable_author(method="draw", document="Ideas", page=1,
+            strokes=[{"points": [[0.1,0.2],[0.8,0.2]], "tool": "highlighter", "color": "yellow"}])
+        - remarkable_author(method="add_page", document="Ideas")
+        - remarkable_author(method="create_document", name="Meeting notes",
+            text="Agenda\nFollow-ups")
         </examples>
         """
 
@@ -608,126 +893,26 @@ def register_write_tools():
             if not _is_ssh_mode():
                 return make_error(
                     error_type="unsupported_transport",
-                    message="Writing strokes back currently requires SSH mode.",
+                    message="Authoring native ink/notebooks currently requires SSH mode.",
                     suggestion=(
                         "Run with: remarkable-mcp --ssh (USB cable + SSH enabled). "
-                        "Stroke write-back over cloud/USB-web is not supported yet — "
+                        "Native write-back over cloud/USB-web is not supported yet — "
                         "for those, render and re-upload a flattened PDF instead."
                     ),
                 )
-            if not strokes:
-                return make_error(
-                    error_type="no_strokes",
-                    message="No strokes provided to write.",
-                    suggestion=(
-                        "Pass a non-empty list of stroke dicts, e.g. "
-                        '[{"points": [[0.1,0.2],[0.8,0.2]], "tool": "fineliner", '
-                        '"color": "black"}].'
-                    ),
-                )
 
-            from remarkable_mcp import strokes as strokes_mod
-
-            ssh_client = _get_ssh_client()
-            collection = ssh_client.get_meta_items()
-            items_by_id = get_items_by_id(collection)
-            target = _resolve_document(document, collection, items_by_id)
-            if not target:
-                from remarkable_mcp.extract import find_similar_documents
-
-                similar = find_similar_documents(document, collection)
-                return make_error(
-                    error_type="document_not_found",
-                    message=f"Document not found: '{document}'",
-                    suggestion="Use remarkable_browse() to find the correct name.",
-                    did_you_mean=similar or None,
-                )
-
-            doc_uuid = target.ID
-            content_raw = _read_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}.content")
-            try:
-                content_data = json.loads(content_raw) if content_raw else {}
-            except (ValueError, TypeError):
-                content_data = {}
-            page_ids = _page_ids_from_content(content_data)
-            if not page_ids:
-                return make_error(
-                    error_type="no_pages",
-                    message=f"Could not read the page list for '{target.VissibleName}'.",
-                    suggestion="The document may have no pages, or an unexpected .content format.",
-                )
-            if page < 1 or page > len(page_ids):
-                return make_error(
-                    error_type="page_out_of_range",
-                    message=f"Page {page} does not exist. Document has {len(page_ids)} page(s).",
-                    suggestion=f"Use page=1 to {len(page_ids)}.",
-                )
-
-            page_id = page_ids[page - 1]
-            file_type = str(content_data.get("fileType", "") or "")
-            rm_path = f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm"
-            original = _read_remote_bytes(ssh_client, rm_path)
-            if original is None:
-                return make_error(
-                    error_type="no_page_layer",
-                    message=f"Page {page} has no existing ink layer (.rm) to append to.",
-                    suggestion=(
-                        "v1 appends to pages that already contain a drawable layer "
-                        "(native notebook pages, or PDF/EPUB pages that have been "
-                        "annotated at least once). Open the page and make one mark on "
-                        "the tablet first, or use remarkable_add_page to add a blank page."
-                    ),
-                )
-
-            try:
-                geom = strokes_mod.page_geometry(original)
-                new_bytes = strokes_mod.append_strokes(original, strokes)
-            except strokes_mod.StrokeError as e:
-                return make_error(
-                    error_type="stroke_write_failed",
-                    message=str(e),
-                    suggestion=(
-                        "Check the stroke format (points normalized [0,1]) and that "
-                        "the page has a drawable layer."
-                    ),
-                )
-            except Exception as e:  # noqa: BLE001 - surface as structured guidance
-                return make_error(
-                    error_type="stroke_write_failed",
-                    message=f"Failed to build strokes for page {page}: {e}",
-                    suggestion="Verify the stroke payload and retry.",
-                )
-
-            # Preserve the pristine original once, then write the appended bytes.
-            bak_path = rm_path + ".bak"
-            if not _remote_file_exists(ssh_client, bak_path):
-                _write_remote_bytes(ssh_client, bak_path, original)
-            _write_remote_bytes(ssh_client, rm_path, new_bytes)
-            _restart_xochitl(ssh_client)
-
-            result = {
-                "written": True,
-                "document": target.VissibleName,
-                "page": page,
-                "total_pages": len(page_ids),
-                "strokes_added": len(strokes),
-                "paper_size": [geom["paper_width"], geom["paper_height"]],
-                "file_type": file_type or "notebook",
-                "writable": True,
-                "transport": "ssh",
-                "ui_submitted": bool(ui_submitted),
-            }
-            if file_type.lower() == "epub":
-                result["caveat"] = (
-                    "This is a reflowable EPUB; annotations are anchored to the "
-                    "current layout and may shift if the font size or layout changes."
-                )
-            hint = (
-                f"Appended {len(strokes)} stroke(s) to page {page} of "
-                f"'{target.VissibleName}'. Call remarkable_canvas(document, page) to "
-                "view the updated page."
+            if method == "draw":
+                return _author_draw(document, page, strokes, ui_submitted)
+            if method == "add_page":
+                return _author_add_page(document)
+            if method == "create_document":
+                return _author_create_document(name, text, folder)
+            return make_error(
+                error_type="unknown_method",
+                message=f"Unknown method: '{method}'.",
+                suggestion='Use method="draw", "add_page", or "create_document".',
+                did_you_mean=["draw", "add_page", "create_document"],
             )
-            return make_response(result, hint)
 
         return await asyncio.to_thread(_impl)
 

--- a/test_server.py
+++ b/test_server.py
@@ -4298,6 +4298,8 @@ class TestCanvasWrite:
             assert data["document"] == "My notes"
             assert data["total_pages"] == 1
             assert data["has_text"] is False
+            # Blank notebook: no typed-text render caveat in the hint.
+            assert "canvas preview" not in data["_hint"]
             uid = data["document_id"]
             assert uid in contents and uid in metas
             assert contents[uid]["fileType"] == "notebook"
@@ -4306,6 +4308,31 @@ class TestCanvasWrite:
             assert metas[uid]["type"] == "DocumentType"
             assert any(p.endswith(".rm") for p in writes)
             mock_restart.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_document_with_text_flags_render_caveat(self):
+        """Seeding text sets has_text and warns it won't show in the canvas preview."""
+        import remarkable_mcp.write_tools as wt
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = []
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+            patch.object(wt, "_write_remote_bytes", lambda ssh, p, d: None),
+            patch.object(wt, "_write_content_file", lambda ssh, u, d: None),
+            patch.object(wt, "_write_metadata", lambda ssh, u, d: None),
+            patch.object(wt, "_restart_xochitl"),
+            patch.object(wt, "_invalidate_client_cache", lambda c: None),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_author",
+                {"method": "create_document", "name": "My notes", "text": "Agenda"},
+            )
+            data = json.loads(result[0][0].text)
+            assert data["has_text"] is True
+            assert "canvas preview" in data["_hint"]
 
     @pytest.mark.asyncio
     async def test_create_document_requires_name(self):

--- a/test_server.py
+++ b/test_server.py
@@ -3605,6 +3605,93 @@ class TestCanvasResource:
         assert APP_UI_MIME == "text/html;profile=mcp-app"
 
 
+class TestFullPageRender:
+    """Full-page (uncropped) render used by the interactive canvas.
+
+    The canvas renders the WHOLE page (viewBox from the page's own
+    SceneInfo.paper_size) and addresses pages by cPages index, so the drawing
+    overlay's normalized coordinates map onto the same stroke space the write
+    tool uses, and blank pages still render.
+    """
+
+    def test_svg_full_page_viewbox_is_centered(self):
+        from remarkable_mcp.extract import _svg_full_page
+
+        svg = _svg_full_page([], 820.0, 1458.0)
+        # Center-origin X, top-origin Y: viewBox "-W/2 0 W H".
+        assert 'viewBox="-410 0 820 1458"' in svg
+        assert "<svg" in svg
+
+    def test_full_page_png_returns_paper_size_and_matching_aspect(self):
+        import io as _io
+
+        from PIL import Image
+
+        from remarkable_mcp.extract import render_rm_file_full_page_png
+
+        try:
+            data = _make_v6_rm_bytes()
+        except Exception as exc:  # pragma: no cover - guards rmscene API drift
+            pytest.skip(f"could not synthesize a v6 fixture: {exc}")
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(data)
+            rm_path = Path(rm_tmp.name)
+        try:
+            result = render_rm_file_full_page_png(rm_path, background_color="#FFFFFF")
+            assert result is not None
+            png, (w, h) = result
+            # The fixture has no SceneInfo -> fall back to the standard page extent.
+            assert (round(w), round(h)) == (1404, 1872)
+            im = Image.open(_io.BytesIO(png))
+            # PNG aspect must match the page aspect so [0,1] maps linearly.
+            assert abs(im.size[0] / im.size[1] - w / h) < 0.01
+        finally:
+            rm_path.unlink(missing_ok=True)
+
+    def test_full_page_render_is_cpages_indexed_and_renders_blank_pages(self):
+        import io as _io
+        import json as _json
+        import zipfile as _zip
+
+        from PIL import Image
+
+        from remarkable_mcp.extract import render_page_full_page_from_document_zip
+
+        try:
+            rm_bytes = _make_v6_rm_bytes()
+        except Exception as exc:  # pragma: no cover - guards rmscene API drift
+            pytest.skip(f"could not synthesize a v6 fixture: {exc}")
+
+        # Two pages in cPages, but only page 1 ("p1") has a .rm layer on disk.
+        content = {"cPages": {"pages": [{"id": "p1"}, {"id": "p2"}]}}
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as ztmp:
+            zpath = Path(ztmp.name)
+        try:
+            with _zip.ZipFile(zpath, "w") as zf:
+                zf.writestr("doc.content", _json.dumps(content))
+                zf.writestr("p1.rm", rm_bytes)  # p2.rm intentionally absent
+
+            # Page 1 has a drawable layer -> rendered from its .rm.
+            r1 = render_page_full_page_from_document_zip(zpath, 1, background_color="#FFFFFF")
+            assert r1 is not None
+            png1, size1 = r1
+            assert Image.open(_io.BytesIO(png1)).size[0] > 0
+
+            # Page 2 exists in cPages but has no .rm -> a BLANK full page is
+            # rendered (not None). If pages were addressed by filesystem .rm
+            # order this would be out of range (only one .rm file exists).
+            r2 = render_page_full_page_from_document_zip(zpath, 2, background_color="#FFFFFF")
+            assert r2 is not None
+            _png2, size2 = r2
+            assert size2 == size1  # blank page sized to the document's paper size
+
+            # Page 3 is not in cPages -> out of range.
+            assert render_page_full_page_from_document_zip(zpath, 3) is None
+        finally:
+            zpath.unlink(missing_ok=True)
+
+
 class TestRenderCanvasPage:
     """Test the read-only canvas page renderer."""
 
@@ -3634,7 +3721,11 @@ class TestRenderCanvasPage:
         monkeypatch.setattr(api, "download_raw_file", lambda c, d, ext: None)
         monkeypatch.setattr(extract, "get_background_color", lambda: "#FBFBFB")
         monkeypatch.setattr(extract, "get_document_page_count", lambda p: page_count)
-        monkeypatch.setattr(extract, "render_page_from_document_zip", lambda p, pg, **k: png)
+        monkeypatch.setattr(
+            extract,
+            "render_page_full_page_from_document_zip",
+            lambda p, pg, **k: ((png, (820.0, 1458.0)) if png is not None else None),
+        )
         monkeypatch.setattr(extract, "find_similar_documents", lambda q, docs: [])
         monkeypatch.setattr(tools, "_get_root_path", lambda: "/")
         monkeypatch.setattr(tools, "_is_within_root", lambda path, root: True)
@@ -3660,6 +3751,7 @@ class TestRenderCanvasPage:
         assert sc["writable"] is False
         assert sc["page_width_px"] == 12
         assert sc["page_height_px"] == 16
+        assert sc["paper_size"] == [820, 1458]
         # Embedded PNG is included for non-app clients.
         assert any(isinstance(c, types.EmbeddedResource) for c in result.content)
 

--- a/test_server.py
+++ b/test_server.py
@@ -2588,7 +2588,7 @@ class TestWriteTools:
         tool_names = [tool.name for tool in tools]
 
         write_tool_names = [
-            "remarkable_canvas_write",
+            "remarkable_author",
             "remarkable_upload",
             "remarkable_mkdir",
             "remarkable_move",
@@ -3585,6 +3585,18 @@ class TestCanvasResource:
         assert "remarkable_canvas" in _CANVAS_HTML
         assert "png_data_uri" in _CANVAS_HTML
 
+    def test_canvas_has_add_page_flow(self):
+        from remarkable_mcp.app_canvas import _CANVAS_HTML
+
+        # The +Page control queues a local blank page and Save materializes it
+        # via remarkable_author(method="add_page") before drawing cached strokes.
+        assert 'id="addpage"' in _CANVAS_HTML
+        assert "pendingPages" in _CANVAS_HTML
+        assert '"add_page"' in _CANVAS_HTML
+        assert "renderPending" in _CANVAS_HTML
+        # +Page is gated to native notebooks (PDFs/EPUBs have fixed pages).
+        assert 'state.fileType === "notebook"' in _CANVAS_HTML
+
     def test_canvas_bridge_is_spec_compliant(self):
         from remarkable_mcp.app_canvas import _CANVAS_HTML
 
@@ -3704,7 +3716,9 @@ class TestRenderCanvasPage:
         Image.new("RGB", (12, 16), "white").save(buf, "PNG")
         return buf.getvalue()
 
-    def _patch_common(self, monkeypatch, *, page_count=3, png=None, doc_name="Notes"):
+    def _patch_common(
+        self, monkeypatch, *, page_count=3, png=None, doc_name="Notes", file_type="notebook"
+    ):
         import remarkable_mcp.api as api
         import remarkable_mcp.extract as extract
         import remarkable_mcp.tools as tools
@@ -3721,6 +3735,7 @@ class TestRenderCanvasPage:
         monkeypatch.setattr(api, "download_raw_file", lambda c, d, ext: None)
         monkeypatch.setattr(extract, "get_background_color", lambda: "#FBFBFB")
         monkeypatch.setattr(extract, "get_document_page_count", lambda p: page_count)
+        monkeypatch.setattr(extract, "get_document_file_type", lambda p: file_type)
         monkeypatch.setattr(
             extract,
             "render_page_full_page_from_document_zip",
@@ -3752,6 +3767,7 @@ class TestRenderCanvasPage:
         assert sc["page_width_px"] == 12
         assert sc["page_height_px"] == 16
         assert sc["paper_size"] == [820, 1458]
+        assert sc["file_type"] == "notebook"
         # Embedded PNG is included for non-app clients.
         assert any(isinstance(c, types.EmbeddedResource) for c in result.content)
 
@@ -3925,7 +3941,7 @@ class TestCLIFlags:
 
 
 class TestCanvasWrite:
-    """Test the remarkable_canvas_write stroke write-back tool (SSH-first)."""
+    """Test the remarkable_author tool (method="draw" stroke write-back, SSH-first)."""
 
     def _mock_doc(self):
         doc = Mock()
@@ -3939,12 +3955,13 @@ class TestCanvasWrite:
     @pytest.mark.asyncio
     async def test_requires_ssh_transport(self):
         """In cloud/USB mode the tool returns an educational unsupported_transport error."""
-        # Neither SSH nor USB env set -> cloud; canvas_write needs SSH.
+        # Neither SSH nor USB env set -> cloud; draw needs SSH.
         old = os.environ.pop("REMARKABLE_USE_SSH", None)
         try:
             result = await mcp.call_tool(
-                "remarkable_canvas_write",
+                "remarkable_author",
                 {
+                    "method": "draw",
                     "document": "Sketchbook",
                     "page": 1,
                     "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "fineliner"}],
@@ -3960,15 +3977,24 @@ class TestCanvasWrite:
     async def test_empty_strokes_rejected(self):
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
             result = await mcp.call_tool(
-                "remarkable_canvas_write",
-                {"document": "Sketchbook", "page": 1, "strokes": []},
+                "remarkable_author",
+                {"method": "draw", "document": "Sketchbook", "page": 1, "strokes": []},
             )
             data = json.loads(result[0][0].text)
             assert data["_error"]["type"] == "no_strokes"
 
     @pytest.mark.asyncio
-    async def test_missing_page_layer_is_educational(self):
-        """A page with no existing .rm overlay returns a clear no_page_layer error."""
+    async def test_unknown_method_is_educational(self):
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            result = await mcp.call_tool("remarkable_author", {"method": "frobnicate"})
+            data = json.loads(result[0][0].text)
+            assert data["_error"]["type"] == "unknown_method"
+            assert "draw" in data["_error"]["did_you_mean"]
+
+    @pytest.mark.asyncio
+    async def test_missing_layer_autocreates_overlay(self):
+        """A page with no .rm overlay gets a blank drawable layer created automatically."""
+        import remarkable_mcp.strokes as strokes_mod
         import remarkable_mcp.write_tools as wt
 
         doc = self._mock_doc()
@@ -3983,20 +4009,44 @@ class TestCanvasWrite:
         client.get_meta_items.return_value = [doc]
         client._scp_download.side_effect = fake_scp
 
+        writes = {}
+
         with (
             patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
             patch.object(wt, "get_rmapi", lambda: client),
+            patch.object(wt, "_write_remote_bytes", lambda ssh, p, d: writes.__setitem__(p, d)),
+            patch.object(wt, "_restart_xochitl") as mock_restart,
+            patch.object(
+                strokes_mod,
+                "page_geometry",
+                lambda b: {
+                    "paper_width": 1404,
+                    "paper_height": 1872,
+                    "has_scene_info": False,
+                    "has_layer": True,
+                },
+            ),
+            patch.object(
+                strokes_mod, "append_strokes", lambda original, strokes: original + b"NEW"
+            ),
         ):
             result = await mcp.call_tool(
-                "remarkable_canvas_write",
+                "remarkable_author",
                 {
+                    "method": "draw",
                     "document": "Sketchbook",
                     "page": 1,
                     "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "fineliner"}],
                 },
             )
             data = json.loads(result[0][0].text)
-            assert data["_error"]["type"] == "no_page_layer"
+            assert data["written"] is True
+            assert data["created_overlay"] is True
+            rm = f"{wt.XOCHITL_PATH}/doc-abc/page-1.rm"
+            # The overlay was written; nothing pre-existed, so no .bak.
+            assert rm in writes
+            assert (rm + ".bak") not in writes
+            mock_restart.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_happy_path_appends_and_backs_up(self):
@@ -4046,8 +4096,9 @@ class TestCanvasWrite:
             ),
         ):
             result = await mcp.call_tool(
-                "remarkable_canvas_write",
+                "remarkable_author",
                 {
+                    "method": "draw",
                     "document": "Sketchbook",
                     "page": 1,
                     "strokes": [
@@ -4067,6 +4118,7 @@ class TestCanvasWrite:
             assert data["strokes_added"] == 1
             assert data["paper_size"] == [1404, 1872]
             assert data["ui_submitted"] is True
+            assert data["created_overlay"] is False
             mock_restart.assert_called_once()
             # Pristine original backed up, then the appended bytes written.
             bak = f"{wt.XOCHITL_PATH}/doc-abc/page-1.rm.bak"
@@ -4115,8 +4167,9 @@ class TestCanvasWrite:
             ),
         ):
             result = await mcp.call_tool(
-                "remarkable_canvas_write",
+                "remarkable_author",
                 {
+                    "method": "draw",
                     "document": "Sketchbook",
                     "page": 1,
                     "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "highlighter"}],
@@ -4125,3 +4178,280 @@ class TestCanvasWrite:
             data = json.loads(result[0][0].text)
             assert data["written"] is True
             assert "caveat" in data and "EPUB" in data["caveat"]
+
+    @pytest.mark.asyncio
+    async def test_add_page_appends_blank_page(self):
+        """method="add_page" uploads a blank .rm and grows the notebook's .content."""
+        import remarkable_mcp.write_tools as wt
+
+        doc = self._mock_doc()
+        content = json.dumps(
+            {
+                "cPages": {
+                    "pages": [{"id": "p1", "idx": {"timestamp": "1:2", "value": "ba"}}],
+                    "uuids": [{"first": "4ceffb02-db05-55dc-bf8b-c2aeb505a8e6", "second": 1}],
+                },
+                "fileType": "notebook",
+                "pageCount": 1,
+            }
+        )
+
+        def fake_scp(path):
+            if path.endswith(".content"):
+                return content.encode()
+            return None
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = [doc]
+        client._scp_download.side_effect = fake_scp
+
+        writes = {}
+        contents = {}
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+            patch.object(wt, "_write_remote_bytes", lambda ssh, p, d: writes.__setitem__(p, d)),
+            patch.object(wt, "_write_content_file", lambda ssh, u, d: contents.__setitem__(u, d)),
+            patch.object(wt, "_restart_xochitl") as mock_restart,
+            patch.object(wt, "_invalidate_client_cache", lambda c: None),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_author", {"method": "add_page", "document": "Sketchbook"}
+            )
+            data = json.loads(result[0][0].text)
+            assert data["added"] is True
+            assert data["page_added"] == 2
+            assert data["total_pages"] == 2
+            mock_restart.assert_called_once()
+            assert any(p.endswith(".rm") for p in writes)
+            assert contents["doc-abc"]["pageCount"] == 2
+            pages = contents["doc-abc"]["cPages"]["pages"]
+            assert len(pages) == 2
+            assert pages[1]["idx"]["value"] == "bb"
+
+    @pytest.mark.asyncio
+    async def test_add_page_rejects_non_notebook(self):
+        """Adding a page to a PDF (flat pages list) returns an educational error."""
+        import remarkable_mcp.write_tools as wt
+
+        doc = self._mock_doc()
+        content = json.dumps({"pages": ["p1", "p2"], "fileType": "pdf"})
+
+        def fake_scp(path):
+            if path.endswith(".content"):
+                return content.encode()
+            return None
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = [doc]
+        client._scp_download.side_effect = fake_scp
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_author", {"method": "add_page", "document": "Sketchbook"}
+            )
+            data = json.loads(result[0][0].text)
+            assert data["_error"]["type"] == "not_a_notebook"
+
+    @pytest.mark.asyncio
+    async def test_create_document_blank(self):
+        """method="create_document" scaffolds a notebook (.rm + .content + .metadata)."""
+        import remarkable_mcp.write_tools as wt
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = []
+
+        writes = {}
+        contents = {}
+        metas = {}
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+            patch.object(wt, "_write_remote_bytes", lambda ssh, p, d: writes.__setitem__(p, d)),
+            patch.object(wt, "_write_content_file", lambda ssh, u, d: contents.__setitem__(u, d)),
+            patch.object(wt, "_write_metadata", lambda ssh, u, d: metas.__setitem__(u, d)),
+            patch.object(wt, "_restart_xochitl") as mock_restart,
+            patch.object(wt, "_invalidate_client_cache", lambda c: None),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_author", {"method": "create_document", "name": "My notes"}
+            )
+            data = json.loads(result[0][0].text)
+            assert data["created"] is True
+            assert data["document"] == "My notes"
+            assert data["total_pages"] == 1
+            assert data["has_text"] is False
+            uid = data["document_id"]
+            assert uid in contents and uid in metas
+            assert contents[uid]["fileType"] == "notebook"
+            assert contents[uid]["pageCount"] == 1
+            assert metas[uid]["visibleName"] == "My notes"
+            assert metas[uid]["type"] == "DocumentType"
+            assert any(p.endswith(".rm") for p in writes)
+            mock_restart.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_document_requires_name(self):
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            result = await mcp.call_tool("remarkable_author", {"method": "create_document"})
+            data = json.loads(result[0][0].text)
+            assert data["_error"]["type"] == "missing_parameter"
+
+
+class TestNotebookBuilders:
+    """Pure-logic tests for remarkable_mcp.notebooks (no transport)."""
+
+    def test_blank_page_is_drawable(self):
+        import io
+
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp import strokes as s
+
+        raw = nb.blank_page_rm_bytes()
+        blocks = list(s.read_blocks(io.BytesIO(raw)))
+        assert s.find_target_layer(blocks) is not None
+
+    def test_text_page_is_drawable_and_appendable(self):
+        import io
+
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp import strokes as s
+
+        raw = nb.page_rm_bytes("Hello\nWorld")
+        blocks = list(s.read_blocks(io.BytesIO(raw)))
+        assert s.find_target_layer(blocks) is not None
+        out = s.append_strokes(
+            raw, [{"points": [[0.1, 0.1], [0.5, 0.5]], "tool": "fineliner", "color": "black"}]
+        )
+        assert out.startswith(raw)
+
+    def test_next_page_idx_sequence(self):
+        from remarkable_mcp import notebooks as nb
+
+        assert nb.next_page_idx([]) == "ba"
+        vals = []
+        for _ in range(5):
+            vals.append(nb.next_page_idx(vals))
+        assert vals == ["ba", "bb", "bc", "bd", "be"]
+        assert nb.next_page_idx(["bz"]) == "bza"
+
+    def test_new_notebook_content_shape(self):
+        from remarkable_mcp import notebooks as nb
+
+        au = nb.new_uuid()
+        pid = nb.new_uuid()
+        c = nb.new_notebook_content([pid], au)
+        assert c["fileType"] == "notebook"
+        assert c["formatVersion"] == 2
+        assert c["pageCount"] == 1
+        assert c["cPages"]["pages"][0]["id"] == pid
+        assert c["cPages"]["pages"][0]["idx"]["value"] == "ba"
+        assert c["cPages"]["uuids"][0]["first"] == au
+        # serializable
+        json.dumps(c)
+
+    def test_content_author_uuid_matches_rm(self):
+        import io
+
+        from rmscene.scene_stream import AuthorIdsBlock
+
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp import strokes as s
+
+        au = nb.new_uuid()
+        raw = nb.blank_page_rm_bytes(author_uuid=au)
+        blocks = list(s.read_blocks(io.BytesIO(raw)))
+        author_block = next(b for b in blocks if isinstance(b, AuthorIdsBlock))
+        c = nb.new_notebook_content([nb.new_uuid()], au)
+        assert c["cPages"]["uuids"][0]["first"] == str(author_block.author_uuids[1])
+
+    def test_append_page_to_content_grows(self):
+        from remarkable_mcp import notebooks as nb
+
+        au = nb.new_uuid()
+        c = nb.new_notebook_content([nb.new_uuid()], au)
+        res = nb.append_page_to_content(c, nb.new_uuid())
+        assert res["page_index"] == 2
+        assert res["total_pages"] == 2
+        assert c["pageCount"] == 2
+        assert c["cPages"]["pages"][1]["idx"]["value"] == "bb"
+
+    def test_append_page_rejects_non_notebook(self):
+        from remarkable_mcp import notebooks as nb
+
+        with pytest.raises(ValueError):
+            nb.append_page_to_content({"pages": ["a", "b"], "fileType": "pdf"}, "x")
+
+    def test_metadata_shape(self):
+        from remarkable_mcp import notebooks as nb
+
+        m = nb.new_document_metadata("Hello", parent="folder-uuid")
+        assert m["visibleName"] == "Hello"
+        assert m["type"] == "DocumentType"
+        assert m["parent"] == "folder-uuid"
+        assert m["deleted"] is False
+        assert m["metadatamodified"] is True
+        json.dumps(m)
+
+
+class TestGetDocumentFileType:
+    """Pure-logic tests for extract.get_document_file_type (zip .content reader)."""
+
+    def _zip_with_content(self, content):
+        import json as _json
+        import tempfile
+        import zipfile as _zip
+        from pathlib import Path
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as ztmp:
+            zpath = Path(ztmp.name)
+        with _zip.ZipFile(zpath, "w") as zf:
+            if content is not None:
+                zf.writestr("doc.content", _json.dumps(content))
+        return zpath
+
+    def test_reads_notebook_file_type(self):
+        from remarkable_mcp.extract import get_document_file_type
+
+        zpath = self._zip_with_content({"fileType": "notebook", "formatVersion": 2})
+        try:
+            assert get_document_file_type(zpath) == "notebook"
+        finally:
+            zpath.unlink(missing_ok=True)
+
+    def test_reads_pdf_file_type(self):
+        from remarkable_mcp.extract import get_document_file_type
+
+        zpath = self._zip_with_content({"fileType": "pdf"})
+        try:
+            assert get_document_file_type(zpath) == "pdf"
+        finally:
+            zpath.unlink(missing_ok=True)
+
+    def test_missing_content_returns_empty(self):
+        from remarkable_mcp.extract import get_document_file_type
+
+        zpath = self._zip_with_content(None)  # no .content entry
+        try:
+            assert get_document_file_type(zpath) == ""
+        finally:
+            zpath.unlink(missing_ok=True)
+
+    def test_bad_zip_returns_empty(self):
+        import tempfile
+        from pathlib import Path
+
+        from remarkable_mcp.extract import get_document_file_type
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as ztmp:
+            ztmp.write(b"not a zip")
+            zpath = Path(ztmp.name)
+        try:
+            assert get_document_file_type(zpath) == ""
+        finally:
+            zpath.unlink(missing_ok=True)

--- a/test_server.py
+++ b/test_server.py
@@ -110,9 +110,9 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Six read tools + always-on canvas + five write tools (write-on by default)."""
+        """Six read tools + always-on canvas + six write tools (write-on by default)."""
         tools = await mcp.list_tools()
-        assert len(tools) == 12, f"Expected 12 tools, got {len(tools)}"
+        assert len(tools) == 13, f"Expected 13 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -1133,7 +1133,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 12
+        assert len(tools) == 13
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:
@@ -2588,6 +2588,7 @@ class TestWriteTools:
         tool_names = [tool.name for tool in tools]
 
         write_tool_names = [
+            "remarkable_canvas_write",
             "remarkable_upload",
             "remarkable_mkdir",
             "remarkable_move",
@@ -3829,3 +3830,206 @@ class TestCLIFlags:
         finally:
             if old is not None:
                 os.environ["REMARKABLE_READ_ONLY"] = old
+
+
+class TestCanvasWrite:
+    """Test the remarkable_canvas_write stroke write-back tool (SSH-first)."""
+
+    def _mock_doc(self):
+        doc = Mock()
+        doc.VissibleName = "Sketchbook"
+        doc.ID = "doc-abc"
+        doc.Parent = ""
+        doc.is_folder = False
+        doc.is_cloud_archived = False
+        return doc
+
+    @pytest.mark.asyncio
+    async def test_requires_ssh_transport(self):
+        """In cloud/USB mode the tool returns an educational unsupported_transport error."""
+        # Neither SSH nor USB env set -> cloud; canvas_write needs SSH.
+        old = os.environ.pop("REMARKABLE_USE_SSH", None)
+        try:
+            result = await mcp.call_tool(
+                "remarkable_canvas_write",
+                {
+                    "document": "Sketchbook",
+                    "page": 1,
+                    "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "fineliner"}],
+                },
+            )
+            data = json.loads(result[0][0].text)
+            assert data["_error"]["type"] == "unsupported_transport"
+        finally:
+            if old is not None:
+                os.environ["REMARKABLE_USE_SSH"] = old
+
+    @pytest.mark.asyncio
+    async def test_empty_strokes_rejected(self):
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            result = await mcp.call_tool(
+                "remarkable_canvas_write",
+                {"document": "Sketchbook", "page": 1, "strokes": []},
+            )
+            data = json.loads(result[0][0].text)
+            assert data["_error"]["type"] == "no_strokes"
+
+    @pytest.mark.asyncio
+    async def test_missing_page_layer_is_educational(self):
+        """A page with no existing .rm overlay returns a clear no_page_layer error."""
+        import remarkable_mcp.write_tools as wt
+
+        doc = self._mock_doc()
+        content = json.dumps({"cPages": {"pages": [{"id": "page-1"}]}, "fileType": "pdf"})
+
+        def fake_scp(path):
+            if path.endswith(".content"):
+                return content.encode()
+            return None  # page .rm absent
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = [doc]
+        client._scp_download.side_effect = fake_scp
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_canvas_write",
+                {
+                    "document": "Sketchbook",
+                    "page": 1,
+                    "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "fineliner"}],
+                },
+            )
+            data = json.loads(result[0][0].text)
+            assert data["_error"]["type"] == "no_page_layer"
+
+    @pytest.mark.asyncio
+    async def test_happy_path_appends_and_backs_up(self):
+        """Strokes are appended, the pristine original is backed up once, xochitl restarts."""
+        import remarkable_mcp.strokes as strokes_mod
+        import remarkable_mcp.write_tools as wt
+
+        doc = self._mock_doc()
+        content = json.dumps(
+            {"cPages": {"pages": [{"id": "page-1"}, {"id": "page-2"}]}, "fileType": "notebook"}
+        )
+
+        def fake_scp(path):
+            if path.endswith(".content"):
+                return content.encode()
+            if path.endswith("/page-1.rm"):
+                return b"ORIGINAL_RM_BYTES"
+            return None
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = [doc]
+        client._scp_download.side_effect = fake_scp
+        client._ssh_command.return_value = "no"  # .bak does not exist yet
+
+        writes = {}
+
+        def fake_write(ssh, remote_path, data):
+            writes[remote_path] = data
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+            patch.object(wt, "_write_remote_bytes", fake_write),
+            patch.object(wt, "_restart_xochitl") as mock_restart,
+            patch.object(
+                strokes_mod,
+                "page_geometry",
+                lambda b: {
+                    "paper_width": 1404,
+                    "paper_height": 1872,
+                    "has_scene_info": True,
+                    "has_layer": True,
+                },
+            ),
+            patch.object(
+                strokes_mod, "append_strokes", lambda original, strokes: original + b"NEW"
+            ),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_canvas_write",
+                {
+                    "document": "Sketchbook",
+                    "page": 1,
+                    "strokes": [
+                        {
+                            "points": [[0.1, 0.2], [0.8, 0.2]],
+                            "tool": "highlighter",
+                            "color": "yellow",
+                        }
+                    ],
+                    "ui_submitted": True,
+                },
+            )
+            data = json.loads(result[0][0].text)
+            assert data["written"] is True
+            assert data["page"] == 1
+            assert data["total_pages"] == 2
+            assert data["strokes_added"] == 1
+            assert data["paper_size"] == [1404, 1872]
+            assert data["ui_submitted"] is True
+            mock_restart.assert_called_once()
+            # Pristine original backed up, then the appended bytes written.
+            bak = f"{wt.XOCHITL_PATH}/doc-abc/page-1.rm.bak"
+            rm = f"{wt.XOCHITL_PATH}/doc-abc/page-1.rm"
+            assert writes[bak] == b"ORIGINAL_RM_BYTES"
+            assert writes[rm] == b"ORIGINAL_RM_BYTESNEW"
+
+    @pytest.mark.asyncio
+    async def test_epub_warns_about_reflow(self):
+        """Annotating a reflowable EPUB surfaces a drift caveat in the response."""
+        import remarkable_mcp.strokes as strokes_mod
+        import remarkable_mcp.write_tools as wt
+
+        doc = self._mock_doc()
+        content = json.dumps({"cPages": {"pages": [{"id": "page-1"}]}, "fileType": "epub"})
+
+        def fake_scp(path):
+            if path.endswith(".content"):
+                return content.encode()
+            if path.endswith("/page-1.rm"):
+                return b"ORIGINAL_RM_BYTES"
+            return None
+
+        client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
+        client.get_meta_items.return_value = [doc]
+        client._scp_download.side_effect = fake_scp
+        client._ssh_command.return_value = "yes"  # .bak already exists
+
+        with (
+            patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            patch.object(wt, "get_rmapi", lambda: client),
+            patch.object(wt, "_write_remote_bytes", lambda *a: None),
+            patch.object(wt, "_restart_xochitl"),
+            patch.object(
+                strokes_mod,
+                "page_geometry",
+                lambda b: {
+                    "paper_width": 1404,
+                    "paper_height": 1872,
+                    "has_scene_info": True,
+                    "has_layer": True,
+                },
+            ),
+            patch.object(
+                strokes_mod, "append_strokes", lambda original, strokes: original + b"NEW"
+            ),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_canvas_write",
+                {
+                    "document": "Sketchbook",
+                    "page": 1,
+                    "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "highlighter"}],
+                },
+            )
+            data = json.loads(result[0][0].text)
+            assert data["written"] is True
+            assert "caveat" in data and "EPUB" in data["caveat"]

--- a/test_server.py
+++ b/test_server.py
@@ -3713,6 +3713,58 @@ class TestFullPageRender:
         finally:
             zpath.unlink(missing_ok=True)
 
+    def test_typed_text_emits_svg_text_elements(self):
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp.extract import _v6_blocks, _v6_text_svg_elements
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(nb.page_rm_bytes("Hello world\nSecond line"))
+            rm_path = Path(rm_tmp.name)
+        try:
+            elements = _v6_text_svg_elements(_v6_blocks(rm_path))
+            assert len(elements) == 2
+            joined = "".join(elements)
+            assert "<text " in joined
+            assert "Hello world" in joined
+            assert "Second line" in joined
+        finally:
+            rm_path.unlink(missing_ok=True)
+
+    def test_blank_page_has_no_typed_text(self):
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp.extract import _v6_blocks, _v6_text_svg_elements
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(nb.blank_page_rm_bytes())
+            rm_path = Path(rm_tmp.name)
+        try:
+            # An empty RootTextBlock (carried by synthesized blank pages) yields
+            # no <text> nodes, so the page renders blank.
+            assert _v6_text_svg_elements(_v6_blocks(rm_path)) == []
+        finally:
+            rm_path.unlink(missing_ok=True)
+
+    def test_typed_text_rasterizes_to_visible_pixels(self):
+        import io as _io
+
+        from PIL import Image
+
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp.extract import render_rm_file_full_page_png
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as rm_tmp:
+            rm_tmp.write(nb.page_rm_bytes("Hello world"))
+            rm_path = Path(rm_tmp.name)
+        try:
+            result = render_rm_file_full_page_png(rm_path, background_color="#FFFFFF")
+            assert result is not None
+            png, _ = result
+            im = Image.open(_io.BytesIO(png)).convert("L")
+            # Typed text must rasterize to dark pixels (not a blank white page).
+            assert sum(im.histogram()[:128]) > 0
+        finally:
+            rm_path.unlink(missing_ok=True)
+
 
 class TestRenderCanvasPage:
     """Test the read-only canvas page renderer."""
@@ -4298,8 +4350,6 @@ class TestCanvasWrite:
             assert data["document"] == "My notes"
             assert data["total_pages"] == 1
             assert data["has_text"] is False
-            # Blank notebook: no typed-text render caveat in the hint.
-            assert "canvas preview" not in data["_hint"]
             uid = data["document_id"]
             assert uid in contents and uid in metas
             assert contents[uid]["fileType"] == "notebook"
@@ -4310,8 +4360,8 @@ class TestCanvasWrite:
             mock_restart.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_document_with_text_flags_render_caveat(self):
-        """Seeding text sets has_text and warns it won't show in the canvas preview."""
+    async def test_create_document_with_text_seeds_first_page(self):
+        """Seeding text sets has_text; the typed text renders in the canvas preview."""
         import remarkable_mcp.write_tools as wt
 
         client = Mock(spec=["get_meta_items", "_scp_download", "_ssh_command"])
@@ -4332,7 +4382,6 @@ class TestCanvasWrite:
             )
             data = json.loads(result[0][0].text)
             assert data["has_text"] is True
-            assert "canvas preview" in data["_hint"]
 
     @pytest.mark.asyncio
     async def test_create_document_requires_name(self):

--- a/test_server.py
+++ b/test_server.py
@@ -3597,6 +3597,16 @@ class TestCanvasResource:
         # +Page is gated to native notebooks (PDFs/EPUBs have fixed pages).
         assert 'state.fileType === "notebook"' in _CANVAS_HTML
 
+    def test_canvas_footer_distinguishes_transport_from_read_only(self):
+        from remarkable_mcp.app_canvas import _CANVAS_HTML
+
+        # When write is enabled but the transport isn't SSH, the footer mirrors
+        # the draw tool's SSH-only error instead of the generic read-only string.
+        assert "writeMode" in _CANVAS_HTML
+        assert 'state.transport !== "ssh"' in _CANVAS_HTML
+        assert "connect via SSH" in _CANVAS_HTML
+        assert "Read-only viewer" in _CANVAS_HTML
+
     def test_canvas_bridge_is_spec_compliant(self):
         from remarkable_mcp.app_canvas import _CANVAS_HTML
 
@@ -3768,6 +3778,8 @@ class TestRenderCanvasPage:
         assert sc["page_height_px"] == 16
         assert sc["paper_size"] == [820, 1458]
         assert sc["file_type"] == "notebook"
+        assert sc["transport"] == "cloud"
+        assert sc["write_mode"] is True
         # Embedded PNG is included for non-app clients.
         assert any(isinstance(c, types.EmbeddedResource) for c in result.content)
 


### PR DESCRIPTION
## Summary

Adds native `.rm` ink + notebook authoring as a **single compound write primitive**, plus the interactive-canvas UX that drives it. The human Save/＋Page path and the model tool-call path call the **exact same tool**, so they produce byte-identical results (one source of truth — the canvas is a thin front-end).

Builds on #113/#114 (write-on-by-default + `--read-only`). Net tool count unchanged: **13 default / 7 read-only** (`remarkable_author` replaces `remarkable_canvas_write`).

## `remarkable_author(method=...)`
- **`draw`** — append pen/highlighter strokes to a page. Auto-creates a blank drawable overlay when a page has no ink yet (fresh notebook page, or an un-annotated PDF/EPUB page).
- **`add_page`** — append a blank, drawable page to the end of a native notebook.
- **`create_document`** — create a new native notebook, optionally seeding the first page with typed text.

SSH-only; rides the existing write gate. All methods are non-destructive (`draw` backs the page up to `{pageId}.rm.bak`), so no confirmation prompt is required.

## Canvas ＋Page flow (queued, materialize-on-Save)
- **＋Page** queues a local blank page (sized to the document's paper aspect) that is drawable immediately — nothing touches the device yet.
- **Save** materializes queued pages via `add_page`, then writes cached strokes (per-page transaction buffer with Undo).
- **Cancel** discards the buffer and returns to the last real page.
- Gated to native notebooks via a new `file_type` field surfaced in `structuredContent` (PDFs/EPUBs have fixed pages); the model digest also gets an `add_page` hint for notebooks.

## Supporting changes
- `remarkable_mcp/notebooks.py` — pure-logic builders (blank/text page `.rm`, notebook `.content`, metadata, page-idx sequencing); no transport.
- `extract.get_document_file_type()` — lightweight zip `.content` reader.

## Validation
- **Device-validated** on a reMarkable Paper Pro: `create_document` + `add_page` + `draw` all render correctly (confirmed on the tablet).
- 196 tests pass; `ruff check`/`format` clean; canvas JS syntax-checked.
- ⚠️ The new ＋Page **canvas UX** has not yet been exercised on-device — draft until live-tested in VS Code.

## Dual-path coherence
The canvas Save calls `remarkable_author(method="draw")` and ＋Page calls `remarkable_author(method="add_page")` over the MCP Apps bridge — the same `tools/call` a model uses directly. There is no parallel JS write path.

## Follow-ups (not this PR)
- Precise PDF/EPUB overlay coordinate transform (`s≈3.10`); currently PDF strokes use the notebook paper-size map (approximate).
- Canvas text-entry mode for `create_document`.