### PR TITLE
feat: hide unavailable tools per transport + multi-mode smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ Thumbs.db
 *.zip
 RESEARCH_NOTES.md
 BLOG_DRAFT.md
+
+# Smoke-test run artifacts (regenerated on every run)
+smoke/snapshots/

--- a/README.md
+++ b/README.md
@@ -695,6 +695,20 @@ uv run pytest test_server.py -v
 
 📖 **[Development Guide](docs/development.md)**
 
+### Multi-transport smoke test
+
+When something looks broken, run the deterministic, no-AI smoke test first. It
+drives the real server over MCP and exercises every available tool in every
+reachable transport (cloud → usb-web → ssh):
+
+```bash
+uv run python smoke/run_smoke.py            # all available modes
+uv run python smoke/run_smoke.py --read-only # connectivity + reads only
+```
+
+📖 **[smoke/README.md](smoke/README.md)** — what PASS / N/A / SKIP / FAIL mean
+and per-mode expectations.
+
 ---
 
 ## License

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -46,6 +46,7 @@ from remarkable_mcp.extract import (
     render_merged_page_from_document_zip,
     render_page_from_document_zip,
     render_page_from_document_zip_svg,
+    render_page_full_page_from_document_zip,
     render_tablet_pdf_page_to_png,
 )
 from remarkable_mcp.responses import make_error, make_response
@@ -1755,6 +1756,22 @@ async def remarkable_image(
                             render_tablet_pdf_page_to_png, pdf_bytes, page
                         )
                         rendered_via_pdf = png_data is not None
