### PR TITLE
Add tags and status label helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,12 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_read` | Read and extract text from documents (with pagination and search) |
 | `remarkable_browse` | Navigate folders, search by document name, or filter by tags |
 | `remarkable_search` | Search content across multiple documents (with tag filtering) |
+| `remarkable_review` | Export deterministic review bundles as JSON, Markdown, or text |
 | `remarkable_recent` | Get recently modified documents |
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, and `remarkable_author` for native ink/notebooks) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
+These seven tools are **read-only** and return structured JSON or deterministic text exports with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, and `remarkable_author` for native ink/notebooks) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -252,6 +253,7 @@ These six tools are **read-only** and return structured JSON with hints for next
 - **Auto-redirect** — Browsing a document path returns its content automatically
 - **Auto-OCR** — Notebooks with no typed text automatically enable OCR
 - **Batch search** — Search across multiple documents in one call
+- **Review/export** — Export one document or a folder as deterministic JSON/Markdown/text
 - **Vision support** — Get page images for visual context (diagrams, mockups, sketches)
 - **Sampling OCR** — Use client's AI for OCR on images (no API key needed)
 - **Tag support** — Filter and organize documents by tags
@@ -280,6 +282,10 @@ remarkable_search("meeting", grep="action items")
 
 # Search with tag filter
 remarkable_search("project", tags=["work"])
+
+# Export review-ready content without summarization
+remarkable_review(document="/Daily/Daily Notes", output_format="markdown")
+remarkable_review(folder="/Daily", tags=["review"], output_format="json")
 
 # Get recent documents
 remarkable_recent(limit=10)

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Write tools let you upload, organize, and manage documents on your reMarkable. *
 | Move | ✅ | ✅ | ❌ |
 | Rename | ✅ | ✅ | ❌ |
 | Delete | ✅ (→ trash) | ✅ | ❌ |
+| Tags/status labels | ✅ | ✅ | ❌ |
 | Create native notebook | ✅ (`create_document`, `daily_notebook`) | ✅ | ❌ |
 | Native add page / draw | ❌ | ✅ | ❌ |
 
@@ -491,6 +492,7 @@ Or set the environment variable:
 | `remarkable_move(document, dest_folder)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name)` | Rename a document or folder (cloud and SSH) |
 | `remarkable_delete(document)` | Delete a document or folder — destructive (cloud and SSH) |
+| `remarkable_tags(document, tags, add_tags, remove_tags, status)` | Set official metadata tags/status labels (cloud and SSH) |
 | `remarkable_author(method, ...)` | Author native notebooks/ink — cloud supports `create_document` and `daily_notebook`; SSH supports `draw`, `add_page`, `create_document`, and `daily_notebook` |
 
 ### Safety
@@ -517,6 +519,11 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 
 # Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
+
+# Set official metadata tags/status labels
+remarkable_tags("Daily Notes", add_tags=["review"])
+remarkable_tags("/Daily/Inbox", status="todo")
+remarkable_tags("Old Notes", status="archive")
 
 # Author native ink and notebooks
 # Cloud mode supports create_document and daily_notebook. SSH mode also supports

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Write tools let you upload, organize, and manage documents on your reMarkable. *
 | Move | ✅ | ✅ | ❌ |
 | Rename | ✅ | ✅ | ❌ |
 | Delete | ✅ (→ trash) | ✅ | ❌ |
-| Create native notebook | ✅ (`create_document`) | ✅ | ❌ |
+| Create native notebook | ✅ (`create_document`, `daily_notebook`) | ✅ | ❌ |
 | Native add page / draw | ❌ | ✅ | ❌ |
 
 ### Disabling Write Tools (read-only mode)
@@ -485,7 +485,7 @@ Or set the environment variable:
 | `remarkable_move(document, dest_folder)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name)` | Rename a document or folder (cloud and SSH) |
 | `remarkable_delete(document)` | Delete a document or folder — destructive (cloud and SSH) |
-| `remarkable_author(method, ...)` | Author native notebooks/ink — cloud supports `create_document`; SSH supports `draw`, `add_page`, and `create_document` |
+| `remarkable_author(method, ...)` | Author native notebooks/ink — cloud supports `create_document` and `daily_notebook`; SSH supports `draw`, `add_page`, `create_document`, and `daily_notebook` |
 
 ### Safety
 
@@ -513,8 +513,8 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 remarkable_delete("Old Draft")
 
 # Author native ink and notebooks
-# Cloud mode supports create_document. SSH mode supports create_document,
-# add_page, and draw.
+# Cloud mode supports create_document and daily_notebook. SSH mode also supports
+# add_page and draw.
 # Append pen/highlighter strokes to a page (SSH only; coordinates normalized [0,1] from
 # the page's top-left). The interactive canvas Save button calls this too.
 remarkable_author(
@@ -527,6 +527,13 @@ remarkable_author(method="add_page", document="Ideas")
 
 # Create a new (blank) notebook — the common case
 remarkable_author(method="create_document", name="Sketches")
+
+# Create or find a date-based notebook for capture/review workflows
+remarkable_author(
+    method="daily_notebook",
+    folder="/Inbox",
+    name_format="Daily Notes {date}",
+)
 
 # Only seed typed text when the user explicitly requested it.
 remarkable_author(method="create_document", name="Meeting notes", text="Agenda\nFollow-ups")
@@ -559,7 +566,7 @@ When write mode is on (the default) **and** the active transport is SSH, the can
 - **＋ Page** (native notebooks only) — queues a new blank page locally that you can navigate to and draw on immediately. **Save** materializes the queued page(s) on the device first, then writes any cached strokes.
 - One source of truth: the canvas calls the **same** `remarkable_author` tool a model would call (`method="draw"` on Save, `method="add_page"` for ＋Page), so the human path and the model path produce byte-identical results.
 
-The Save / Draw / ＋Page controls are hidden when the page isn't writable (read-only mode, or a non-SSH transport), and the canvas falls back to a plain image viewer. Cloud mode can still create a new native notebook through `remarkable_author(method="create_document")`; editing existing pages remains SSH-only. The iframe bridge follows the MCP Apps spec but is best validated against your specific client.
+The Save / Draw / ＋Page controls are hidden when the page isn't writable (read-only mode, or a non-SSH transport), and the canvas falls back to a plain image viewer. Cloud mode can still create new native notebooks through `remarkable_author(method="create_document")` and create-or-find date-based notebooks through `remarkable_author(method="daily_notebook")`; editing existing pages remains SSH-only. The iframe bridge follows the MCP Apps spec but is best validated against your specific client.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ Write tools let you upload, organize, and manage documents on your reMarkable. *
 | Move | ✅ | ✅ | ❌ |
 | Rename | ✅ | ✅ | ❌ |
 | Delete | ✅ (→ trash) | ✅ | ❌ |
+| Create native notebook | ✅ (`create_document`) | ✅ | ❌ |
+| Native add page / draw | ❌ | ✅ | ❌ |
 
 ### Disabling Write Tools (read-only mode)
 
@@ -483,7 +485,7 @@ Or set the environment variable:
 | `remarkable_move(document, dest_folder)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name)` | Rename a document or folder (cloud and SSH) |
 | `remarkable_delete(document)` | Delete a document or folder — destructive (cloud and SSH) |
-| `remarkable_author(method, ...)` | Author native ink and notebooks — `draw` (append strokes), `add_page` (append a blank notebook page), `create_document` (new notebook) — **SSH only** |
+| `remarkable_author(method, ...)` | Author native notebooks/ink — cloud supports `create_document`; SSH supports `draw`, `add_page`, and `create_document` |
 
 ### Safety
 
@@ -510,8 +512,10 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 # Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
 
-# Author native ink and notebooks (SSH only)
-# Append pen/highlighter strokes to a page (coordinates normalized [0,1] from
+# Author native ink and notebooks
+# Cloud mode supports create_document. SSH mode supports create_document,
+# add_page, and draw.
+# Append pen/highlighter strokes to a page (SSH only; coordinates normalized [0,1] from
 # the page's top-left). The interactive canvas Save button calls this too.
 remarkable_author(
     method="draw", document="Ideas", page=1,
@@ -555,7 +559,7 @@ When write mode is on (the default) **and** the active transport is SSH, the can
 - **＋ Page** (native notebooks only) — queues a new blank page locally that you can navigate to and draw on immediately. **Save** materializes the queued page(s) on the device first, then writes any cached strokes.
 - One source of truth: the canvas calls the **same** `remarkable_author` tool a model would call (`method="draw"` on Save, `method="add_page"` for ＋Page), so the human path and the model path produce byte-identical results.
 
-The Save / Draw / ＋Page controls are hidden when the page isn't writable (read-only mode, or a non-SSH transport), and the canvas falls back to a plain image viewer. The iframe bridge follows the MCP Apps spec but is best validated against your specific client.
+The Save / Draw / ＋Page controls are hidden when the page isn't writable (read-only mode, or a non-SSH transport), and the canvas falls back to a plain image viewer. Cloud mode can still create a new native notebook through `remarkable_author(method="create_document")`; editing existing pages remains SSH-only. The iframe bridge follows the MCP Apps spec but is best validated against your specific client.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,6 +85,7 @@ For handwriting OCR, add a Google Vision API key:
 | `remarkable_read` | Read document content with text extraction, pagination, grep |
 | `remarkable_browse` | Browse folders, search by name, filter by tags |
 | `remarkable_search` | Multi-document content search with OCR |
+| `remarkable_review` | Deterministic JSON/Markdown/text export for review workflows |
 | `remarkable_recent` | List recently modified documents |
 | `remarkable_image` | Render pages as PNG or SVG |
 | `remarkable_status` | Check connection and device info |

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,7 @@ For handwriting OCR, add a Google Vision API key:
 | `remarkable_recent` | List recently modified documents |
 | `remarkable_image` | Render pages as PNG or SVG |
 | `remarkable_status` | Check connection and device info |
+| `remarkable_tags` | Set official metadata tags/status labels |
 
 ## Workflow
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -9,6 +9,7 @@ This document provides detailed documentation for all MCP tools provided by rema
 | [`remarkable_read`](#remarkable_read) | Read and search document content |
 | [`remarkable_browse`](#remarkable_browse) | Navigate folders and find documents |
 | [`remarkable_search`](#remarkable_search) | Search across multiple documents |
+| [`remarkable_review`](#remarkable_review) | Export deterministic review bundles |
 | [`remarkable_recent`](#remarkable_recent) | Get recently modified documents |
 | [`remarkable_status`](#remarkable_status) | Check connection status |
 | [`remarkable_image`](#remarkable_image) | Get page images (PNG or SVG) |
@@ -217,6 +218,65 @@ remarkable_search("journal", grep="project idea", include_ocr=True)
 - Maximum 5 documents per search
 - Content is truncated to ~2000 characters per document
 - Designed for quick discovery, use `remarkable_read` for full content
+
+---
+
+## remarkable_review
+
+**Export deterministic review bundles without summarization or mutation.**
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `document` | string | `None` | One document name/path/id to export |
+| `folder` | string | `"/"` | Folder to export when `document` is omitted |
+| `tags` | list[string] | `None` | Optional tags to filter folder exports |
+| `since` | string | `None` | Optional ISO date/timestamp; skip older documents |
+| `include_ocr` | bool | `False` | Enable OCR where `remarkable_read` supports it |
+| `output_format` | string | `"json"` | `"json"`, `"markdown"`, or `"text"` |
+
+### Examples
+
+```python
+# Export one document as Markdown
+remarkable_review(document="/Daily/Daily Notes", output_format="markdown")
+
+# Export review-tagged documents from a folder as JSON
+remarkable_review(folder="/Daily", tags=["review"], output_format="json")
+
+# Include OCR in a plain-text export
+remarkable_review(folder="/Inbox", include_ocr=True, output_format="text")
+```
+
+### Response Format
+
+For `output_format="json"`:
+
+```json
+{
+  "output_format": "json",
+  "scope": {"folder": "/Daily", "tags": ["review"]},
+  "count": 1,
+  "documents": [
+    {
+      "name": "Daily Notes",
+      "path": "/Daily/Daily Notes",
+      "file_type": "notebook",
+      "modified": "2025-11-28T10:30:00Z",
+      "tags": ["review"],
+      "content": "Extracted text content..."
+    }
+  ],
+  "_hint": "Exported 1 document(s) for review."
+}
+```
+
+### Notes
+
+- Read-only: this tool only calls the existing browse/read surface.
+- No LLM summarization, classification, task creation, or external integration.
+- Markdown/text output is deterministic and intended for review/export workflows.
 
 ---
 

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -153,6 +153,7 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - `remarkable_move(document, dest_folder)` - Move a document/folder
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
+- `remarkable_author(method="create_document", name=..., folder=...)` - Create a native notebook
 
 ### Safety
 - **Delete is destructive** and immediate — the MCP client should confirm with the user first
@@ -193,6 +194,7 @@ and sync to all your devices:
 - `remarkable_move(document, dest_folder)` - Move a document/folder
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
+- `remarkable_author(method="create_document", name=..., folder=...)` - Create a native notebook
 
 ### Safety
 - **Delete is destructive** — the MCP client should confirm with the user first

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -86,6 +86,7 @@ def _build_instructions() -> str:
 - `remarkable_browse(path, query)` - Browse folders or search for documents
 - `remarkable_read(document, content_type, page, grep)` - Read document content with pagination
 - `remarkable_recent(limit)` - Get recently modified documents
+- `remarkable_review(document, folder, tags, since, output_format)` - Deterministic review/export
 - `remarkable_status()` - Check connection and diagnose issues
 - `remarkable_image(document, page, include_ocr)` - Get a PNG image with optional OCR
 
@@ -116,6 +117,7 @@ Use pagination to avoid overwhelming context. The response includes:
 - Browse → Read: Find documents first, then read them
 - Recent → Read: Check what was recently modified, then read specific ones
 - Read with grep: Search for specific content within large documents
+- Review/export: Use `remarkable_review` for deterministic JSON/Markdown/text exports
 - Browse → Image: Find a document then get its visual representation
 
 ## MCP Resources

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -155,6 +155,7 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - `remarkable_move(document, dest_folder)` - Move a document/folder
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
+- `remarkable_tags(document, add_tags=..., status=...)` - Set metadata tags/status
 - `remarkable_author(method="create_document", name=..., folder=...)` - Create a native notebook
 - `remarkable_author(method="daily_notebook", folder=...)` - Create/find a dated notebook
 
@@ -197,6 +198,7 @@ and sync to all your devices:
 - `remarkable_move(document, dest_folder)` - Move a document/folder
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
+- `remarkable_tags(document, add_tags=..., status=...)` - Set metadata tags/status
 - `remarkable_author(method="create_document", name=..., folder=...)` - Create a native notebook
 - `remarkable_author(method="daily_notebook", folder=...)` - Create/find a dated notebook
 

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -154,6 +154,7 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
 - `remarkable_author(method="create_document", name=..., folder=...)` - Create a native notebook
+- `remarkable_author(method="daily_notebook", folder=...)` - Create/find a dated notebook
 
 ### Safety
 - **Delete is destructive** and immediate — the MCP client should confirm with the user first
@@ -195,6 +196,7 @@ and sync to all your devices:
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
 - `remarkable_author(method="create_document", name=..., folder=...)` - Create a native notebook
+- `remarkable_author(method="daily_notebook", folder=...)` - Create/find a dated notebook
 
 ### Safety
 - **Delete is destructive** — the MCP client should confirm with the user first

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -1091,6 +1091,49 @@ class RemarkableClient:
             parent=parent_id or "",
         )
 
+    def create_notebook(
+        self,
+        name: str,
+        parent_id: str = "",
+        text: Optional[str] = None,
+    ) -> Document:
+        """Create a native notebook in the cloud and return it.
+
+        This mirrors the SSH ``remarkable_author(method="create_document")``
+        path, but commits the generated native notebook blobs through the cloud
+        sync v3/v4 root instead of writing to xochitl over SSH.
+        """
+        from remarkable_mcp import notebooks as nb
+
+        doc_id = nb.new_uuid()
+        page_id = nb.new_uuid()
+        author_uuid = nb.new_uuid()
+
+        page_bytes = nb.page_rm_bytes(text or "", author_uuid=author_uuid)
+        content_json = nb.new_notebook_content([page_id], author_uuid)
+        metadata = nb.new_document_metadata(name, parent=parent_id)
+
+        files = [
+            self._upload_file_blob(page_bytes, f"{doc_id}/{page_id}.rm"),
+            self._upload_file_blob(
+                json.dumps(content_json, sort_keys=True).encode("utf-8"),
+                f"{doc_id}.content",
+            ),
+            self._upload_file_blob(
+                json.dumps(metadata, sort_keys=True).encode("utf-8"),
+                f"{doc_id}.metadata",
+            ),
+        ]
+        new_entry = self._upload_doc_index(doc_id, files)
+        self._sync_root(lambda entries: entries + [new_entry])
+        return Document(
+            id=doc_id,
+            hash=new_entry["hash"],
+            name=name,
+            doc_type="DocumentType",
+            parent=parent_id or "",
+        )
+
     @staticmethod
     def _page_layout(content: bytes, ext: str) -> tuple:
         """Return ``(page_count, page_uuids)`` for a source file.

--- a/remarkable_mcp/sync.py
+++ b/remarkable_mcp/sync.py
@@ -1014,6 +1014,18 @@ class RemarkableClient:
         """Restore a trashed document or folder back to ``parent_id`` ("" = root)."""
         self.move(doc_id, parent_id or "")
 
+    def set_tags(self, doc_id: str, tags: List[str]) -> None:
+        """Set a document or folder's official metadata tags in the cloud."""
+
+        def apply(meta):
+            meta["tags"] = tags
+
+        def mutate(entries):
+            entry = self._require_entry(entries, doc_id)
+            return self._replace_root_entry(entries, self._mutate_doc_metadata(entry, apply))
+
+        self._sync_root(mutate)
+
     def upload_document(
         self,
         content: bytes,

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -7,6 +7,7 @@ USB web) and do not modify any documents.
 """
 
 import base64
+import json
 import os
 import re
 import tempfile
@@ -138,6 +139,11 @@ BROWSE_ANNOTATIONS = ToolAnnotations(
 
 SEARCH_ANNOTATIONS = ToolAnnotations(
     title="Search reMarkable Documents",
+    **_BASE_ANNOTATIONS,
+)
+
+REVIEW_ANNOTATIONS = ToolAnnotations(
+    title="Review/export reMarkable Documents",
     **_BASE_ANNOTATIONS,
 )
 
@@ -1280,6 +1286,204 @@ async def remarkable_search(
             message=str(e),
             suggestion="Check remarkable_status() to verify your connection.",
         )
+
+
+def _review_timestamp(value) -> Optional[float]:
+    """Return a comparable timestamp for ISO strings or datetime values."""
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        try:
+            return value.timestamp()
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(normalized).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _review_metadata_from_read(data: dict, fallback_path: str) -> dict:
+    """Convert a remarkable_read page response into review/export metadata."""
+    doc = {
+        "name": data.get("document") or fallback_path.strip("/").split("/")[-1] or fallback_path,
+        "path": data.get("path") or fallback_path,
+        "file_type": data.get("file_type"),
+        "modified": data.get("modified"),
+        "content": data.get("content", ""),
+    }
+    if "tags" in data:
+        doc["tags"] = data["tags"]
+    if "ocr_backend" in data:
+        doc["ocr_backend"] = data["ocr_backend"]
+    return doc
+
+
+async def _review_read_full_document(path: str, include_ocr: bool) -> dict:
+    """Read every available page from a document through remarkable_read."""
+    page = 1
+    pages = []
+    doc = None
+    while page <= 100:
+        read_result = await remarkable_read(document=path, page=page, include_ocr=include_ocr)
+        data = json.loads(read_result)
+        if "_error" in data:
+            return {"path": path, "error": data["_error"].get("message", "read failed")}
+        if doc is None:
+            doc = _review_metadata_from_read(data, path)
+        content = data.get("content", "")
+        if content:
+            pages.append(content)
+        if not data.get("more"):
+            break
+        page = int(data.get("next_page") or page + 1)
+    if doc is None:
+        doc = {"name": path.strip("/").split("/")[-1] or path, "path": path, "content": ""}
+    doc["content"] = "\n\n".join(pages)
+    return doc
+
+
+def _review_scope(document, folder, tags, since) -> dict:
+    """Build a stable scope object for output."""
+    if document:
+        return {"document": document}
+    scope = {"folder": folder or "/"}
+    if tags:
+        scope["tags"] = tags
+    if since:
+        scope["since"] = since
+    return scope
+
+
+def _review_markdown(result: dict) -> str:
+    """Render review/export data as deterministic Markdown."""
+    lines = ["# reMarkable review export", ""]
+    scope = result["scope"]
+    if "document" in scope:
+        lines.append(f"Scope: document `{scope['document']}`")
+    else:
+        lines.append(f"Scope: folder `{scope.get('folder', '/')}`")
+        if scope.get("tags"):
+            lines.append("Tags: " + ", ".join(f"`{tag}`" for tag in scope["tags"]))
+        if scope.get("since"):
+            lines.append(f"Since: `{scope['since']}`")
+    lines.append(f"Documents: {result['count']}")
+    for doc in result["documents"]:
+        lines.extend(["", f"## {doc.get('name') or doc.get('path')}"])
+        if doc.get("path"):
+            lines.append(f"Path: `{doc['path']}`")
+        if doc.get("modified"):
+            lines.append(f"Modified: `{doc['modified']}`")
+        if doc.get("tags"):
+            lines.append("Tags: " + ", ".join(f"`{tag}`" for tag in doc["tags"]))
+        if doc.get("error"):
+            lines.append(f"Error: {doc['error']}")
+            continue
+        lines.extend(["", doc.get("content", "")])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _review_text(result: dict) -> str:
+    """Render review/export data as plain text."""
+    chunks = ["reMarkable review export", f"documents: {result['count']}"]
+    for doc in result["documents"]:
+        chunks.append(f"\n{doc.get('name') or doc.get('path')}\n{doc.get('path', '')}")
+        if doc.get("modified"):
+            chunks.append(f"modified: {doc['modified']}")
+        if doc.get("tags"):
+            chunks.append("tags: " + ", ".join(doc["tags"]))
+        if doc.get("error"):
+            chunks.append("error: " + doc["error"])
+        else:
+            chunks.append(doc.get("content", ""))
+    return "\n".join(chunks).rstrip() + "\n"
+
+
+@mcp.tool(annotations=REVIEW_ANNOTATIONS)
+async def remarkable_review(
+    document: Optional[str] = None,
+    folder: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    since: Optional[str] = None,
+    include_ocr: bool = False,
+    output_format: str = "json",
+) -> str:
+    """
+    <usecase>Export deterministic review content from one document or folder.</usecase>
+    <instructions>
+    Read-only helper for review workflows. It does not summarize, classify,
+    mutate documents, call an LLM, or integrate with external note/task systems.
+    It gathers document metadata plus extracted text/OCR from existing read tools
+    and returns it as JSON, Markdown, or plain text.
+    </instructions>
+    <parameters>
+    - document: Optional document name/path/id to export.
+    - folder: Optional folder to export when document is omitted (default "/").
+    - tags: Optional tags to filter folder exports.
+    - since: Optional ISO timestamp/date; folder exports skip older documents.
+    - include_ocr: Enable OCR where remarkable_read supports it.
+    - output_format: "json", "markdown", or "text".
+    </parameters>
+    <examples>
+    - remarkable_review(document="/Daily/Daily Notes", output_format="markdown")
+    - remarkable_review(folder="/Daily", tags=["review"], output_format="json")
+    </examples>
+    """
+    output_format = (output_format or "json").lower()
+    if output_format not in {"json", "markdown", "text"}:
+        return make_error(
+            error_type="invalid_output_format",
+            message=f"Unsupported output_format: '{output_format}'.",
+            suggestion='Use output_format="json", "markdown", or "text".',
+        )
+
+    since_ts = _review_timestamp(since) if since else None
+    if since and since_ts is None:
+        return make_error(
+            error_type="invalid_since",
+            message=f"Invalid since value: '{since}'.",
+            suggestion='Use an ISO date or timestamp, e.g. "2026-06-24".',
+        )
+
+    if document:
+        docs = [await _review_read_full_document(document, include_ocr)]
+    else:
+        browse_result = await remarkable_browse(path=folder or "/", tags=tags)
+        browse_data = json.loads(browse_result)
+        if "_error" in browse_data:
+            return browse_result
+        candidates = browse_data.get("documents") or browse_data.get("results") or []
+        docs = []
+        for candidate in candidates:
+            if candidate.get("type") != "document":
+                continue
+            modified_ts = _review_timestamp(candidate.get("modified"))
+            if since_ts is not None and (modified_ts is None or modified_ts < since_ts):
+                continue
+            path = candidate.get("path") or candidate.get("name")
+            if not path:
+                continue
+            doc = await _review_read_full_document(path, include_ocr)
+            if "tags" not in doc and candidate.get("tags"):
+                doc["tags"] = candidate["tags"]
+            if not doc.get("modified") and candidate.get("modified"):
+                doc["modified"] = candidate["modified"]
+            docs.append(doc)
+
+    result = {
+        "output_format": output_format,
+        "scope": _review_scope(document, folder, tags, since),
+        "count": len(docs),
+        "documents": docs,
+    }
+    if output_format == "markdown":
+        return _review_markdown(result)
+    if output_format == "text":
+        return _review_text(result)
+    return make_response(result, f"Exported {len(docs)} document(s) for review.")
 
 
 @mcp.tool(annotations=STATUS_ANNOTATIONS)

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -50,6 +50,7 @@ MKDIR_ANNOTATIONS = WRITE_ANNOTATIONS
 MOVE_ANNOTATIONS = WRITE_ANNOTATIONS
 RENAME_ANNOTATIONS = WRITE_ANNOTATIONS
 DELETE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+TAGS_ANNOTATIONS = ToolAnnotations(readOnlyHint=False)
 
 
 def read_only_enabled() -> bool:
@@ -333,6 +334,154 @@ def _invalidate_client_cache(client) -> None:
     """Drop the in-memory document cache so the next read reflects the write."""
     client._documents = []
     client._documents_by_id = {}
+
+
+_STATUS_TAGS = {"review", "todo", "archive"}
+
+
+def _unique_tags(values: Optional[list]) -> list[str]:
+    """Normalize tags while preserving first-seen order."""
+    result = []
+    seen = set()
+    for value in values or []:
+        tag = str(value).strip()
+        if not tag or tag in seen:
+            continue
+        result.append(tag)
+        seen.add(tag)
+    return result
+
+
+def _tags_with_status(
+    base_tags: list[str], status: Optional[str]
+) -> tuple[Optional[list[str]], Optional[str]]:
+    """Return tags with an optional exclusive status label applied."""
+    if status is None:
+        return base_tags, None
+    normalized = status.strip().lower()
+    if normalized not in _STATUS_TAGS and normalized != "none":
+        return None, make_error(
+            error_type="invalid_status",
+            message=f"Unsupported status: '{status}'.",
+            suggestion='Use status="review", "todo", "archive", or "none".',
+        )
+    tags = [tag for tag in base_tags if tag.lower() not in _STATUS_TAGS]
+    if normalized != "none":
+        tags.append(normalized)
+    return tags, None
+
+
+def _update_tags(
+    current_tags: Optional[list],
+    tags: Optional[list],
+    add_tags: Optional[list],
+    remove_tags: Optional[list],
+    status: Optional[str],
+) -> tuple[Optional[list[str]], Optional[str]]:
+    """Compute the requested official metadata tag list."""
+    next_tags = _unique_tags(tags if tags is not None else current_tags)
+    for tag in _unique_tags(add_tags):
+        if tag not in next_tags:
+            next_tags.append(tag)
+    remove = {tag.lower() for tag in _unique_tags(remove_tags)}
+    if remove:
+        next_tags = [tag for tag in next_tags if tag.lower() not in remove]
+    return _tags_with_status(next_tags, status)
+
+
+def _document_not_found(document: str, collection: list) -> str:
+    from remarkable_mcp.extract import find_similar_documents
+
+    similar = find_similar_documents(document, collection)
+    return make_error(
+        error_type="document_not_found",
+        message=f"Document not found: '{document}'",
+        suggestion="Use remarkable_browse() to find the correct name.",
+        did_you_mean=similar if similar else None,
+    )
+
+
+def _cloud_tags(
+    document: str,
+    tags: Optional[list],
+    add_tags: Optional[list],
+    remove_tags: Optional[list],
+    status: Optional[str],
+) -> str:
+    """Set official metadata tags through the cloud sync protocol."""
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        return _document_not_found(document, collection)
+    previous_tags = _unique_tags(getattr(target, "tags", []))
+    next_tags, error = _update_tags(previous_tags, tags, add_tags, remove_tags, status)
+    if error:
+        return error
+    assert next_tags is not None
+    client.set_tags(target.ID, next_tags)
+    _invalidate_client_cache(client)
+    return make_response(
+        {
+            "updated": True,
+            "document": target.VissibleName,
+            "document_id": target.ID,
+            "previous_tags": previous_tags,
+            "tags": next_tags,
+            "status": next((tag for tag in next_tags if tag.lower() in _STATUS_TAGS), None),
+            "transport": "cloud",
+        },
+        "Updated official reMarkable metadata tags. Use remarkable_browse() to verify.",
+    )
+
+
+def _ssh_tags(
+    document: str,
+    tags: Optional[list],
+    add_tags: Optional[list],
+    remove_tags: Optional[list],
+    status: Optional[str],
+) -> str:
+    """Set official metadata tags by rewriting the SSH .metadata file."""
+    ssh_client = _get_ssh_client()
+    collection = ssh_client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    target = _resolve_document(document, collection, items_by_id)
+    if not target:
+        return _document_not_found(document, collection)
+    meta_path = f"{XOCHITL_PATH}/{target.ID}.metadata"
+    raw = _read_remote_bytes(ssh_client, meta_path)
+    if raw is None:
+        return make_error(
+            error_type="metadata_not_found",
+            message=f"Metadata file not found for '{document}'.",
+            suggestion="Use cloud mode if this document is not fully synced to the device.",
+        )
+    metadata = json.loads(raw.decode("utf-8"))
+    previous_tags = _unique_tags(metadata.get("tags", getattr(target, "tags", [])))
+    next_tags, error = _update_tags(previous_tags, tags, add_tags, remove_tags, status)
+    if error:
+        return error
+    assert next_tags is not None
+    metadata["tags"] = next_tags
+    metadata["lastModified"] = str(int(time.time() * 1000))
+    metadata["metadatamodified"] = True
+    _write_metadata(ssh_client, target.ID, metadata)
+    _restart_xochitl(ssh_client)
+    _invalidate_client_cache(ssh_client)
+    return make_response(
+        {
+            "updated": True,
+            "document": target.VissibleName,
+            "document_id": target.ID,
+            "previous_tags": previous_tags,
+            "tags": next_tags,
+            "status": next((tag for tag in next_tags if tag.lower() in _STATUS_TAGS), None),
+            "transport": "ssh",
+        },
+        "Updated official reMarkable metadata tags. Use remarkable_browse() to verify.",
+    )
 
 
 def _cloud_mkdir(folder_name: str, parent: str) -> str:
@@ -1681,6 +1830,47 @@ def register_write_tools():
                         message=f"Failed to rename document: {e}",
                         suggestion="Check SSH connection and try again.",
                     )
+
+            return await asyncio.to_thread(_impl)
+
+        @mcp.tool(annotations=TAGS_ANNOTATIONS)
+        async def remarkable_tags(
+            document: str,
+            tags: Optional[list[str]] = None,
+            add_tags: Optional[list[str]] = None,
+            remove_tags: Optional[list[str]] = None,
+            status: Optional[str] = None,
+        ) -> str:
+            """
+            <usecase>Set official reMarkable document tags and simple status labels.</usecase>
+            <instructions>
+            Updates the document's official metadata `tags` list. Status is not a
+            separate private field: status="review", "todo", or "archive" is stored
+            as one normal tag, with only one of those status tags kept at a time.
+            Use status="none" to clear the status tag. Works in cloud and SSH modes;
+            USB web has no metadata-write endpoint.
+            </instructions>
+            <parameters>
+            - document: Name or path of the document/folder to tag.
+            - tags: Optional full replacement tag list.
+            - add_tags: Optional tags to add to the current/replacement list.
+            - remove_tags: Optional tags to remove from the current/replacement list.
+            - status: Optional status label: "review", "todo", "archive", or "none".
+            </parameters>
+            <examples>
+            - remarkable_tags("Daily Notes", add_tags=["review"])
+            - remarkable_tags("/Daily/Inbox", status="todo")
+            - remarkable_tags("Old Notes", status="archive")
+            </examples>
+            """
+
+            def _impl() -> str:
+                error = _require_managed_write_mode()
+                if error:
+                    return error
+                if _is_cloud_mode():
+                    return _cloud_tags(document, tags, add_tags, remove_tags, status)
+                return _ssh_tags(document, tags, add_tags, remove_tags, status)
 
             return await asyncio.to_thread(_impl)
 

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -484,6 +484,55 @@ def _cloud_delete(document: str) -> str:
     )
 
 
+def _cloud_author_create_document(
+    name: Optional[str], text: Optional[str], folder: Optional[str]
+) -> str:
+    """Create a new native notebook through the cloud sync protocol."""
+    if not name:
+        return make_error(
+            error_type="missing_parameter",
+            message="create_document requires 'name'.",
+            suggestion='Call remarkable_author(method="create_document", name="My notes").',
+        )
+
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    folder_path = folder or "/"
+    parent_id = _resolve_parent_id(folder_path, items_by_id, collection)
+    if parent_id is None:
+        folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+        return make_error(
+            error_type="folder_not_found",
+            message=f"Folder not found: '{folder}'",
+            suggestion="Use remarkable_browse('/') to see available folders.",
+            did_you_mean=folders[:5] if folders else None,
+        )
+
+    create_notebook = getattr(client, "create_notebook", None)
+    if not callable(create_notebook):
+        return make_error(
+            error_type="unsupported_transport",
+            message="This transport cannot create native notebooks.",
+            suggestion="Use cloud mode for create_document or SSH mode for full authoring.",
+        )
+
+    doc = create_notebook(name, parent_id, text)
+    doc_id = getattr(doc, "id", None)
+    _invalidate_client_cache(client)
+    result = {
+        "created": True,
+        "document": name,
+        "document_id": doc_id,
+        "total_pages": 1,
+        "folder": folder_path,
+        "has_text": bool(text),
+        "transport": "cloud",
+    }
+    hint = f"Created notebook '{name}' in the reMarkable cloud. Use remarkable_browse() to verify."
+    return make_response(result, hint)
+
+
 class _DeleteConfirmation(BaseModel):
     """Schema for confirming a destructive delete via elicitation."""
 
@@ -836,10 +885,11 @@ def register_write_tools():
         ＋Page → add_page, new notebook → create_document) AND model-driven markup
         (highlighting, underlining, marking) — the model composes the strokes.</usecase>
         <instructions>
-        Requires SSH mode (the default tablet-filesystem transport for write-back)
-        and write mode (the default; disabled with --read-only). All methods are
-        non-destructive (draw appends to existing ink and backs the page up to
-        {pageId}.rm.bak the first time), so no confirmation prompt is required.
+        Requires write mode (the default; disabled with --read-only). In cloud
+        mode, only method="create_document" is supported. In SSH mode, all
+        methods are supported and non-destructive (draw appends to existing ink
+        and backs the page up to {pageId}.rm.bak the first time), so no
+        confirmation prompt is required.
 
         Pick the method, then pass only that method's parameters:
 
@@ -898,6 +948,19 @@ def register_write_tools():
             if error:
                 return error
 
+            if _is_cloud_mode():
+                if method == "create_document":
+                    return _cloud_author_create_document(name, text, folder)
+                return make_error(
+                    error_type="unsupported_in_cloud",
+                    message=f'Cloud mode supports method="create_document" only, not "{method}".',
+                    suggestion=(
+                        "Use SSH mode for add_page/draw, or create a new cloud notebook "
+                        'with remarkable_author(method="create_document", name=...).'
+                    ),
+                    did_you_mean=["create_document"],
+                )
+
             if method == "draw":
                 return _author_draw(document, page, strokes, ui_submitted)
             if method == "add_page":
@@ -913,11 +976,11 @@ def register_write_tools():
 
         return await asyncio.to_thread(_impl)
 
-    # Native ink/notebook authoring is SSH-only today (cloud/USB-web write-back
-    # is not implemented yet), so only expose the tool in SSH mode rather than
-    # registering it everywhere and erroring at call time. Clients on other
-    # transports simply don't see a tool they couldn't use.
-    if _is_ssh_mode():
+    # Native ink/notebook authoring is partially supported in cloud mode:
+    # create_document can be committed as a brand-new sync document, while
+    # add_page/draw still require SSH because they mutate an existing document.
+    # USB web has no native write-back endpoint, so it does not expose authoring.
+    if _is_ssh_mode() or _is_cloud_mode():
         mcp.tool(annotations=WRITE_ANNOTATIONS)(remarkable_author)
 
     @mcp.tool(annotations=UPLOAD_ANNOTATIONS)

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -25,6 +25,7 @@ import logging
 import os
 import time
 import uuid
+from datetime import date as date_cls
 from typing import Optional
 
 from mcp.server.fastmcp import Context
@@ -533,6 +534,135 @@ def _cloud_author_create_document(
     return make_response(result, hint)
 
 
+def _daily_notebook_name(
+    daily_date: Optional[str], name_format: Optional[str]
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return ``(date_string, notebook_name, error_json)``."""
+    date_string = daily_date or date_cls.today().isoformat()
+    try:
+        parsed_date = date_cls.fromisoformat(date_string)
+    except ValueError:
+        return (
+            None,
+            None,
+            make_error(
+                error_type="invalid_date",
+                message=f"Invalid date: '{daily_date}'.",
+                suggestion='Use ISO format: date="YYYY-MM-DD".',
+            ),
+        )
+
+    fmt = name_format or "Daily Notes {date}"
+    try:
+        name = fmt.format(date=parsed_date.isoformat())
+    except (KeyError, IndexError, ValueError) as e:
+        return (
+            None,
+            None,
+            make_error(
+                error_type="invalid_name_format",
+                message=f"Invalid name_format: {e}",
+                suggestion='Use a format string such as "Daily Notes {date}".',
+            ),
+        )
+    if not name.strip():
+        return (
+            None,
+            None,
+            make_error(
+                error_type="invalid_name_format",
+                message="name_format produced an empty notebook name.",
+                suggestion='Use a format string such as "Daily Notes {date}".',
+            ),
+        )
+    return parsed_date.isoformat(), name.strip(), None
+
+
+def _find_child_document(collection: list, parent_id: str, name: str):
+    """Find a non-folder child document with ``name`` under ``parent_id``."""
+    for item in collection:
+        if getattr(item, "Parent", "") != parent_id:
+            continue
+        if getattr(item, "VissibleName", None) != name:
+            continue
+        if getattr(item, "is_folder", False):
+            continue
+        return item
+    return None
+
+
+def _cloud_author_daily_notebook(
+    daily_date: Optional[str],
+    name_format: Optional[str],
+    text: Optional[str],
+    folder: Optional[str],
+) -> str:
+    """Find or create a dated native notebook through the cloud sync protocol."""
+    normalized_date, name, error = _daily_notebook_name(daily_date, name_format)
+    if error:
+        return error
+    assert normalized_date is not None
+    assert name is not None
+
+    client = get_rmapi()
+    collection = client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    folder_path = folder or "/"
+    parent_id = _resolve_parent_id(folder_path, items_by_id, collection)
+    if parent_id is None:
+        folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+        return make_error(
+            error_type="folder_not_found",
+            message=f"Folder not found: '{folder}'",
+            suggestion="Use remarkable_browse('/') to see available folders.",
+            did_you_mean=folders[:5] if folders else None,
+        )
+
+    existing = _find_child_document(collection, parent_id, name)
+    if existing:
+        path = get_item_path(existing, items_by_id)
+        return make_response(
+            {
+                "created": False,
+                "found": True,
+                "document": name,
+                "document_id": getattr(existing, "ID", None),
+                "path": path,
+                "folder": folder_path,
+                "date": normalized_date,
+                "transport": "cloud",
+            },
+            f"Found existing daily notebook '{name}'.",
+        )
+
+    create_notebook = getattr(client, "create_notebook", None)
+    if not callable(create_notebook):
+        return make_error(
+            error_type="unsupported_transport",
+            message="This transport cannot create native notebooks.",
+            suggestion="Use cloud mode for daily_notebook or SSH mode for full authoring.",
+        )
+
+    doc = create_notebook(name, parent_id, text)
+    doc_id = getattr(doc, "id", None)
+    _invalidate_client_cache(client)
+    path = f"{folder_path.rstrip('/')}/{name}" if folder_path != "/" else f"/{name}"
+    return make_response(
+        {
+            "created": True,
+            "found": False,
+            "document": name,
+            "document_id": doc_id,
+            "path": path,
+            "folder": folder_path,
+            "date": normalized_date,
+            "has_text": bool(text),
+            "transport": "cloud",
+        },
+        f"Created daily notebook '{name}' in the reMarkable cloud.",
+    )
+
+
 class _DeleteConfirmation(BaseModel):
     """Schema for confirming a destructive delete via elicitation."""
 
@@ -858,6 +988,62 @@ def _author_create_document(name: str, text: Optional[str], folder: Optional[str
     return make_response(result, hint)
 
 
+def _author_daily_notebook(
+    daily_date: Optional[str],
+    name_format: Optional[str],
+    text: Optional[str],
+    folder: Optional[str],
+) -> str:
+    """Find or create a date-based native notebook over SSH."""
+    normalized_date, name, error = _daily_notebook_name(daily_date, name_format)
+    if error:
+        return error
+    assert normalized_date is not None
+    assert name is not None
+
+    ssh_client = _get_ssh_client()
+    collection = ssh_client.get_meta_items()
+    items_by_id = get_items_by_id(collection)
+    folder_path = folder or "/"
+    parent_id = _resolve_parent_id(folder_path, items_by_id, collection)
+    if parent_id is None:
+        folders = [get_item_path(i, items_by_id) for i in collection if i.is_folder]
+        return make_error(
+            error_type="folder_not_found",
+            message=f"Folder not found: '{folder}'",
+            suggestion="Use remarkable_browse('/') to see available folders.",
+            did_you_mean=folders[:5] if folders else None,
+        )
+
+    existing = _find_child_document(collection, parent_id, name)
+    if existing:
+        return make_response(
+            {
+                "created": False,
+                "found": True,
+                "document": name,
+                "document_id": getattr(existing, "ID", None),
+                "path": get_item_path(existing, items_by_id),
+                "folder": folder_path,
+                "date": normalized_date,
+                "transport": "ssh",
+            },
+            f"Found existing daily notebook '{name}'.",
+        )
+
+    created = json.loads(_author_create_document(name, text, folder))
+    path = f"{folder_path.rstrip('/')}/{name}" if folder_path != "/" else f"/{name}"
+    created.update(
+        {
+            "created": True,
+            "found": False,
+            "path": path,
+            "date": normalized_date,
+        }
+    )
+    return make_response(created, f"Created daily notebook '{name}'.")
+
+
 def register_write_tools():
     """Register all write tools with the MCP server."""
     # Imported lazily to break a circular import: server.py imports this module
@@ -873,23 +1059,25 @@ def register_write_tools():
         name: Optional[str] = None,
         text: Optional[str] = None,
         folder: Optional[str] = None,
+        date: Optional[str] = None,
+        name_format: Optional[str] = None,
         ui_submitted: bool = False,
         ctx: Context = None,
     ) -> str:
         """
         <usecase>Author native reMarkable ink and notebooks. ONE compound write
-        primitive with three methods: "draw" appends pen/highlighter strokes to a
-        page, "add_page" appends a blank drawable page to a notebook, and
+        primitive with four methods: "draw" appends pen/highlighter strokes to a
+        page, "add_page" appends a blank drawable page to a notebook,
         "create_document" creates a new notebook (optionally seeded with typed
-        text). This is the single tool behind the interactive canvas (Save → draw,
+        text), and "daily_notebook" finds or creates a date-based notebook.
         ＋Page → add_page, new notebook → create_document) AND model-driven markup
         (highlighting, underlining, marking) — the model composes the strokes.</usecase>
         <instructions>
         Requires write mode (the default; disabled with --read-only). In cloud
-        mode, only method="create_document" is supported. In SSH mode, all
-        methods are supported and non-destructive (draw appends to existing ink
-        and backs the page up to {pageId}.rm.bak the first time), so no
-        confirmation prompt is required.
+        mode, only method="create_document" and method="daily_notebook" are
+        supported. In SSH mode, all methods are supported and non-destructive
+        (draw appends to existing ink and backs the page up to {pageId}.rm.bak
+        the first time), so no confirmation prompt is required.
 
         Pick the method, then pass only that method's parameters:
 
@@ -913,12 +1101,18 @@ def register_write_tools():
           placeholder, or "created by" line. Returns the new document id and
           first-page geometry.
 
+        - method="daily_notebook": finds or creates one date-based native
+          notebook. Optional `date` defaults to today and must be YYYY-MM-DD when
+          provided. Optional `name_format` defaults to "Daily Notes {date}".
+          Optional `folder` defaults to root. Optional `text` seeds the first
+          page only when a new notebook is created.
+
         The interactive canvas calls this exact tool via the MCP Apps bridge,
         passing ui_submitted=true for draw (the human already chose Save). A model
         calling it directly should omit ui_submitted.
         </instructions>
         <parameters>
-        - method: "draw" | "add_page" | "create_document".
+        - method: "draw" | "add_page" | "create_document" | "daily_notebook".
         - document: Target document name/path/id (draw, add_page).
         - page: 1-based page number (draw).
         - strokes: List of stroke dicts (draw). Each:
@@ -927,10 +1121,14 @@ def register_write_tools():
              "color": "black" | "yellow" | ...,
              "width": <optional float>, "thickness_scale": <optional float>}
         - name: Title of the new notebook (create_document).
-        - text: Optional typed text for the first page (create_document). Omit it
-            unless the user explicitly requested specific content; never fabricate
-            placeholder text. Paragraphs split on newlines.
-        - folder: Destination folder path (create_document; default "/").
+        - text: Optional typed text for the first page (create_document,
+            daily_notebook when created). Omit it unless the user explicitly
+            requested specific content; never fabricate placeholder text.
+            Paragraphs split on newlines.
+        - folder: Destination folder path (create_document, daily_notebook;
+            default "/").
+        - date: Optional ISO date for daily_notebook (YYYY-MM-DD; default today).
+        - name_format: Optional daily_notebook format string with `{date}`.
         - ui_submitted: Set by the canvas app when the user clicked Save. Models omit it.
         </parameters>
         <examples>
@@ -940,6 +1138,8 @@ def register_write_tools():
         - remarkable_author(method="create_document", name="Sketches")
         - remarkable_author(method="create_document", name="Meeting notes",
             text="Agenda\nFollow-ups")  # only when the user supplied that text
+        - remarkable_author(method="daily_notebook", folder="/Inbox",
+            name_format="Daily Notes {date}")
         </examples>
         """
 
@@ -951,14 +1151,19 @@ def register_write_tools():
             if _is_cloud_mode():
                 if method == "create_document":
                     return _cloud_author_create_document(name, text, folder)
+                if method == "daily_notebook":
+                    return _cloud_author_daily_notebook(date, name_format, text, folder)
                 return make_error(
                     error_type="unsupported_in_cloud",
-                    message=f'Cloud mode supports method="create_document" only, not "{method}".',
+                    message=(
+                        'Cloud mode supports method="create_document" and '
+                        f'method="daily_notebook" only, not "{method}".'
+                    ),
                     suggestion=(
                         "Use SSH mode for add_page/draw, or create a new cloud notebook "
                         'with remarkable_author(method="create_document", name=...).'
                     ),
-                    did_you_mean=["create_document"],
+                    did_you_mean=["create_document", "daily_notebook"],
                 )
 
             if method == "draw":
@@ -967,11 +1172,13 @@ def register_write_tools():
                 return _author_add_page(document)
             if method == "create_document":
                 return _author_create_document(name, text, folder)
+            if method == "daily_notebook":
+                return _author_daily_notebook(date, name_format, text, folder)
             return make_error(
                 error_type="unknown_method",
                 message=f"Unknown method: '{method}'.",
-                suggestion='Use method="draw", "add_page", or "create_document".',
-                did_you_mean=["draw", "add_page", "create_document"],
+                suggestion='Use method="draw", "add_page", "create_document", or "daily_notebook".',
+                did_you_mean=["draw", "add_page", "create_document", "daily_notebook"],
             )
 
         return await asyncio.to_thread(_impl)

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -34,7 +34,7 @@ Each `(mode, tool)` cell is one of:
 | Result | Meaning |
 | ------ | ------- |
 | **PASS** ✅ | The tool ran and returned a sensible result for this transport. |
-| **N/A** ⛔ | The transport does not expose this tool — it is *correctly hidden* (e.g. `mkdir`/`move`/`rename`/`delete` over USB web, or `remarkable_author` outside SSH). This is expected, **not** a failure. |
+| **N/A** ⛔ | The transport does not expose this tool — it is *correctly hidden* (e.g. `mkdir`/`move`/`rename`/`delete` over USB web, or native authoring over USB web). This is expected, **not** a failure. |
 | **SKIP** | The tool could not be run (mode unreachable, or no target document to read). |
 | **FAIL** ❌ | The tool is exposed but errored or returned the wrong thing. **This is the only result that means something is broken.** |
 
@@ -53,13 +53,13 @@ tool visibility changes.
 | `remarkable_status` / `browse` / `recent` / `search` / `read` / `image` / `canvas` | PASS | PASS | PASS |
 | `remarkable_upload` | PASS | PASS | PASS |
 | `remarkable_mkdir` / `rename` / `move` / `delete` | PASS | **N/A** | PASS |
-| `remarkable_author` | PASS (`create_document`) | **N/A** | PASS |
+| `remarkable_author` | PASS (`create_document`, `daily_notebook`) | **N/A** | PASS |
 
 USB web is read + render + upload-to-root only — the device firmware HTTP server
 exposes no folder/move/rename/delete/native authoring endpoints, so those tools
 are not registered in that mode (shown as N/A). Cloud mode exposes
-`remarkable_author` for `create_document` only; SSH mode validates
-`create_document`, `add_page`, and `draw`.
+`remarkable_author` for `create_document` and `daily_notebook` only; SSH mode
+validates `create_document`, `daily_notebook`, `add_page`, and `draw`.
 
 ### Upload is verified end-to-end (cloud/ssh)
 

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -52,7 +52,7 @@ tool visibility changes.
 | ---- | :---: | :-----: | :-: |
 | `remarkable_status` / `browse` / `recent` / `search` / `review` / `read` / `image` / `canvas` | PASS | PASS | PASS |
 | `remarkable_upload` | PASS | PASS | PASS |
-| `remarkable_mkdir` / `rename` / `move` / `delete` | PASS | **N/A** | PASS |
+| `remarkable_mkdir` / `rename` / `move` / `tags` / `delete` | PASS | **N/A** | PASS |
 | `remarkable_author` | PASS (`create_document`, `daily_notebook`) | **N/A** | PASS |
 
 USB web is read + render + upload-to-root only — the device firmware HTTP server

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -50,7 +50,7 @@ tool visibility changes.
 
 | Tool | cloud | usb-web | ssh |
 | ---- | :---: | :-----: | :-: |
-| `remarkable_status` / `browse` / `recent` / `search` / `read` / `image` / `canvas` | PASS | PASS | PASS |
+| `remarkable_status` / `browse` / `recent` / `search` / `review` / `read` / `image` / `canvas` | PASS | PASS | PASS |
 | `remarkable_upload` | PASS | PASS | PASS |
 | `remarkable_mkdir` / `rename` / `move` / `delete` | PASS | **N/A** | PASS |
 | `remarkable_author` | PASS (`create_document`, `daily_notebook`) | **N/A** | PASS |

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -53,12 +53,13 @@ tool visibility changes.
 | `remarkable_status` / `browse` / `recent` / `search` / `read` / `image` / `canvas` | PASS | PASS | PASS |
 | `remarkable_upload` | PASS | PASS | PASS |
 | `remarkable_mkdir` / `rename` / `move` / `delete` | PASS | **N/A** | PASS |
-| `remarkable_author` | **N/A** | **N/A** | PASS |
+| `remarkable_author` | PASS (`create_document`) | **N/A** | PASS |
 
 USB web is read + render + upload-to-root only — the device firmware HTTP server
-exposes no folder/move/rename/delete endpoints, so those tools are not registered
-in that mode (shown as N/A). `remarkable_author` requires native `.rm` write-back
-and is SSH-only today.
+exposes no folder/move/rename/delete/native authoring endpoints, so those tools
+are not registered in that mode (shown as N/A). Cloud mode exposes
+`remarkable_author` for `create_document` only; SSH mode validates
+`create_document`, `add_page`, and `draw`.
 
 ### Upload is verified end-to-end (cloud/ssh)
 

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -13,7 +13,8 @@ so SSH (the only mode that writes to the device filesystem) runs LAST, after the
 USB-web checks are done.
 
 The server HIDES tools a transport cannot support (e.g. mkdir/move/rename/delete
-are not registered over USB web; remarkable_author is SSH-only). The harness is
+are not registered over USB web; remarkable_author is registered in cloud for
+create_document only and in SSH for full native authoring). The harness is
 therefore ``tools/list``-driven: it asks each running server which tools it
 actually exposes and only exercises those. Any tool in the master list that a
 mode does not expose is reported as N/A for that mode -- which is the *correct*
@@ -482,7 +483,7 @@ async def run_write_phase(session, mode, rec, registered):
             else:
                 rec.record(mode, "remarkable_move", SKIP, "no document to move")
 
-        # --- author (SSH only) ------------------------------------------
+        # --- author ------------------------------------------------------
         if "remarkable_author" in registered:
             nb_name = f"{runid}-nb"
             payload, is_err, exc = await call_tool(
@@ -495,34 +496,37 @@ async def run_write_phase(session, mode, rec, registered):
             nb_path = f"{folder_path}/{nb_name}"
             if state == PASS:
                 created.insert(0, ("doc", nb_path))  # delete before its folder
-                ap_payload, ap_err, ap_exc = await call_tool(
-                    session,
-                    "remarkable_author",
-                    {"method": "add_page", "document": nb_path},
-                    TIMEOUTS["remarkable_author"],
-                )
-                ap_state, _ = classify_ok(ap_payload, ap_err, ap_exc)
-                dr_payload, dr_err, dr_exc = await call_tool(
-                    session,
-                    "remarkable_author",
-                    {
-                        "method": "draw",
-                        "document": nb_path,
-                        "page": 1,
-                        "strokes": [
-                            {
-                                "points": [[0.1, 0.5], [0.9, 0.5]],
-                                "tool": "fineliner",
-                                "color": "black",
-                            }
-                        ],
-                    },
-                    TIMEOUTS["remarkable_author"],
-                )
-                dr_state, _ = classify_ok(dr_payload, dr_err, dr_exc)
-                sub = f"create_document=PASS; add_page={ap_state}; draw={dr_state}"
-                final = PASS if (ap_state == PASS and dr_state == PASS) else FAIL
-                rec.record(mode, "remarkable_author", final, sub)
+                if is_ssh:
+                    ap_payload, ap_err, ap_exc = await call_tool(
+                        session,
+                        "remarkable_author",
+                        {"method": "add_page", "document": nb_path},
+                        TIMEOUTS["remarkable_author"],
+                    )
+                    ap_state, _ = classify_ok(ap_payload, ap_err, ap_exc)
+                    dr_payload, dr_err, dr_exc = await call_tool(
+                        session,
+                        "remarkable_author",
+                        {
+                            "method": "draw",
+                            "document": nb_path,
+                            "page": 1,
+                            "strokes": [
+                                {
+                                    "points": [[0.1, 0.5], [0.9, 0.5]],
+                                    "tool": "fineliner",
+                                    "color": "black",
+                                }
+                            ],
+                        },
+                        TIMEOUTS["remarkable_author"],
+                    )
+                    dr_state, _ = classify_ok(dr_payload, dr_err, dr_exc)
+                    sub = f"create_document=PASS; add_page={ap_state}; draw={dr_state}"
+                    final = PASS if (ap_state == PASS and dr_state == PASS) else FAIL
+                    rec.record(mode, "remarkable_author", final, sub)
+                else:
+                    rec.record(mode, "remarkable_author", PASS, "create_document=PASS")
             else:
                 rec.record(mode, "remarkable_author", state, note)
 

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -93,6 +93,7 @@ ALL_TOOLS = [
     "remarkable_rename",
     "remarkable_move",
     "remarkable_author",
+    "remarkable_tags",
     "remarkable_delete",
 ]
 
@@ -111,6 +112,7 @@ WRITE_TOOLS = {
     "remarkable_rename",
     "remarkable_move",
     "remarkable_author",
+    "remarkable_tags",
     "remarkable_delete",
 }
 
@@ -448,6 +450,21 @@ async def run_write_phase(session, mode, rec, registered):
                 # Upload itself succeeded (only the read-back failed), so the doc
                 # still exists and must be cleaned up despite the FAIL verdict.
                 created.append(("doc", uploaded_path))
+
+        # --- tags --------------------------------------------------------
+        if "remarkable_tags" in registered:
+            doc_entry = next((p for k, p in created if k == "doc"), None)
+            if doc_entry:
+                payload, is_err, exc = await call_tool(
+                    session,
+                    "remarkable_tags",
+                    {"document": doc_entry, "tags": ["review"], "status": "review"},
+                    TIMEOUTS["_default"],
+                )
+                state, note = classify_ok(payload, is_err, exc)
+                rec.record(mode, "remarkable_tags", state, note)
+            else:
+                rec.record(mode, "remarkable_tags", SKIP, "no document to tag")
 
         # --- rename ------------------------------------------------------
         renamed_path = None

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -496,6 +496,22 @@ async def run_write_phase(session, mode, rec, registered):
             nb_path = f"{folder_path}/{nb_name}"
             if state == PASS:
                 created.insert(0, ("doc", nb_path))  # delete before its folder
+                daily_date = "2099-01-02"
+                daily_name = f"{runid}-daily-{daily_date}"
+                daily_payload, daily_err, daily_exc = await call_tool(
+                    session,
+                    "remarkable_author",
+                    {
+                        "method": "daily_notebook",
+                        "date": daily_date,
+                        "folder": folder_path,
+                        "name_format": f"{runid}-daily-{{date}}",
+                    },
+                    TIMEOUTS["remarkable_author"],
+                )
+                daily_state, _ = classify_ok(daily_payload, daily_err, daily_exc)
+                if daily_state == PASS:
+                    created.insert(0, ("doc", f"{folder_path}/{daily_name}"))
                 if is_ssh:
                     ap_payload, ap_err, ap_exc = await call_tool(
                         session,
@@ -522,11 +538,20 @@ async def run_write_phase(session, mode, rec, registered):
                         TIMEOUTS["remarkable_author"],
                     )
                     dr_state, _ = classify_ok(dr_payload, dr_err, dr_exc)
-                    sub = f"create_document=PASS; add_page={ap_state}; draw={dr_state}"
-                    final = PASS if (ap_state == PASS and dr_state == PASS) else FAIL
+                    sub = (
+                        f"create_document=PASS; daily_notebook={daily_state}; "
+                        f"add_page={ap_state}; draw={dr_state}"
+                    )
+                    final = (
+                        PASS
+                        if (daily_state == PASS and ap_state == PASS and dr_state == PASS)
+                        else FAIL
+                    )
                     rec.record(mode, "remarkable_author", final, sub)
                 else:
-                    rec.record(mode, "remarkable_author", PASS, "create_document=PASS")
+                    final = PASS if daily_state == PASS else FAIL
+                    sub = f"create_document=PASS; daily_notebook={daily_state}"
+                    rec.record(mode, "remarkable_author", final, sub)
             else:
                 rec.record(mode, "remarkable_author", state, note)
 

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -84,6 +84,7 @@ ALL_TOOLS = [
     "remarkable_browse",
     "remarkable_recent",
     "remarkable_search",
+    "remarkable_review",
     "remarkable_read",
     "remarkable_image",
     "remarkable_canvas",
@@ -99,6 +100,7 @@ READ_TOOLS = {
     "remarkable_browse",
     "remarkable_recent",
     "remarkable_search",
+    "remarkable_review",
     "remarkable_read",
     "remarkable_image",
     "remarkable_canvas",
@@ -347,9 +349,10 @@ async def run_read_phase(session, mode, rec, registered):
             mode, "remarkable_search", state, note, _detail_for("remarkable_search", payload)
         )
 
-    # read / image / canvas need a target document
+    # read / review / image / canvas need a target document
     for tool, call_args in (
         ("remarkable_read", {"content_type": "text", "page": 1}),
+        ("remarkable_review", {"output_format": "json"}),
         ("remarkable_image", {"page": 1}),
         ("remarkable_canvas", {"page": 1}),
     ):

--- a/test_server.py
+++ b/test_server.py
@@ -110,13 +110,13 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Cloud default: 6 read tools + always-on canvas + 5 write tools.
+        """Cloud default: read tools + canvas + writes + create-only authoring.
 
-        ``remarkable_author`` is SSH-only and therefore hidden in cloud mode, so
-        the default (cloud) surface is 12 tools, not 13.
+        In cloud mode ``remarkable_author`` is exposed for
+        ``method=create_document`` only; add_page/draw remain SSH-only.
         """
         tools = await mcp.list_tools()
-        assert len(tools) == 12, f"Expected 12 tools, got {len(tools)}"
+        assert len(tools) == 13, f"Expected 13 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -1189,7 +1189,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 12
+        assert len(tools) == 13
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:
@@ -2641,9 +2641,9 @@ class TestWriteTools:
     async def test_write_tools_registered_by_default(self):
         """Write tools ARE registered by default (write-on); read-only would skip them.
 
-        ``remarkable_author`` is intentionally excluded here: it is SSH-only and
-        therefore hidden in cloud mode (the mode these tests import). See
-        ``test_author_only_registered_in_ssh_mode`` for its gating.
+        Cloud mode exposes ``remarkable_author`` for create_document only; SSH
+        exposes the full authoring surface. See
+        ``test_author_registered_in_cloud_and_ssh_only`` for transport gating.
         """
         tools = await mcp.list_tools()
         tool_names = [tool.name for tool in tools]
@@ -2653,6 +2653,7 @@ class TestWriteTools:
             "remarkable_mkdir",
             "remarkable_move",
             "remarkable_rename",
+            "remarkable_author",
             "remarkable_delete",
         ]
 
@@ -2660,9 +2661,6 @@ class TestWriteTools:
             assert tool_name in tool_names, (
                 f"Write tool {tool_name} should be registered by default"
             )
-        assert "remarkable_author" not in tool_names, (
-            "remarkable_author is SSH-only and must be hidden in cloud mode"
-        )
 
     @pytest.mark.asyncio
     async def test_write_tools_registered_when_enabled(self):
@@ -2693,6 +2691,7 @@ class TestWriteTools:
                 "remarkable_mkdir",
                 "remarkable_move",
                 "remarkable_rename",
+                "remarkable_author",
                 "remarkable_delete",
             ]:
                 mcp._tool_manager._tools.pop(name, None)
@@ -2771,6 +2770,7 @@ class TestWriteTools:
                 "remarkable_mkdir",
                 "remarkable_move",
                 "remarkable_rename",
+                "remarkable_author",
                 "remarkable_delete",
             ]:
                 mcp._tool_manager._tools.pop(name, None)
@@ -2835,6 +2835,7 @@ class TestWriteTools:
                 "remarkable_mkdir",
                 "remarkable_move",
                 "remarkable_rename",
+                "remarkable_author",
                 "remarkable_delete",
             ]:
                 mcp._tool_manager._tools.pop(name, None)
@@ -2915,12 +2916,11 @@ class TestWriteTools:
                     mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_author_only_registered_in_ssh_mode(self):
-        """remarkable_author is SSH-only: present in SSH, hidden in cloud and USB web.
+    async def test_author_registered_in_cloud_and_ssh_only(self):
+        """remarkable_author is present in cloud/SSH, hidden in USB web.
 
-        Native ink/notebook authoring has no cloud/USB-web write-back path yet, so
-        rather than registering the tool everywhere and erroring at call time we
-        only expose it in SSH mode.
+        Cloud mode supports create_document only; SSH supports the full
+        create_document/add_page/draw authoring surface.
         """
         from remarkable_mcp.write_tools import register_write_tools
 
@@ -2933,14 +2933,14 @@ class TestWriteTools:
             finally:
                 mcp._tool_manager._tools.pop("remarkable_author", None)
 
-        # Cloud mode -> author hidden.
+        # Cloud mode -> author present for create_document.
         env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
         env.pop("REMARKABLE_USE_USB_WEB", None)
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
                 names = {t.name for t in await mcp.list_tools()}
-                assert "remarkable_author" not in names
+                assert "remarkable_author" in names
             finally:
                 for name in [
                     "remarkable_author",
@@ -2987,6 +2987,7 @@ class TestCloudWriteDispatch:
             "remarkable_mkdir",
             "remarkable_move",
             "remarkable_rename",
+            "remarkable_author",
             "remarkable_delete",
         ]:
             mcp._tool_manager._tools.pop(name, None)
@@ -3010,6 +3011,59 @@ class TestCloudWriteDispatch:
                 assert data["transport"] == "cloud"
                 assert data["uuid"] == "folder-xyz"
                 client.create_folder.assert_called_once_with("Projects", "")
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_author_create_document_dispatch(self):
+        """Cloud remarkable_author supports create_document via the cloud client."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                folder = self._make_item("folder-1", "Inbox", is_folder=True)
+                mock_doc = Mock()
+                mock_doc.id = "new-native-doc"
+                client = Mock(spec=["get_meta_items", "create_notebook"])
+                client.get_meta_items.return_value = [folder]
+                client.create_notebook.return_value = mock_doc
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_author",
+                        {
+                            "method": "create_document",
+                            "name": "Cloud Sketches",
+                            "text": "Agenda\nFollow-ups",
+                            "folder": "/Inbox",
+                        },
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["created"] is True
+                assert data["transport"] == "cloud"
+                assert data["document_id"] == "new-native-doc"
+                assert data["folder"] == "/Inbox"
+                assert data["has_text"] is True
+                client.create_notebook.assert_called_once_with(
+                    "Cloud Sketches", "folder-1", "Agenda\nFollow-ups"
+                )
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_author_rejects_add_page_and_draw(self):
+        """Cloud authoring intentionally exposes create_document only."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                for method in ("add_page", "draw"):
+                    result = await mcp.call_tool(
+                        "remarkable_author", {"method": method, "document": "Notebook"}
+                    )
+                    data = json.loads(result[0][0].text)
+                    assert data["_error"]["type"] == "unsupported_in_cloud"
             finally:
                 self._cleanup()
 
@@ -3202,6 +3256,87 @@ class TestConcurrentToolDispatch:
             f"Concurrent tool calls appear serialized: elapsed={elapsed:.2f}s "
             f"vs single-call delay={call_delay}s"
         )
+
+
+class TestCloudNativeNotebookCreate:
+    """Cloud client can create a native notebook document."""
+
+    def test_create_notebook_uploads_native_notebook_blobs(self, monkeypatch):
+        from remarkable_mcp.sync import Document, RemarkableClient
+
+        client = RemarkableClient(user_token="user-token")
+        uploaded = []
+
+        def fake_upload(content, filename):
+            uploaded.append((filename, content))
+            return {
+                "hash": f"hash-{len(uploaded)}",
+                "type": "0",
+                "id": filename,
+                "subfiles": 0,
+                "size": len(content),
+            }
+
+        monkeypatch.setattr(client, "_upload_file_blob", fake_upload)
+        monkeypatch.setattr(
+            client,
+            "_upload_doc_index",
+            lambda doc_id, files: {
+                "hash": "doc-index-hash",
+                "type": "0",
+                "id": doc_id,
+                "subfiles": len(files),
+                "size": sum(int(f["size"]) for f in files),
+            },
+        )
+        synced_entries = []
+
+        def fake_sync_root(mutate):
+            synced_entries.extend(mutate([]))
+
+        monkeypatch.setattr(client, "_sync_root", fake_sync_root)
+        ids = iter(
+            [
+                "00000000-0000-4000-8000-000000000001",
+                "00000000-0000-4000-8000-000000000002",
+                "00000000-0000-4000-8000-000000000003",
+            ]
+        )
+        monkeypatch.setattr("remarkable_mcp.notebooks.new_uuid", ids.__next__)
+
+        doc = client.create_notebook("Cloud Sketches", parent_id="folder-id", text="Agenda")
+
+        assert isinstance(doc, Document)
+        assert doc.id == "00000000-0000-4000-8000-000000000001"
+        assert doc.name == "Cloud Sketches"
+        assert doc.parent == "folder-id"
+        filenames = [name for name, _content in uploaded]
+        assert filenames == [
+            "00000000-0000-4000-8000-000000000001/00000000-0000-4000-8000-000000000002.rm",
+            "00000000-0000-4000-8000-000000000001.content",
+            "00000000-0000-4000-8000-000000000001.metadata",
+        ]
+        content_data = json.loads(
+            dict(uploaded)["00000000-0000-4000-8000-000000000001.content"].decode("utf-8")
+        )
+        assert content_data["fileType"] == "notebook"
+        assert content_data["pageCount"] == 1
+        assert content_data["cPages"]["pages"][0]["id"] == "00000000-0000-4000-8000-000000000002"
+        metadata = json.loads(
+            dict(uploaded)["00000000-0000-4000-8000-000000000001.metadata"].decode("utf-8")
+        )
+        assert metadata["visibleName"] == "Cloud Sketches"
+        assert metadata["parent"] == "folder-id"
+        assert metadata["type"] == "DocumentType"
+        assert synced_entries == [
+            {
+                "hash": "doc-index-hash",
+                "type": "0",
+                "id": "00000000-0000-4000-8000-000000000001",
+                "subfiles": 3,
+                "size": sum(len(content) for _name, content in uploaded),
+            }
+        ]
 
 
 class TestCloudBlobCache:

--- a/test_server.py
+++ b/test_server.py
@@ -3051,6 +3051,127 @@ class TestCloudWriteDispatch:
                 self._cleanup()
 
     @pytest.mark.asyncio
+    async def test_cloud_author_daily_notebook_creates_missing_notebook(self):
+        """Cloud daily_notebook creates a dated native notebook when absent."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                folder = self._make_item("folder-1", "Inbox", is_folder=True)
+                mock_doc = Mock()
+                mock_doc.id = "daily-doc-id"
+                client = Mock(spec=["get_meta_items", "create_notebook"])
+                client.get_meta_items.return_value = [folder]
+                client.create_notebook.return_value = mock_doc
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_author",
+                        {
+                            "method": "daily_notebook",
+                            "date": "2026-06-24",
+                            "folder": "/Inbox",
+                            "name_format": "Daily Notes {date}",
+                            "text": "Starter notes",
+                        },
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["created"] is True
+                assert data["found"] is False
+                assert data["document"] == "Daily Notes 2026-06-24"
+                assert data["document_id"] == "daily-doc-id"
+                assert data["path"] == "/Inbox/Daily Notes 2026-06-24"
+                assert data["date"] == "2026-06-24"
+                assert data["folder"] == "/Inbox"
+                assert data["transport"] == "cloud"
+                client.create_notebook.assert_called_once_with(
+                    "Daily Notes 2026-06-24", "folder-1", "Starter notes"
+                )
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_author_daily_notebook_returns_existing_notebook(self):
+        """Cloud daily_notebook is idempotent when the notebook already exists."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                folder = self._make_item("folder-1", "Inbox", is_folder=True)
+                existing = self._make_item(
+                    "daily-doc-id", "Daily Notes 2026-06-24", parent="folder-1"
+                )
+                client = Mock(spec=["get_meta_items", "create_notebook"])
+                client.get_meta_items.return_value = [folder, existing]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_author",
+                        {
+                            "method": "daily_notebook",
+                            "date": "2026-06-24",
+                            "folder": "/Inbox",
+                        },
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["created"] is False
+                assert data["found"] is True
+                assert data["document"] == "Daily Notes 2026-06-24"
+                assert data["document_id"] == "daily-doc-id"
+                assert data["path"] == "/Inbox/Daily Notes 2026-06-24"
+                assert data["transport"] == "cloud"
+                client.create_notebook.assert_not_called()
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_author_daily_notebook_rejects_invalid_date(self):
+        """daily_notebook requires an ISO YYYY-MM-DD date when provided."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                client = Mock(spec=["get_meta_items", "create_notebook"])
+                client.get_meta_items.return_value = []
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_author",
+                        {"method": "daily_notebook", "date": "24-06-2026"},
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["_error"]["type"] == "invalid_date"
+                client.create_notebook.assert_not_called()
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_author_daily_notebook_rejects_missing_folder(self):
+        """daily_notebook returns a structured error for missing folders."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                folder = self._make_item("folder-1", "Inbox", is_folder=True)
+                client = Mock(spec=["get_meta_items", "create_notebook"])
+                client.get_meta_items.return_value = [folder]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_author",
+                        {
+                            "method": "daily_notebook",
+                            "date": "2026-06-24",
+                            "folder": "/Missing",
+                        },
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["_error"]["type"] == "folder_not_found"
+                client.create_notebook.assert_not_called()
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
     async def test_cloud_author_rejects_add_page_and_draw(self):
         """Cloud authoring intentionally exposes create_document only."""
         from remarkable_mcp.write_tools import register_write_tools

--- a/test_server.py
+++ b/test_server.py
@@ -100,6 +100,7 @@ class TestMCPServerInitialization:
             "remarkable_browse",
             "remarkable_recent",
             "remarkable_search",
+            "remarkable_review",
             "remarkable_status",
             "remarkable_image",
             "remarkable_canvas",
@@ -110,13 +111,13 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Cloud default: read tools + canvas + writes + create-only authoring.
+        """Cloud default: read tools + canvas + writes + cloud-safe authoring.
 
-        In cloud mode ``remarkable_author`` is exposed for
-        ``method=create_document`` only; add_page/draw remain SSH-only.
+        In cloud mode ``remarkable_author`` is exposed for ``create_document`` and
+        ``daily_notebook``; add_page/draw remain SSH-only.
         """
         tools = await mcp.list_tools()
-        assert len(tools) == 13, f"Expected 13 tools, got {len(tools)}"
+        assert len(tools) == 14, f"Expected 14 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -630,6 +631,160 @@ class TestRemarkableSearch:
 
         assert "_error" in data
         assert data["_error"]["type"] == "no_documents_found"
+
+
+# =============================================================================
+# Test remarkable_review Tool
+# =============================================================================
+
+
+class TestRemarkableReview:
+    """Test remarkable_review export helper."""
+
+    @pytest.mark.asyncio
+    async def test_review_single_document_json_export(self):
+        """Review exports one document as deterministic JSON without summarizing."""
+        read_payload = make_response(
+            {
+                "document": "Daily Notes",
+                "path": "/Daily/Daily Notes",
+                "file_type": "notebook",
+                "content": "todo: review notes",
+                "page": 1,
+                "total_pages": 1,
+                "more": False,
+                "modified": "2026-06-24T10:00:00Z",
+                "tags": ["review"],
+            },
+            "ok",
+        )
+
+        with patch(
+            "remarkable_mcp.tools.remarkable_read", new=AsyncMock(return_value=read_payload)
+        ):
+            result = await mcp.call_tool(
+                "remarkable_review",
+                {"document": "/Daily/Daily Notes", "output_format": "json"},
+            )
+
+        data = json.loads(result[0][0].text)
+        assert data["output_format"] == "json"
+        assert data["scope"] == {"document": "/Daily/Daily Notes"}
+        assert data["count"] == 1
+        assert data["documents"][0]["path"] == "/Daily/Daily Notes"
+        assert data["documents"][0]["content"] == "todo: review notes"
+        assert data["documents"][0]["tags"] == ["review"]
+        assert "summary" not in data["documents"][0]
+
+    @pytest.mark.asyncio
+    async def test_review_single_document_markdown_export(self):
+        """Review can render deterministic Markdown for a document."""
+        read_payload = make_response(
+            {
+                "document": "Daily Notes",
+                "path": "/Daily/Daily Notes",
+                "file_type": "notebook",
+                "content": "archive this",
+                "page": 1,
+                "total_pages": 1,
+                "more": False,
+                "modified": None,
+            },
+            "ok",
+        )
+
+        with patch(
+            "remarkable_mcp.tools.remarkable_read", new=AsyncMock(return_value=read_payload)
+        ):
+            result = await mcp.call_tool(
+                "remarkable_review",
+                {"document": "/Daily/Daily Notes", "output_format": "markdown"},
+            )
+
+        text = result[0][0].text
+        assert text.startswith("# reMarkable review export")
+        assert "## Daily Notes" in text
+        assert "Path: `/Daily/Daily Notes`" in text
+        assert "archive this" in text
+
+    @pytest.mark.asyncio
+    async def test_review_folder_filters_tags_and_since(self):
+        """Folder review exports matching documents using browse metadata."""
+        browse_payload = make_response(
+            {
+                "mode": "browse",
+                "path": "/Daily",
+                "documents": [
+                    {
+                        "name": "Keep",
+                        "path": "/Daily/Keep",
+                        "type": "document",
+                        "modified": "2026-06-24T10:00:00Z",
+                        "tags": ["review"],
+                    },
+                    {
+                        "name": "Old",
+                        "path": "/Daily/Old",
+                        "type": "document",
+                        "modified": "2026-06-20T10:00:00Z",
+                        "tags": ["review"],
+                    },
+                ],
+            },
+            "ok",
+        )
+        read_payload = make_response(
+            {
+                "document": "Keep",
+                "path": "/Daily/Keep",
+                "file_type": "pdf",
+                "content": "review me",
+                "page": 1,
+                "total_pages": 1,
+                "more": False,
+                "modified": "2026-06-24T10:00:00Z",
+                "tags": ["review"],
+            },
+            "ok",
+        )
+
+        with (
+            patch(
+                "remarkable_mcp.tools.remarkable_browse", new=AsyncMock(return_value=browse_payload)
+            ),
+            patch(
+                "remarkable_mcp.tools.remarkable_read", new=AsyncMock(return_value=read_payload)
+            ) as read,
+        ):
+            result = await mcp.call_tool(
+                "remarkable_review",
+                {
+                    "folder": "/Daily",
+                    "tags": ["review"],
+                    "since": "2026-06-23T00:00:00Z",
+                    "output_format": "json",
+                },
+            )
+
+        data = json.loads(result[0][0].text)
+        assert data["scope"] == {
+            "folder": "/Daily",
+            "tags": ["review"],
+            "since": "2026-06-23T00:00:00Z",
+        }
+        assert data["count"] == 1
+        assert data["documents"][0]["path"] == "/Daily/Keep"
+        read.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_review_rejects_invalid_output_format(self):
+        """Review rejects unknown output formats with a structured error."""
+        result = await mcp.call_tool(
+            "remarkable_review",
+            {"document": "Daily Notes", "output_format": "html"},
+        )
+        data = json.loads(result[0][0].text)
+        assert data["_error"]["type"] == "invalid_output_format"
 
 
 # =============================================================================
@@ -1189,7 +1344,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 13
+        assert len(tools) == 14
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:

--- a/test_server.py
+++ b/test_server.py
@@ -102,6 +102,7 @@ class TestMCPServerInitialization:
             "remarkable_search",
             "remarkable_review",
             "remarkable_status",
+            "remarkable_tags",
             "remarkable_image",
             "remarkable_canvas",
         ]
@@ -117,7 +118,7 @@ class TestMCPServerInitialization:
         ``daily_notebook``; add_page/draw remain SSH-only.
         """
         tools = await mcp.list_tools()
-        assert len(tools) == 14, f"Expected 14 tools, got {len(tools)}"
+        assert len(tools) == 15, f"Expected 15 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -1344,7 +1345,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await mcp.list_tools()
 
-        assert len(tools) == 14
+        assert len(tools) == 15
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:
@@ -3323,6 +3324,59 @@ class TestCloudWriteDispatch:
                 data = json.loads(result[0][0].text)
                 assert data["_error"]["type"] == "folder_not_found"
                 client.create_notebook.assert_not_called()
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_tags_sets_status_and_preserves_other_tags(self):
+        """remarkable_tags sets official metadata tags through the cloud client."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Daily Notes")
+                target.tags = ["todo", "project"]
+                client = Mock(spec=["get_meta_items", "set_tags"])
+                client.get_meta_items.return_value = [target]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_tags",
+                        {
+                            "document": "Daily Notes",
+                            "tags": ["project"],
+                            "status": "review",
+                        },
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["document"] == "Daily Notes"
+                assert data["previous_tags"] == ["todo", "project"]
+                assert data["tags"] == ["project", "review"]
+                assert data["status"] == "review"
+                client.set_tags.assert_called_once_with("doc-1", ["project", "review"])
+            finally:
+                self._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cloud_tags_rejects_invalid_status(self):
+        """remarkable_tags only accepts documented status labels."""
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, self._cloud_env(), clear=True):
+            register_write_tools()
+            try:
+                target = self._make_item("doc-1", "Daily Notes")
+                target.tags = []
+                client = Mock(spec=["get_meta_items", "set_tags"])
+                client.get_meta_items.return_value = [target]
+                with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
+                    result = await mcp.call_tool(
+                        "remarkable_tags",
+                        {"document": "Daily Notes", "status": "blocked"},
+                    )
+                data = json.loads(result[0][0].text)
+                assert data["_error"]["type"] == "invalid_status"
+                client.set_tags.assert_not_called()
             finally:
                 self._cleanup()
 


### PR DESCRIPTION
## Summary
- add `remarkable_tags` for official reMarkable metadata tags
- treat simple statuses (`review`, `todo`, `archive`) as normal tags rather than private/custom metadata
- support Cloud and SSH metadata updates; keep USB web unsupported because it has no metadata-write endpoint

## Notes
This is intentionally stacked on the existing open work, so the PR diff may include earlier commits from #127 and #128 until those land. I can rebase/split it cleanly afterward if that is easier for review.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run python -m pytest -q`
- `uv run python smoke/run_smoke.py --modes cloud`
