### PR TITLE
test(smoke): verify upload end-to-end with a read-back round-trip

### DIFF
--- a/smoke/README.md
+++ b/smoke/README.md
@@ -60,6 +60,22 @@ exposes no folder/move/rename/delete endpoints, so those tools are not registere
 in that mode (shown as N/A). `remarkable_author` requires native `.rm` write-back
 and is SSH-only today.
 
+### Upload is verified end-to-end (cloud/ssh)
+
+In **managed** modes (cloud and ssh) the upload check is a true round-trip: the
+harness uploads the fixture PDF, then reads it straight back and asserts a known
+marker string from the fixture's text layer survived. So an upload **PASS** means
+the bytes are actually retrievable — not merely that the upload call returned
+without error. If the upload call succeeds but the document can't be read back (or
+its content is wrong), the upload row is marked **FAIL** with that reason. This is
+safe and non-flaky: the cloud client invalidates its in-memory document cache on
+every root commit and blobs are content-addressed (immutable), so there is no
+eventual-consistency window to wait on within a session.
+
+USB-web uploads land at the device root with the requested name ignored, so they
+can't be reliably re-targeted for read-back and are **not** round-tripped (the
+upload row still PASSes on a successful upload call).
+
 ## Caveats
 
 - **USB upload leaves a file at the device root.** The USB web interface ignores

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -59,6 +59,11 @@ from mcp.client.stdio import stdio_client
 HERE = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent
 FIXTURE_PDF = HERE / "fixtures" / "smoke-doc.pdf"
+# A known string embedded in the fixture PDF's text layer. The upload round-trip
+# reads the freshly-uploaded document back and asserts this marker survived, so a
+# "PASS" on upload means the bytes are actually retrievable -- not just that the
+# upload call returned without error.
+FIXTURE_MARKER = "reMarkable MCP Smoke Test"
 SNAP_DIR = HERE / "snapshots"
 USB_HOST = "10.11.99.1"
 
@@ -277,6 +282,31 @@ def _detail_for(tool, payload):
     return None
 
 
+async def verify_upload_roundtrip(session, doc_path):
+    """Read a just-uploaded fixture back and confirm its known text survived.
+
+    Returns ``(ok, note)``. This makes the upload check end-to-end: the cloud
+    client invalidates its in-memory document cache on every root commit and
+    blobs are content-addressed (immutable), so a managed upload is readable in
+    the same session with no eventual-consistency window to wait on.
+    """
+    payload, is_err, exc = await call_tool(
+        session,
+        "remarkable_read",
+        {"document": doc_path, "content_type": "raw", "page": 1},
+        TIMEOUTS["_default"],
+    )
+    if exc:
+        return False, f"read-back errored: {exc}"
+    err_type = _error_type(payload)
+    if err_type:
+        return False, f"read-back error: {err_type}"
+    content = payload.get("content", "") if isinstance(payload, dict) else ""
+    if FIXTURE_MARKER in content:
+        return True, "round-trip OK (read-back content matched)"
+    return False, "read-back found the doc but its known text was missing/garbled"
+
+
 async def run_read_phase(session, mode, rec, registered):
     """browse, recent, search, read, image, canvas -- expected OK where exposed."""
     # browse
@@ -342,6 +372,11 @@ async def run_write_phase(session, mode, rec, registered):
 
     All created items are confined to a unique per-run folder and cleaned up.
     Tools that are not exposed in this transport were already recorded N/A.
+
+    In managed modes (cloud/ssh) the upload is verified end-to-end: the fixture
+    is read back and its known text confirmed, so upload PASS means the bytes are
+    actually retrievable. USB-web uploads land at the device root with the name
+    ignored, so they can't be reliably re-targeted and are not round-tripped.
     """
     is_ssh = MODES[mode]["transport"] == "ssh"
     managed = "remarkable_mkdir" in registered  # folder ops exposed -> cloud/ssh
@@ -381,19 +416,34 @@ async def run_write_phase(session, mode, rec, registered):
                 session, "remarkable_upload", up_args, TIMEOUTS["remarkable_upload"]
             )
             state, note = classify_ok(payload, is_err, exc)
+            uploaded_path = f"{upload_parent.rstrip('/')}/{runid}-doc"
             if state == PASS and not managed:
                 note = (
                     "uploaded to device root (USB web ignores name/folder); "
                     "swept in the SSH phase if SSH is available this run"
                 )
+            elif state == PASS and managed:
+                # End-to-end check: read the just-uploaded fixture back and
+                # confirm its known text survived. A successful-but-unreadable
+                # upload is a real failure worth surfacing on this row.
+                ok, rt_note = await verify_upload_roundtrip(session, uploaded_path)
+                if ok:
+                    note = f"uploaded to {uploaded_path}; {rt_note}"
+                else:
+                    state = FAIL
+                    note = f"upload call returned OK but {rt_note}"
             rec.record(
                 mode, "remarkable_upload", state, note, _detail_for("remarkable_upload", payload)
             )
             if state == PASS:
                 if managed:
-                    created.append(("doc", f"{upload_parent.rstrip('/')}/{runid}-doc"))
+                    created.append(("doc", uploaded_path))
                 else:
                     rec.modes[mode].setdefault("usb_root_leftover", f"/{runid}-doc")
+            elif managed and is_err is False and exc is None:
+                # Upload itself succeeded (only the read-back failed), so the doc
+                # still exists and must be cleaned up despite the FAIL verdict.
+                created.append(("doc", uploaded_path))
 
         # --- rename ------------------------------------------------------
         renamed_path = None


### PR DESCRIPTION
## What & why

Follow-up to #117. The smoke harness checked **"can upload a fixture"** and **"can read documents"** *independently* — the read phase reads the most-recent *existing* document, never the one it just uploaded. So a successful-but-unreadable upload would still report **PASS**.

This closes that gap with a true round-trip in **managed modes (cloud/ssh)**:
1. Upload the fixture PDF to a known path.
2. Read it straight back (`content_type="raw"`).
3. Assert a known marker string from the fixture's text layer (`"reMarkable MCP Smoke Test"`) survived.

Upload **PASS** now means the bytes are actually retrievable. If the upload call returns OK but the doc can't be read back (or its content is wrong), the upload row is **FAIL** with that reason. The just-uploaded doc is cleaned up either way.

## Why it's safe / non-flaky (cache-aware)

No eventual-consistency window to engineer around: the cloud client invalidates its in-memory document cache on every root commit (`_sync_root` → `_invalidate_caches`) and blobs are **content-addressed (immutable)**, so the freshly-uploaded doc is readable in the same session immediately. No new cache-invalidation logic was added.

**USB-web** uploads land at the device root with the requested name ignored and can't be reliably re-targeted, so they are intentionally **not** round-tripped (that row still PASSes on a successful upload call).

## Validation

Live against real cloud:
```
PASS ✅ remarkable_upload  uploaded to /smoke-cloud-…/…-doc; round-trip OK (read-back content matched)
PASS ✅ remarkable_rename / move / delete   (deleted 2 item(s) — self-cleaned)
OVERALL: PASS ✅
```
Harness is ruff-clean; product test suite unchanged (**202 pass**). Harness-only change — no product code touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>