+
+                # Blank-page fallback: the stroke renderer returns None for a
+                # notebook page with no drawable strokes (e.g. a freshly-created
+                # or blank page). The interactive canvas already renders such
+                # pages full-bleed at their own paper size; do the same here so a
+                # blank page yields a blank image instead of render_failed,
+                # keeping remarkable_image consistent with remarkable_canvas.
+                if png_data is None:
+                    full = await run_blocking(
+                        render_page_full_page_from_document_zip,
+                        tmp_path,
+                        page,
+                        background_color=background,
+                    )
+                    if full is not None:
+                        png_data = full[0]
 
                 if png_data is None:
                     return make_error(

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -38,7 +38,6 @@ from remarkable_mcp.api import (
 )
 from remarkable_mcp.capabilities import client_supports_elicitation
 from remarkable_mcp.responses import make_error, make_response
-from remarkable_mcp.server import mcp
 from remarkable_mcp.ssh import XOCHITL_PATH, SSHClient
 
 logger = logging.getLogger(__name__)
@@ -812,8 +811,11 @@ def _author_create_document(name: str, text: Optional[str], folder: Optional[str
 
 def register_write_tools():
     """Register all write tools with the MCP server."""
+    # Imported lazily to break a circular import: server.py imports this module
+    # at load time and immediately calls register_write_tools(), so importing
+    # `mcp` at module top would re-enter a partially-initialized server module.
+    from remarkable_mcp.server import mcp
 
-    @mcp.tool(annotations=WRITE_ANNOTATIONS)
     async def remarkable_author(
         method: str,
         document: Optional[str] = None,
@@ -895,16 +897,6 @@ def register_write_tools():
             error = _require_write_transport()
             if error:
                 return error
-            if not _is_ssh_mode():
-                return make_error(
-                    error_type="unsupported_transport",
-                    message="Authoring native ink/notebooks currently requires SSH mode.",
-                    suggestion=(
-                        "Run with: remarkable-mcp --ssh (USB cable + SSH enabled). "
-                        "Native write-back over cloud/USB-web is not supported yet — "
-                        "for those, render and re-upload a flattened PDF instead."
-                    ),
-                )
 
             if method == "draw":
                 return _author_draw(document, page, strokes, ui_submitted)
@@ -920,6 +912,13 @@ def register_write_tools():
             )
 
         return await asyncio.to_thread(_impl)
+
+    # Native ink/notebook authoring is SSH-only today (cloud/USB-web write-back
+    # is not implemented yet), so only expose the tool in SSH mode rather than
+    # registering it everywhere and erroring at call time. Clients on other
+    # transports simply don't see a tool they couldn't use.
+    if _is_ssh_mode():
+        mcp.tool(annotations=WRITE_ANNOTATIONS)(remarkable_author)
 
     @mcp.tool(annotations=UPLOAD_ANNOTATIONS)
     async def remarkable_upload(

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -1,0 +1,78 @@
+# Multi-transport MCP smoke test
+
+`run_smoke.py` is the **first port of call for a support request**. It is a
+deterministic, no-AI diagnostic that drives the *real* `remarkable-mcp` server
+over the MCP protocol (stdio, via the official `mcp` client SDK — no models, no
+mocks) and exercises **every available tool in every available transport**.
+
+It answers one question quickly: *"does each mode this machine can reach actually
+work, tool by tool?"*
+
+## Running it
+
+```bash
+# All modes this machine can reach (cloud, then usb-web, then ssh)
+uv run python smoke/run_smoke.py
+
+# Just one mode
+uv run python smoke/run_smoke.py --modes cloud
+uv run python smoke/run_smoke.py --modes usb
+uv run python smoke/run_smoke.py --modes ssh
+
+# Connectivity + read checks only — no writes at all
+uv run python smoke/run_smoke.py --read-only
+```
+
+Modes run in the order **cloud → usb-web → ssh** on purpose: pushing files over
+SSH can reset the USB web interface, so the only filesystem-writing transport
+runs last.
+
+## Reading the result
+
+Each `(mode, tool)` cell is one of:
+
+| Result | Meaning |
+| ------ | ------- |
+| **PASS** ✅ | The tool ran and returned a sensible result for this transport. |
+| **N/A** ⛔ | The transport does not expose this tool — it is *correctly hidden* (e.g. `mkdir`/`move`/`rename`/`delete` over USB web, or `remarkable_author` outside SSH). This is expected, **not** a failure. |
+| **SKIP** | The tool could not be run (mode unreachable, or no target document to read). |
+| **FAIL** ❌ | The tool is exposed but errored or returned the wrong thing. **This is the only result that means something is broken.** |
+
+`OVERALL: PASS` means no exposed tool misbehaved. A mode you don't have (no cloud
+token, device unplugged, SSH off) is reported as *unavailable* and all of its
+tools are SKIPped, so a single-mode user still gets a clean report.
+
+The harness is **`tools/list`-driven**: it asks each running server which tools it
+actually exposes and only exercises those, so it stays correct as per-transport
+tool visibility changes.
+
+## Per-mode expectations
+
+| Tool | cloud | usb-web | ssh |
+| ---- | :---: | :-----: | :-: |
+| `remarkable_status` / `browse` / `recent` / `search` / `read` / `image` / `canvas` | PASS | PASS | PASS |
+| `remarkable_upload` | PASS | PASS | PASS |
+| `remarkable_mkdir` / `rename` / `move` / `delete` | PASS | **N/A** | PASS |
+| `remarkable_author` | **N/A** | **N/A** | PASS |
+
+USB web is read + render + upload-to-root only — the device firmware HTTP server
+exposes no folder/move/rename/delete endpoints, so those tools are not registered
+in that mode (shown as N/A). `remarkable_author` requires native `.rm` write-back
+and is SSH-only today.
+
+## Caveats
+
+- **USB upload leaves a file at the device root.** The USB web interface ignores
+  the requested name/folder and has no delete endpoint, so a full (non-`--read-only`)
+  USB run leaves one clearly-named `smoke-usb-<ts>-…` document on the tablet. If
+  SSH is also available in the same run it is swept automatically; otherwise delete
+  it from the tablet by hand. Use `--read-only` to avoid it entirely.
+- **SSH requires working key auth.** With `--ssh`/`--usb` the harness disables the
+  cloud startup fallback (`REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) so a dead device
+  can't silently "pass" via cloud. If SSH key auth isn't set up, the SSH mode waits
+  for its connect timeout and is then reported as unavailable.
+- Writes are confined to a unique per-run folder and cleaned up afterwards
+  (cloud/SSH). The only exception is the USB-root upload noted above.
+
+Run artifacts (`smoke/snapshots/*.json`) are written on every run and are
+git-ignored.

--- a/smoke/fixtures/smoke-doc.pdf
+++ b/smoke/fixtures/smoke-doc.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 251 >>
+stream
+BT /F1 14 Tf 72 720 Td (reMarkable MCP Smoke Test) Tj 0 -28 Td /F1 11 Tf
+(This is a deterministic fixture document.) Tj 0 -18 Td
+(Used by smoke/run_smoke.py to exercise upload + read + render.) Tj 0 -18 Td
+(Safe to delete. Page 1 of 1.) Tj 0 -18 Td
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000543 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+613
+%%EOF

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""Deterministic, no-AI multi-transport MCP smoke test for remarkable-mcp.
+
+This is the "first port of call" diagnostic: it drives the *real* MCP server over
+the protocol (stdio, via the official ``mcp`` client SDK -- no AI, no models, no
+mocks) and exercises EVERY available tool in EVERY available transport, in the
+order:
+
+    cloud  ->  usb-web  ->  ssh
+
+Why that order matters: pushing files over SSH can reset the USB web interface,
+so SSH (the only mode that writes to the device filesystem) runs LAST, after the
+USB-web checks are done.
+
+The server HIDES tools a transport cannot support (e.g. mkdir/move/rename/delete
+are not registered over USB web; remarkable_author is SSH-only). The harness is
+therefore ``tools/list``-driven: it asks each running server which tools it
+actually exposes and only exercises those. Any tool in the master list that a
+mode does not expose is reported as N/A for that mode -- which is the *correct*
+behaviour, not a failure.
+
+Each (mode, tool) cell is classified as one of:
+
+    PASS  the tool ran and returned a sensible result for this transport
+    N/A   the transport does not expose this tool (correctly hidden)
+    SKIP  could not run (mode unavailable, or no target document to read)
+    FAIL  the tool is exposed but errored or returned the wrong thing
+
+A mode whose transport is not reachable (no cloud token, device unplugged, SSH
+off) is reported as *unavailable* and all of its tools are SKIPped -- so a user
+who only has one mode still gets a clean report for that mode.
+
+Writes are confined to a unique per-run folder and cleaned up afterwards. Run
+with ``--read-only`` to skip all write tools (pure connectivity/read check).
+
+Usage:
+    uv run python smoke/run_smoke.py                  # all available modes
+    uv run python smoke/run_smoke.py --modes cloud    # one mode
+    uv run python smoke/run_smoke.py --read-only      # no writes
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import pathlib
+import shutil
+import socket
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent
+FIXTURE_PDF = HERE / "fixtures" / "smoke-doc.pdf"
+SNAP_DIR = HERE / "snapshots"
+USB_HOST = "10.11.99.1"
+
+# Result states
+PASS = "PASS"
+FAIL = "FAIL"
+NA = "N/A"
+SKIP = "SKIP"
+
+GLYPH = {PASS: "PASS  \u2705", FAIL: "FAIL  \u274c", NA: "N/A   \u26d4", SKIP: "SKIP  \u26a0\ufe0f"}
+
+# The complete tool surface across all transports, in a stable display order.
+# Not every mode exposes every tool; the harness discovers each mode's real
+# surface via tools/list and marks the rest N/A.
+ALL_TOOLS = [
+    "remarkable_status",
+    "remarkable_browse",
+    "remarkable_recent",
+    "remarkable_search",
+    "remarkable_read",
+    "remarkable_image",
+    "remarkable_canvas",
+    "remarkable_upload",
+    "remarkable_mkdir",
+    "remarkable_rename",
+    "remarkable_move",
+    "remarkable_author",
+    "remarkable_delete",
+]
+
+READ_TOOLS = {
+    "remarkable_browse",
+    "remarkable_recent",
+    "remarkable_search",
+    "remarkable_read",
+    "remarkable_image",
+    "remarkable_canvas",
+}
+WRITE_TOOLS = {
+    "remarkable_upload",
+    "remarkable_mkdir",
+    "remarkable_rename",
+    "remarkable_move",
+    "remarkable_author",
+    "remarkable_delete",
+}
+
+# Per-mode launch spec. Every mode gets REMARKABLE_SKIP_CONFIRM=1 so the delete
+# tool's confirmation (which refuses without MCP elicitation) does not block this
+# non-interactive harness -- this also validates the documented automation escape
+# hatch. usb/ssh disable cloud fallback so a dead device cannot silently pass via
+# cloud.
+MODES = {
+    "cloud": {
+        "transport": "cloud",
+        "args": [],
+        "env": {},
+        "probe_port": None,
+    },
+    "usb": {
+        "transport": "usb-web",
+        "args": ["--usb"],
+        "env": {
+            "REMARKABLE_USE_USB_WEB": "1",
+            "REMARKABLE_DISABLE_CLOUD_FALLBACK": "1",
+        },
+        "probe_port": 80,
+    },
+    "ssh": {
+        "transport": "ssh",
+        "args": ["--ssh"],
+        "env": {
+            "REMARKABLE_USE_SSH": "1",
+            "REMARKABLE_DISABLE_CLOUD_FALLBACK": "1",
+        },
+        "probe_port": 22,
+    },
+}
+
+# Per-call timeouts (seconds). Rendering and the on-device probe can be slow.
+TIMEOUTS = {
+    "remarkable_status": 60,
+    "remarkable_image": 120,
+    "remarkable_canvas": 120,
+    "remarkable_author": 120,
+    "remarkable_upload": 120,
+    "remarkable_delete": 90,
+    "_default": 60,
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _cloud_token_present() -> bool:
+    if os.environ.get("REMARKABLE_TOKEN"):
+        return True
+    return (pathlib.Path.home() / ".rmapi").exists()
+
+
+def _tcp_open(host: str, port: int, timeout: float = 2.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _mode_prescreen(mode: str) -> tuple[bool, str]:
+    """Cheap reachability check before spawning the server (avoids long hangs)."""
+    spec = MODES[mode]
+    if mode == "cloud":
+        if _cloud_token_present():
+            return True, "cloud token present"
+        return False, "no cloud token (REMARKABLE_TOKEN unset and ~/.rmapi missing)"
+    port = spec["probe_port"]
+    if _tcp_open(USB_HOST, port):
+        return True, f"{USB_HOST}:{port} reachable"
+    label = "USB web interface" if mode == "usb" else "SSH"
+    return False, f"{label} not reachable at {USB_HOST}:{port} (device unplugged or disabled)"
+
+
+def _parse_payload(result) -> dict:
+    """Extract the tool's JSON payload from a CallToolResult, if any."""
+    for content in getattr(result, "content", []) or []:
+        text = getattr(content, "text", None)
+        if text:
+            try:
+                return json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                continue
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+    return {}
+
+
+def _error_type(payload: dict) -> str | None:
+    err = payload.get("_error") if isinstance(payload, dict) else None
+    if isinstance(err, dict):
+        return err.get("type")
+    return None
+
+
+class Recorder:
+    """Holds the per-mode/per-tool results plus run metadata."""
+
+    def __init__(self):
+        self.modes: dict[str, dict] = {}
+
+    def mode_unavailable(self, mode: str, reason: str):
+        self.modes[mode] = {"available": False, "reason": reason, "tools": {}}
+        for tool in ALL_TOOLS:
+            self.modes[mode]["tools"][tool] = {"state": SKIP, "note": "mode unavailable"}
+
+    def ensure_mode(self, mode: str, transport: str, doc_count, reason: str):
+        self.modes[mode] = {
+            "available": True,
+            "transport": transport,
+            "document_count": doc_count,
+            "reason": reason,
+            "tools": {},
+        }
+
+    def record(self, mode: str, tool: str, state: str, note: str = "", detail=None):
+        entry = {"state": state, "note": note}
+        if detail is not None:
+            entry["detail"] = detail
+        self.modes[mode]["tools"][tool] = entry
+
+
+async def call_tool(session, tool, args, timeout):
+    """Call a tool, returning (payload, is_error, exception)."""
+    try:
+        result = await asyncio.wait_for(session.call_tool(tool, args), timeout)
+    except asyncio.TimeoutError:
+        return {}, True, f"timed out after {timeout}s"
+    except Exception as exc:  # noqa: BLE001 - report any client/transport error
+        return {}, True, f"{type(exc).__name__}: {exc}"
+    payload = _parse_payload(result)
+    return payload, bool(getattr(result, "isError", False)), None
+
+
+def classify_ok(payload, is_error, exc, ok_error_types=()):
+    """Classify a tool that is EXPECTED to work in this transport.
+
+    ``ok_error_types`` lists error types that still count as PASS (e.g. a search
+    with no matching documents legitimately returns ``no_documents_found``).
+    Returns (state, note).
+    """
+    err_type = _error_type(payload)
+    if exc:
+        return FAIL, exc
+    if err_type:
+        if err_type in ok_error_types:
+            return PASS, f"benign error: {err_type}"
+        return FAIL, f"error: {err_type}"
+    if is_error:
+        return FAIL, "tool reported isError"
+    return PASS, ""
+
+
+def _detail_for(tool, payload):
+    """A compact, human-useful snippet for the snapshot/report."""
+    if not isinstance(payload, dict):
+        return None
+    if tool == "remarkable_status":
+        keys = ("transport", "status", "document_count", "write_enabled", "fell_back_to_cloud")
+        return {k: payload.get(k) for k in keys if k in payload}
+    if tool in ("remarkable_browse", "remarkable_recent", "remarkable_search"):
+        return {"count": payload.get("count")}
+    err = _error_type(payload)
+    if err:
+        return {"error_type": err}
+    return None
+
+
+async def run_read_phase(session, mode, rec, registered):
+    """browse, recent, search, read, image, canvas -- expected OK where exposed."""
+    # browse
+    if "remarkable_browse" in registered:
+        payload, is_err, exc = await call_tool(
+            session, "remarkable_browse", {"path": "/"}, TIMEOUTS["_default"]
+        )
+        state, note = classify_ok(payload, is_err, exc)
+        rec.record(
+            mode, "remarkable_browse", state, note, _detail_for("remarkable_browse", payload)
+        )
+
+    # recent -- also used to pick a read/render target
+    target = None
+    if "remarkable_recent" in registered:
+        payload, is_err, exc = await call_tool(
+            session, "remarkable_recent", {"limit": 5}, TIMEOUTS["_default"]
+        )
+        state, note = classify_ok(payload, is_err, exc)
+        rec.record(
+            mode, "remarkable_recent", state, note, _detail_for("remarkable_recent", payload)
+        )
+        docs = payload.get("documents") if isinstance(payload, dict) else None
+        if docs:
+            target = docs[0].get("path") or docs[0].get("name")
+
+    # search -- use a unique no-match query so we validate the tool cheaply
+    # (a match would trigger up to 5 full document downloads). Both a real match
+    # and a clean "no documents found" prove the search path works.
+    if "remarkable_search" in registered:
+        query = f"zzzsmoke-no-match-{int(time.time())}"
+        payload, is_err, exc = await call_tool(
+            session, "remarkable_search", {"query": query}, TIMEOUTS["_default"]
+        )
+        state, note = classify_ok(payload, is_err, exc, ok_error_types=("no_documents_found",))
+        rec.record(
+            mode, "remarkable_search", state, note, _detail_for("remarkable_search", payload)
+        )
+
+    # read / image / canvas need a target document
+    for tool, call_args in (
+        ("remarkable_read", {"content_type": "text", "page": 1}),
+        ("remarkable_image", {"page": 1}),
+        ("remarkable_canvas", {"page": 1}),
+    ):
+        if tool not in registered:
+            continue
+        if not target:
+            rec.record(mode, tool, SKIP, "no document available to read in this mode")
+            continue
+        a = {"document": target, **call_args}
+        payload, is_err, exc = await call_tool(
+            session, tool, a, TIMEOUTS.get(tool, TIMEOUTS["_default"])
+        )
+        state, note = classify_ok(payload, is_err, exc)
+        if not note and target:
+            note = f"target: {target}"
+        rec.record(mode, tool, state, note, _detail_for(tool, payload))
+
+
+async def run_write_phase(session, mode, rec, registered):
+    """upload, mkdir, rename, move, author, delete -- only the exposed ones.
+
+    All created items are confined to a unique per-run folder and cleaned up.
+    Tools that are not exposed in this transport were already recorded N/A.
+    """
+    is_ssh = MODES[mode]["transport"] == "ssh"
+    managed = "remarkable_mkdir" in registered  # folder ops exposed -> cloud/ssh
+    runid = f"smoke-{mode}-{int(time.time())}"
+    folder_path = f"/{runid}"
+
+    created = []  # (kind, path) to clean up at the end, children before parents
+
+    # Unique per-run upload payload so the USB-web upload (which lands at root and
+    # ignores document_name) is identifiable for later SSH cleanup.
+    tmp_pdf = pathlib.Path(tempfile.gettempdir()) / f"{runid}-doc.pdf"
+    shutil.copyfile(FIXTURE_PDF, tmp_pdf)
+
+    try:
+        # --- mkdir -------------------------------------------------------
+        upload_parent = "/"
+        if "remarkable_mkdir" in registered:
+            payload, is_err, exc = await call_tool(
+                session,
+                "remarkable_mkdir",
+                {"folder_name": runid, "parent": "/"},
+                TIMEOUTS["_default"],
+            )
+            state, note = classify_ok(payload, is_err, exc)
+            rec.record(mode, "remarkable_mkdir", state, note)
+            if state == PASS:
+                created.append(("folder", folder_path))
+                upload_parent = folder_path
+
+        # --- upload ------------------------------------------------------
+        if "remarkable_upload" in registered:
+            up_args = {"file_path": str(tmp_pdf)}
+            if managed:
+                up_args["parent_folder"] = upload_parent
+                up_args["document_name"] = f"{runid}-doc"
+            payload, is_err, exc = await call_tool(
+                session, "remarkable_upload", up_args, TIMEOUTS["remarkable_upload"]
+            )
+            state, note = classify_ok(payload, is_err, exc)
+            if state == PASS and not managed:
+                note = (
+                    "uploaded to device root (USB web ignores name/folder); "
+                    "swept in the SSH phase if SSH is available this run"
+                )
+            rec.record(
+                mode, "remarkable_upload", state, note, _detail_for("remarkable_upload", payload)
+            )
+            if state == PASS:
+                if managed:
+                    created.append(("doc", f"{upload_parent.rstrip('/')}/{runid}-doc"))
+                else:
+                    rec.modes[mode].setdefault("usb_root_leftover", f"/{runid}-doc")
+
+        # --- rename ------------------------------------------------------
+        renamed_path = None
+        if "remarkable_rename" in registered:
+            doc_entry = next((p for k, p in created if k == "doc"), None)
+            if doc_entry:
+                new_name = f"{runid}-renamed"
+                payload, is_err, exc = await call_tool(
+                    session,
+                    "remarkable_rename",
+                    {"document": doc_entry, "new_name": new_name},
+                    TIMEOUTS["_default"],
+                )
+                state, note = classify_ok(payload, is_err, exc)
+                rec.record(mode, "remarkable_rename", state, note)
+                if state == PASS:
+                    renamed_path = f"{upload_parent.rstrip('/')}/{new_name}"
+                    created = [(k, renamed_path if k == "doc" else p) for k, p in created]
+            else:
+                rec.record(mode, "remarkable_rename", SKIP, "no uploaded document to rename")
+
+        # --- move --------------------------------------------------------
+        if "remarkable_move" in registered:
+            if renamed_path:
+                payload, is_err, exc = await call_tool(
+                    session,
+                    "remarkable_move",
+                    {"document": renamed_path, "dest_folder": "/"},
+                    TIMEOUTS["_default"],
+                )
+                state, note = classify_ok(payload, is_err, exc)
+                rec.record(mode, "remarkable_move", state, note)
+                if state == PASS:
+                    moved_path = f"/{runid}-renamed"
+                    created = [(k, moved_path if k == "doc" else p) for k, p in created]
+            else:
+                rec.record(mode, "remarkable_move", SKIP, "no document to move")
+
+        # --- author (SSH only) ------------------------------------------
+        if "remarkable_author" in registered:
+            nb_name = f"{runid}-nb"
+            payload, is_err, exc = await call_tool(
+                session,
+                "remarkable_author",
+                {"method": "create_document", "name": nb_name, "folder": folder_path},
+                TIMEOUTS["remarkable_author"],
+            )
+            state, note = classify_ok(payload, is_err, exc)
+            nb_path = f"{folder_path}/{nb_name}"
+            if state == PASS:
+                created.insert(0, ("doc", nb_path))  # delete before its folder
+                ap_payload, ap_err, ap_exc = await call_tool(
+                    session,
+                    "remarkable_author",
+                    {"method": "add_page", "document": nb_path},
+                    TIMEOUTS["remarkable_author"],
+                )
+                ap_state, _ = classify_ok(ap_payload, ap_err, ap_exc)
+                dr_payload, dr_err, dr_exc = await call_tool(
+                    session,
+                    "remarkable_author",
+                    {
+                        "method": "draw",
+                        "document": nb_path,
+                        "page": 1,
+                        "strokes": [
+                            {
+                                "points": [[0.1, 0.5], [0.9, 0.5]],
+                                "tool": "fineliner",
+                                "color": "black",
+                            }
+                        ],
+                    },
+                    TIMEOUTS["remarkable_author"],
+                )
+                dr_state, _ = classify_ok(dr_payload, dr_err, dr_exc)
+                sub = f"create_document=PASS; add_page={ap_state}; draw={dr_state}"
+                final = PASS if (ap_state == PASS and dr_state == PASS) else FAIL
+                rec.record(mode, "remarkable_author", final, sub)
+            else:
+                rec.record(mode, "remarkable_author", state, note)
+
+        # --- delete (cleanup) -------------------------------------------
+        if "remarkable_delete" in registered:
+            # Also sweep any USB-web leftover from an earlier usb phase this run.
+            if is_ssh:
+                for data in rec.modes.values():
+                    leftover = data.get("usb_root_leftover")
+                    if leftover:
+                        created.append(("doc", leftover))
+                        data.pop("usb_root_leftover", None)
+
+            delete_states = []
+            for _kind, path in created:
+                payload, is_err, exc = await call_tool(
+                    session, "remarkable_delete", {"document": path}, TIMEOUTS["remarkable_delete"]
+                )
+                st, _ = classify_ok(payload, is_err, exc)
+                delete_states.append((path, st))
+            if not delete_states:
+                rec.record(mode, "remarkable_delete", SKIP, "nothing was created to delete")
+            else:
+                failed = [p for p, s in delete_states if s != PASS]
+                if failed:
+                    rec.record(mode, "remarkable_delete", FAIL, f"could not delete: {failed}")
+                else:
+                    rec.record(
+                        mode, "remarkable_delete", PASS, f"deleted {len(delete_states)} item(s)"
+                    )
+    finally:
+        tmp_pdf.unlink(missing_ok=True)
+
+
+def _mark_hidden_tools_na(mode, rec, registered):
+    """Any master-list tool not exposed by this mode is correctly hidden -> N/A."""
+    for tool in ALL_TOOLS:
+        if tool == "remarkable_status":
+            continue  # status is recorded explicitly once it succeeds
+        if tool not in registered:
+            rec.record(mode, tool, NA, "not exposed in this transport (correctly hidden)")
+
+
+async def run_mode(mode: str, rec: Recorder, read_only: bool):
+    ok, reason = _mode_prescreen(mode)
+    if not ok:
+        rec.mode_unavailable(mode, reason)
+        return
+
+    spec = MODES[mode]
+    env = {**os.environ, "REMARKABLE_SKIP_CONFIRM": "1", **spec["env"]}
+    params = StdioServerParameters(
+        command="uv",
+        args=["run", "python", "server.py", *spec["args"]],
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+
+    try:
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await asyncio.wait_for(session.initialize(), 60)
+
+                # status decides availability for real (handles fallback / auth).
+                payload, is_err, exc = await call_tool(
+                    session, "remarkable_status", {}, TIMEOUTS["remarkable_status"]
+                )
+                authed = isinstance(payload, dict) and payload.get("authenticated") is True
+                transport = payload.get("transport") if isinstance(payload, dict) else None
+                fell_back = (
+                    bool(payload.get("fell_back_to_cloud")) if isinstance(payload, dict) else False
+                )
+                want_transport = spec["transport"]
+
+                if exc or not authed or transport != want_transport or fell_back:
+                    detail = exc or (
+                        f"authenticated={authed} transport={transport} "
+                        f"expected={want_transport} fell_back={fell_back}"
+                    )
+                    rec.mode_unavailable(mode, f"status check failed: {detail}")
+                    return
+
+                rec.ensure_mode(mode, transport, payload.get("document_count"), "connected")
+                rec.record(
+                    mode, "remarkable_status", PASS, "", _detail_for("remarkable_status", payload)
+                )
+
+                # tools/list is the source of truth for what this mode supports.
+                tools_result = await asyncio.wait_for(session.list_tools(), 30)
+                registered = {t.name for t in tools_result.tools}
+                rec.modes[mode]["registered_tools"] = sorted(registered)
+                _mark_hidden_tools_na(mode, rec, registered)
+
+                await run_read_phase(session, mode, rec, registered)
+                if read_only:
+                    for tool in WRITE_TOOLS:
+                        if tool in registered:
+                            rec.record(mode, tool, SKIP, "write phase skipped (--read-only)")
+                else:
+                    await run_write_phase(session, mode, rec, registered)
+    except Exception as exc:  # noqa: BLE001
+        rec.mode_unavailable(mode, f"server launch/session error: {type(exc).__name__}: {exc}")
+
+
+def print_report(rec: Recorder, modes: list[str], started: str) -> bool:
+    """Print a human-readable report. Returns True if any FAIL occurred."""
+    any_fail = False
+    line = "=" * 72
+    print(f"\n{line}\nreMarkable MCP -- multi-transport smoke test\nstarted: {started}\n{line}")
+
+    for mode in modes:
+        data = rec.modes.get(mode, {})
+        print(f"\n### MODE: {mode}")
+        if not data.get("available"):
+            print(f"  UNAVAILABLE -- {data.get('reason', 'unknown')}  (all tools SKIPped)")
+            continue
+        print(
+            f"  available -- transport={data.get('transport')} "
+            f"documents={data.get('document_count')}"
+        )
+        for tool in ALL_TOOLS:
+            entry = data["tools"].get(tool, {"state": SKIP, "note": "not run"})
+            st = entry["state"]
+            if st == FAIL:
+                any_fail = True
+            note = entry.get("note", "")
+            print(f"    {GLYPH.get(st, st):10} {tool:22} {note}")
+
+    # Matrix summary
+    print(f"\n{line}\nSUMMARY MATRIX (rows=tools, cols=modes)\n{line}")
+    header = "  {:22}".format("tool") + "".join(f"{m:>10}" for m in modes)
+    print(header)
+    short = {PASS: "PASS", FAIL: "FAIL", NA: "N/A", SKIP: "SKIP"}
+    for tool in ALL_TOOLS:
+        row = "  {:22}".format(tool)
+        for mode in modes:
+            data = rec.modes.get(mode, {})
+            st = data.get("tools", {}).get(tool, {}).get("state", SKIP)
+            row += f"{short.get(st, st):>10}"
+        print(row)
+
+    print(line)
+    verdict = "FAIL \u274c" if any_fail else "PASS \u2705"
+    print(f"OVERALL: {verdict}  (FAIL = a tool misbehaved; N/A and SKIP are not failures)")
+    print(line)
+    return any_fail
+
+
+async def main_async(args) -> int:
+    rec = Recorder()
+    started = _now()
+    modes = args.modes
+    for mode in modes:  # strict order: cloud -> usb -> ssh
+        await run_mode(mode, rec, args.read_only)
+
+    any_fail = print_report(rec, modes, started)
+
+    SNAP_DIR.mkdir(exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    snap = SNAP_DIR / f"smoke-{stamp}.json"
+    snap.write_text(
+        json.dumps(
+            {
+                "started": started,
+                "finished": _now(),
+                "read_only": args.read_only,
+                "modes": modes,
+                "results": rec.modes,
+            },
+            indent=2,
+        )
+    )
+    print(f"\nFull snapshot: {snap.relative_to(REPO_ROOT)}")
+    return 1 if any_fail else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--modes",
+        default="cloud,usb,ssh",
+        help="Comma-separated subset of modes in run order (default: cloud,usb,ssh)",
+    )
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Skip all write tools (upload/mkdir/rename/move/author/delete)",
+    )
+    args = parser.parse_args()
+
+    order = ["cloud", "usb", "ssh"]
+    requested = [m.strip() for m in args.modes.split(",") if m.strip()]
+    unknown = [m for m in requested if m not in MODES]
+    if unknown:
+        parser.error(f"unknown mode(s): {unknown}. Choose from {list(MODES)}")
+    # Always honour cloud -> usb -> ssh ordering regardless of input order.
+    args.modes = [m for m in order if m in requested]
+
+    if not FIXTURE_PDF.exists():
+        print(f"ERROR: fixture missing: {FIXTURE_PDF}", file=sys.stderr)
+        return 2
+
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_server.py
+++ b/test_server.py
@@ -110,9 +110,13 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Six read tools + always-on canvas + six write tools (write-on by default)."""
+        """Cloud default: 6 read tools + always-on canvas + 5 write tools.
+
+        ``remarkable_author`` is SSH-only and therefore hidden in cloud mode, so
+        the default (cloud) surface is 12 tools, not 13.
+        """
         tools = await mcp.list_tools()
-        assert len(tools) == 13, f"Expected 13 tools, got {len(tools)}"
+        assert len(tools) == 12, f"Expected 12 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -1026,6 +1030,7 @@ class TestRenderTabletPdfFallback:
         mock_download_raw.assert_called_once()
 
     @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.render_page_full_page_from_document_zip")
     @patch("remarkable_mcp.tools.download_raw_file")
     @patch("remarkable_mcp.tools.render_page_from_document_zip")
     @patch("remarkable_mcp.tools.get_document_page_count")
@@ -1036,9 +1041,10 @@ class TestRenderTabletPdfFallback:
         mock_page_count,
         mock_render,
         mock_download_raw,
+        mock_full,
         mock_document,
     ):
-        """With no local render and no tablet PDF (e.g. cloud), report render_failed."""
+        """With no local render, no tablet PDF, and no blank-page render, report render_failed."""
         mock_client = Mock()
         mock_get_rmapi.return_value = mock_client
         mock_document.is_folder = False
@@ -1047,6 +1053,7 @@ class TestRenderTabletPdfFallback:
         mock_page_count.return_value = 1
         mock_render.return_value = None
         mock_download_raw.return_value = None  # cloud: no native export
+        mock_full.return_value = None  # full-page blank render also unavailable
 
         with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
             mock_tmp = Mock()
@@ -1066,6 +1073,55 @@ class TestRenderTabletPdfFallback:
         suggestion = data["_error"]["suggestion"].lower()
         assert "v5" not in suggestion
         assert "cairo" in suggestion or "native pdf" in suggestion
+
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.render_page_full_page_from_document_zip")
+    @patch("remarkable_mcp.tools.download_raw_file")
+    @patch("remarkable_mcp.tools.render_page_from_document_zip")
+    @patch("remarkable_mcp.tools.get_document_page_count")
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_image_falls_back_to_blank_full_page(
+        self,
+        mock_get_rmapi,
+        mock_page_count,
+        mock_render,
+        mock_download_raw,
+        mock_full,
+        mock_document,
+    ):
+        """A strokeless notebook page renders as a blank page (matches the canvas).
+
+        When the stroke renderer returns None and there is no PDF underlay (a
+        notebook), remarkable_image falls back to the full-page renderer used by
+        remarkable_canvas so a blank/freshly-created page yields a blank image
+        instead of render_failed.
+        """
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = b"fake zip"
+        mock_page_count.return_value = 1
+        mock_render.return_value = None  # no strokes -> stroke renderer None
+        mock_download_raw.return_value = None  # notebook -> no PDF underlay
+        mock_full.return_value = (b"\x89PNG-blank-page", (1404.0, 1872.0))
+
+        with patch("tempfile.NamedTemporaryFile") as mock_tmpfile:
+            mock_tmp = Mock()
+            mock_tmp.__enter__ = Mock(return_value=mock_tmp)
+            mock_tmp.__exit__ = Mock(return_value=False)
+            mock_tmp.name = "/tmp/test.zip"
+            mock_tmpfile.return_value = mock_tmp
+            with patch("pathlib.Path.unlink"):
+                result = await mcp.call_tool(
+                    "remarkable_image",
+                    {"document": "Test Document", "page": 1, "compatibility": True},
+                )
+
+        data = json.loads(result[0].text)
+        assert "_error" not in data
+        assert data.get("image_base64")
+        mock_full.assert_called_once()
 
 
 # =============================================================================
@@ -1133,7 +1189,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 13
+        assert len(tools) == 12
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:
@@ -2583,12 +2639,16 @@ class TestWriteTools:
 
     @pytest.mark.asyncio
     async def test_write_tools_registered_by_default(self):
-        """Write tools ARE registered by default (write-on); read-only would skip them."""
+        """Write tools ARE registered by default (write-on); read-only would skip them.
+
+        ``remarkable_author`` is intentionally excluded here: it is SSH-only and
+        therefore hidden in cloud mode (the mode these tests import). See
+        ``test_author_only_registered_in_ssh_mode`` for its gating.
+        """
         tools = await mcp.list_tools()
         tool_names = [tool.name for tool in tools]
 
         write_tool_names = [
-            "remarkable_author",
             "remarkable_upload",
             "remarkable_mkdir",
             "remarkable_move",
@@ -2600,6 +2660,9 @@ class TestWriteTools:
             assert tool_name in tool_names, (
                 f"Write tool {tool_name} should be registered by default"
             )
+        assert "remarkable_author" not in tool_names, (
+            "remarkable_author is SSH-only and must be hidden in cloud mode"
+        )
 
     @pytest.mark.asyncio
     async def test_write_tools_registered_when_enabled(self):
@@ -2850,6 +2913,55 @@ class TestWriteTools:
                     "remarkable_delete",
                 ]:
                     mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_author_only_registered_in_ssh_mode(self):
+        """remarkable_author is SSH-only: present in SSH, hidden in cloud and USB web.
+
+        Native ink/notebook authoring has no cloud/USB-web write-back path yet, so
+        rather than registering the tool everywhere and erroring at call time we
+        only expose it in SSH mode.
+        """
+        from remarkable_mcp.write_tools import register_write_tools
+
+        # SSH mode -> author present.
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+            try:
+                names = {t.name for t in await mcp.list_tools()}
+                assert "remarkable_author" in names
+            finally:
+                mcp._tool_manager._tools.pop("remarkable_author", None)
+
+        # Cloud mode -> author hidden.
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env.pop("REMARKABLE_USE_USB_WEB", None)
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
+            try:
+                names = {t.name for t in await mcp.list_tools()}
+                assert "remarkable_author" not in names
+            finally:
+                for name in [
+                    "remarkable_author",
+                    "remarkable_upload",
+                    "remarkable_mkdir",
+                    "remarkable_move",
+                    "remarkable_rename",
+                    "remarkable_delete",
+                ]:
+                    mcp._tool_manager._tools.pop(name, None)
+
+        # USB web mode -> author hidden.
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env["REMARKABLE_USE_USB_WEB"] = "1"
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
+            try:
+                names = {t.name for t in await mcp.list_tools()}
+                assert "remarkable_author" not in names
+            finally:
+                mcp._tool_manager._tools.pop("remarkable_author", None)
 
 
 class TestCloudWriteDispatch:
@@ -4007,6 +4119,22 @@ class TestCLIFlags:
 class TestCanvasWrite:
     """Test the remarkable_author tool (method="draw" stroke write-back, SSH-first)."""
 
+    @pytest.fixture(autouse=True)
+    def _register_author(self):
+        """Expose remarkable_author for these tests.
+
+        The tool is SSH-only and therefore hidden in the default (cloud) import
+        mode, so register it explicitly under SSH, then remove it afterward to
+        restore the default surface. Individual tests still patch
+        REMARKABLE_USE_SSH at call time so the impl runs in SSH mode.
+        """
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+        yield
+        mcp._tool_manager._tools.pop("remarkable_author", None)
+
     def _mock_doc(self):
         doc = Mock()
         doc.VissibleName = "Sketchbook"
@@ -4015,27 +4143,6 @@ class TestCanvasWrite:
         doc.is_folder = False
         doc.is_cloud_archived = False
         return doc
-
-    @pytest.mark.asyncio
-    async def test_requires_ssh_transport(self):
-        """In cloud/USB mode the tool returns an educational unsupported_transport error."""
-        # Neither SSH nor USB env set -> cloud; draw needs SSH.
-        old = os.environ.pop("REMARKABLE_USE_SSH", None)
-        try:
-            result = await mcp.call_tool(
-                "remarkable_author",
-                {
-                    "method": "draw",
-                    "document": "Sketchbook",
-                    "page": 1,
-                    "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "fineliner"}],
-                },
-            )
-            data = json.loads(result[0][0].text)
-            assert data["_error"]["type"] == "unsupported_transport"
-        finally:
-            if old is not None:
-                os.environ["REMARKABLE_USE_SSH"] = old
 
     @pytest.mark.asyncio
     async def test_empty_strokes_rejected(self):


### PR DESCRIPTION
## What & why

Make per-transport behaviour honest: **hide tools a transport can't support** instead of registering them everywhere and erroring at call time. Clients now only see tools they can actually use.

### Tool visibility
- **`remarkable_author` is now SSH-only.** Native `.rm` write-back has no cloud or USB-web path yet, so the tool is registered *only* in SSH mode rather than erroring with `unsupported_transport` in cloud/USB.
- Per-transport surface is now: **cloud = 12, usb-web = 8, ssh = 13**.

### Bug fixes
- **Circular import in `write_tools.py`** (real bug): `from remarkable_mcp.server import mcp` ran at module load while `server.py` was importing `write_tools`, re-entering a partially-initialized module. The import is now lazy inside `register_write_tools()` (mirrors the module's other lazy imports). `import remarkable_mcp.write_tools` standalone now succeeds.
- **Cloud blank-page render** (`remarkable_image`): a strokeless notebook page (blank/freshly-created) returned `render_failed`, while `remarkable_canvas` rendered it fine. `remarkable_image` now falls back to the same full-page renderer the canvas uses, so blank pages yield a blank image and the two tools stay consistent.

### New: multi-transport smoke test
`smoke/run_smoke.py` — a deterministic, **no-AI** diagnostic and the "first port of call for a support request". It drives the real MCP server over the protocol (stdio, official `mcp` client SDK) and exercises **every available tool in every reachable transport** (`cloud → usb-web → ssh`). It is `tools/list`-driven, so tools a mode hides are reported **N/A** (not failures), and a mode the machine can't reach is reported **unavailable** with its tools SKIPped — so a single-mode user still gets a clean report. Documented in `smoke/README.md` and linked from the main README; run artifacts are git-ignored.

## Validation
Live-validated on this machine over the real MCP protocol:
- **cloud**: all read + write tools **PASS** (upload/mkdir/rename/move/delete; delete self-cleaned), `remarkable_author` correctly **N/A**, blank probe page now renders. ✅
- **usb-web**: all read tools + upload **PASS**, folder ops + author correctly **N/A**. ✅
- **ssh**: environment auth not configured here → reported unavailable cleanly (SSH code is unit-tested + was device-validated in #115).

Gate: `uv run ruff check .` clean, `uv run ruff format --check .` clean, **202 tests pass**.

## Notes
- Conformance validates the *structure* of registered tools in cloud mode (not a count), so hiding `author` in cloud doesn't break it.
- Cloud-mode authoring is feasible and tracked as a follow-up issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>