### PR TITLE
fix(ssh): batch xochitl restarts to eliminate bulk-write races

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, and `remarkable_author` for native ink/notebooks) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
+These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, `remarkable_refresh`, and `remarkable_author` for native ink/notebooks) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -478,11 +478,12 @@ Or set the environment variable:
 
 | Tool | Description |
 |------|-------------|
-| `remarkable_upload(file_path, parent_folder, document_name)` | Upload a PDF or EPUB file (all modes; USB web ignores folder/name and uploads to root) |
-| `remarkable_mkdir(folder_name, parent)` | Create a new folder (cloud and SSH) |
-| `remarkable_move(document, dest_folder)` | Move a document or folder (cloud and SSH) |
-| `remarkable_rename(document, new_name)` | Rename a document or folder (cloud and SSH) |
-| `remarkable_delete(document)` | Delete a document or folder — destructive (cloud and SSH) |
+| `remarkable_upload(file_path, parent_folder, document_name, defer_restart)` | Upload a PDF or EPUB file (all modes; USB web ignores folder/name and uploads to root) |
+| `remarkable_mkdir(folder_name, parent, defer_restart)` | Create a new folder (cloud and SSH) |
+| `remarkable_move(document, dest_folder, defer_restart)` | Move a document or folder (cloud and SSH) |
+| `remarkable_rename(document, new_name, defer_restart)` | Rename a document or folder (cloud and SSH) |
+| `remarkable_delete(document, defer_restart)` | Delete a document or folder — destructive (cloud and SSH) |
+| `remarkable_refresh()` | Restart `xochitl` once to apply writes made with `defer_restart=True` — **SSH only** |
 | `remarkable_author(method, ...)` | Author native ink and notebooks — `draw` (append strokes), `add_page` (append a blank notebook page), `create_document` (new notebook) — **SSH only** |
 
 ### Safety
@@ -490,7 +491,7 @@ Or set the environment variable:
 - **Upload registers in all modes** — cloud, SSH, and USB web.
 - **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
 - **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
-- After each write operation in SSH mode, the tablet UI restarts automatically to reflect changes.
+- After each write operation in SSH mode, the tablet UI (`xochitl`) restarts automatically to reflect changes; the call waits for it to come back before returning so the next write doesn't race a restarting daemon. For bulk operations, pass `defer_restart=True` to each write — or set `REMARKABLE_DEFER_RESTART=1` — and call `remarkable_refresh()` once at the end, so the batch triggers a single restart instead of one per write (each restart forces a full document-store rescan).
 
 ### Examples
 
@@ -509,6 +510,12 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 
 # Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
+
+# Bulk import (SSH): defer the restart on each write, then refresh once.
+# One xochitl restart for the whole batch instead of one per upload.
+remarkable_upload("a.pdf", parent_folder="/Research", defer_restart=True)
+remarkable_upload("b.pdf", parent_folder="/Research", defer_restart=True)
+remarkable_refresh()
 
 # Author native ink and notebooks (SSH only)
 # Append pen/highlighter strokes to a page (coordinates normalized [0,1] from

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -187,6 +187,9 @@ Note: WiFi is slower than USB but works from anywhere on your network.
 | `REMARKABLE_SSH_PORT` | `22` | SSH port |
 | `REMARKABLE_SSH_PASSWORD` | *(none)* | SSH password (requires `sshpass`, key auth recommended) |
 | `REMARKABLE_SSH_KEY` | *(none)* | Path to a private key for key auth. Pins this on-disk identity (`IdentitiesOnly`) and ignores any ssh-agent. |
+| `REMARKABLE_RESTART_TIMEOUT` | `30` | Max seconds to wait for `xochitl` to report active again after a write restarts it |
+| `REMARKABLE_RESTART_POLL_INTERVAL` | `1` | Seconds between `systemctl is-active` polls while waiting for `xochitl` |
+| `REMARKABLE_RESTART_SETTLE` | `3` | Extra settle delay (seconds) after `xochitl` is active, before the next operation runs |
 
 ## Troubleshooting
 

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -190,6 +190,7 @@ Note: WiFi is slower than USB but works from anywhere on your network.
 | `REMARKABLE_RESTART_TIMEOUT` | `30` | Max seconds to wait for `xochitl` to report active again after a write restarts it |
 | `REMARKABLE_RESTART_POLL_INTERVAL` | `1` | Seconds between `systemctl is-active` polls while waiting for `xochitl` |
 | `REMARKABLE_RESTART_SETTLE` | `3` | Extra settle delay (seconds) after `xochitl` is active, before the next operation runs |
+| `REMARKABLE_DEFER_RESTART` | *(unset)* | When set (`1`/`true`/`yes`), write tools skip their per-write `xochitl` restart; call `remarkable_refresh` once to apply a whole batch with a single restart |
 
 ## Troubleshooting
 

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -153,10 +153,14 @@ Write operations are enabled. These tools modify your tablet's filesystem:
 - `remarkable_move(document, dest_folder)` - Move a document/folder
 - `remarkable_rename(document, new_name)` - Rename a document/folder
 - `remarkable_delete(document)` - Delete a document/folder (destructive)
+- `remarkable_refresh()` - Restart xochitl once to apply writes deferred with `defer_restart=True`
 
 ### Safety
 - **Delete is destructive** and immediate — the MCP client should confirm with the user first
-- After each write operation, the tablet UI restarts automatically
+- After each write operation, the tablet UI restarts automatically (the call waits for it
+  to settle). For batches, pass `defer_restart=True` to each write (or set
+  `REMARKABLE_DEFER_RESTART=1`) and call `remarkable_refresh()` once at the end, to restart
+  a single time instead of once per write
 - Use `remarkable_browse()` to verify changes after write operations
 - Run with `--read-only` to disable all write tools
 """

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -191,9 +191,50 @@ def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str)
             raise RuntimeError("SSH upload timed out after 120s")
 
 
-def _restart_xochitl(ssh_client: SSHClient) -> None:
-    """Restart the xochitl UI service on the tablet."""
-    ssh_client._ssh_command("systemctl restart xochitl", timeout=15)
+# Tunables for the post-restart readiness wait (see _restart_xochitl). All are
+# overridable by env var so the wait can be tightened or relaxed per device
+# without code changes.
+_RESTART_READY_TIMEOUT = float(os.environ.get("REMARKABLE_RESTART_TIMEOUT", "30"))
+_RESTART_POLL_INTERVAL = float(os.environ.get("REMARKABLE_RESTART_POLL_INTERVAL", "1"))
+_RESTART_SETTLE_SECONDS = float(os.environ.get("REMARKABLE_RESTART_SETTLE", "3"))
+
+
+def _restart_xochitl(ssh_client: SSHClient, wait_ready: bool = True) -> None:
+    """Restart the xochitl UI service so it picks up metadata changes.
+
+    Restarting forces xochitl to rescan the entire document store. On the
+    resource-constrained tablet that briefly starves the SSH daemon, so a
+    follow-up write issued immediately can land mid-rescan and have its
+    connection refused or torn down — the "race" seen during bulk operations.
+
+    To avoid that, after issuing the restart we poll ``systemctl is-active``
+    until xochitl reports ``active`` again, then add a short settle delay so the
+    rescan-driven CPU/IO spike has subsided before we return. The call therefore
+    only completes once the tablet is ready for the next operation. Pass
+    ``wait_ready=False`` to restore the old fire-and-return behaviour.
+    """
+    ssh_client._ssh_command("systemctl restart xochitl", timeout=30)
+    if not wait_ready:
+        return
+
+    deadline = time.monotonic() + _RESTART_READY_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            state = ssh_client._ssh_command("systemctl is-active xochitl", timeout=10).strip()
+        except RuntimeError:
+            # While the unit is still activating, `is-active` exits non-zero
+            # (surfaced as RuntimeError) and the SSH layer itself may be briefly
+            # refusing connections. Either way it isn't ready yet — keep polling.
+            state = "activating"
+        if state == "active":
+            break
+        time.sleep(_RESTART_POLL_INTERVAL)
+
+    # `systemctl restart` returns once the process is respawned, but the store
+    # rescan continues afterwards; settle briefly so the next reconnect lands
+    # after the spike rather than during it.
+    if _RESTART_SETTLE_SECONDS > 0:
+        time.sleep(_RESTART_SETTLE_SECONDS)
 
 
 def _page_ids_from_content(content_data: dict) -> list:

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -237,6 +237,51 @@ def _restart_xochitl(ssh_client: SSHClient, wait_ready: bool = True) -> None:
         time.sleep(_RESTART_SETTLE_SECONDS)
 
 
+def _defer_restart_enabled() -> bool:
+    """Whether xochitl restarts should be deferred by default (env override).
+
+    Set REMARKABLE_DEFER_RESTART=1 to make every write skip its own restart, so
+    a batch of writes pays the restart cost (and its race surface) exactly once
+    via remarkable_refresh instead of once per write.
+    """
+    return os.environ.get("REMARKABLE_DEFER_RESTART", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _maybe_restart_xochitl(ssh_client: SSHClient, defer_restart: bool = False) -> bool:
+    """Restart xochitl unless deferral is requested (per-call arg or env).
+
+    Returns True if a restart was performed, False if it was deferred. When
+    deferred the on-disk metadata has changed but xochitl has not yet rescanned,
+    so the caller must run remarkable_refresh once the batch is complete for the
+    changes to become visible in the UI.
+    """
+    if defer_restart or _defer_restart_enabled():
+        return False
+    _restart_xochitl(ssh_client)
+    return True
+
+
+def _write_result_message(
+    restarted: bool,
+    done: str,
+    verify: str = "Use remarkable_browse() to verify.",
+) -> str:
+    """Build a write tool's success message, accounting for restart deferral.
+
+    ``done`` is the past-tense summary of what happened (e.g. "Document
+    moved."). When the restart ran, ``verify`` tells the user how to confirm the
+    change; when it was deferred, the user is instead reminded to call
+    remarkable_refresh once their batch is complete.
+    """
+    if restarted:
+        return f"{done} {verify}"
+    return f"{done} Restart deferred — call remarkable_refresh() once your batch is done."
+
+
 def _page_ids_from_content(content_data: dict) -> list:
     """Return ordered page ids from a parsed ``.content`` file.
 
@@ -685,7 +730,7 @@ def _author_draw(document: str, page: int, strokes: list, ui_submitted: bool) ->
         if not _remote_file_exists(ssh_client, bak_path):
             _write_remote_bytes(ssh_client, bak_path, original)
     _write_remote_bytes(ssh_client, rm_path, new_bytes)
-    _restart_xochitl(ssh_client)
+    _maybe_restart_xochitl(ssh_client)
 
     result = {
         "written": True,
@@ -778,7 +823,7 @@ def _author_add_page(document: str) -> str:
 
     _write_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}/{new_page_id}.rm", page_bytes)
     _write_content_file(ssh_client, doc_uuid, updated["content"])
-    _restart_xochitl(ssh_client)
+    _maybe_restart_xochitl(ssh_client)
     _invalidate_client_cache(ssh_client)
 
     result = {
@@ -832,7 +877,7 @@ def _author_create_document(name: str, text: Optional[str], folder: Optional[str
     _write_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm", page_bytes)
     _write_content_file(ssh_client, doc_uuid, content_data)
     _write_metadata(ssh_client, doc_uuid, metadata)
-    _restart_xochitl(ssh_client)
+    _maybe_restart_xochitl(ssh_client)
     _invalidate_client_cache(ssh_client)
 
     result = {
@@ -966,6 +1011,7 @@ def register_write_tools():
         file_path: str,
         parent_folder: str = "/",
         document_name: Optional[str] = None,
+        defer_restart: bool = False,
     ) -> str:
         """
         <usecase>Upload a PDF or EPUB file to the reMarkable tablet.</usecase>
@@ -985,11 +1031,22 @@ def register_write_tools():
           Honored in cloud and SSH modes; ignored by the USB web interface.
         - document_name: Display name on tablet (default: filename without
           extension). Honored in cloud and SSH modes; ignored by the USB web interface.
+        - defer_restart: SSH only. When True, skip the xochitl restart that
+          normally makes the upload visible. Use this for every upload in a
+          batch, then call remarkable_refresh() ONCE at the end. Each restart
+          forces a full document-store rescan that briefly destabilises the SSH
+          link, so deferring turns N restarts (and N races) into one. The
+          response sets "refresh_pending": true while a refresh is owed. Ignored
+          in cloud/USB modes (no xochitl).
         </parameters>
         <examples>
         - remarkable_upload("/tmp/paper.pdf")
         - remarkable_upload("/tmp/book.epub", parent_folder="/Books")
         - remarkable_upload("/tmp/report.pdf", document_name="Q4 Report")
+        - # batch import: defer every upload, refresh once at the end
+          remarkable_upload("/tmp/a.pdf", defer_restart=True)
+          remarkable_upload("/tmp/b.pdf", defer_restart=True)
+          remarkable_refresh()
         </examples>
         """
 
@@ -1124,8 +1181,8 @@ def register_write_tools():
                 # Create the document directory (required by xochitl)
                 ssh_client._ssh_command(f"mkdir -p '{XOCHITL_PATH}/{doc_uuid}'")
 
-                # Restart xochitl to pick up changes
-                _restart_xochitl(ssh_client)
+                # Restart xochitl to pick up changes (unless deferred for a batch)
+                restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
                 # Clear cached documents so next read picks up the new doc
                 ssh_client._documents = []
@@ -1140,8 +1197,13 @@ def register_write_tools():
                         "parent_folder": parent_folder,
                         "remote_path": remote_file,
                         "transport": "ssh",
+                        "refresh_pending": not restarted,
                     },
-                    "Document uploaded successfully. Use remarkable_browse() to verify it appears.",
+                    _write_result_message(
+                        restarted,
+                        "Document uploaded successfully.",
+                        "Use remarkable_browse() to verify it appears.",
+                    ),
                 )
 
             except Exception as e:
@@ -1160,6 +1222,7 @@ def register_write_tools():
         async def remarkable_mkdir(
             folder_name: str,
             parent: str = "/",
+            defer_restart: bool = False,
         ) -> str:
             """
             <usecase>Create a new folder on the reMarkable tablet.</usecase>
@@ -1174,6 +1237,9 @@ def register_write_tools():
             <parameters>
             - folder_name: Name of the new folder
             - parent: Parent folder path (default: root "/")
+            - defer_restart: SSH only. Skip the xochitl restart so a batch of
+              writes can refresh once via remarkable_refresh() instead of once
+              per write. Sets "refresh_pending": true. Ignored in cloud mode.
             </parameters>
             <examples>
             - remarkable_mkdir("Projects")
@@ -1222,8 +1288,8 @@ def register_write_tools():
                     }
                     _write_metadata(ssh_client, doc_uuid, metadata)
 
-                    # Restart xochitl
-                    _restart_xochitl(ssh_client)
+                    # Restart xochitl (unless deferred for a batch)
+                    restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
                     # Clear cache
                     ssh_client._documents = []
@@ -1235,8 +1301,9 @@ def register_write_tools():
                             "folder_name": folder_name,
                             "uuid": doc_uuid,
                             "parent": parent,
+                            "refresh_pending": not restarted,
                         },
-                        "Folder created. Use remarkable_browse() to verify.",
+                        _write_result_message(restarted, "Folder created."),
                     )
 
                 except Exception as e:
@@ -1252,6 +1319,7 @@ def register_write_tools():
         async def remarkable_move(
             document: str,
             dest_folder: str,
+            defer_restart: bool = False,
         ) -> str:
             """
             <usecase>Move a document or folder to a different location.</usecase>
@@ -1265,6 +1333,9 @@ def register_write_tools():
             <parameters>
             - document: Name or path of the document/folder to move
             - dest_folder: Destination folder path (use "/" for root)
+            - defer_restart: SSH only. Skip the xochitl restart so a batch of
+              writes can refresh once via remarkable_refresh() instead of once
+              per write. Sets "refresh_pending": true. Ignored in cloud mode.
             </parameters>
             <examples>
             - remarkable_move("Meeting Notes", "/Archive")
@@ -1342,8 +1413,8 @@ def register_write_tools():
                     metadata["metadatamodified"] = True
                     _write_metadata(ssh_client, target.ID, metadata)
 
-                    # Restart xochitl
-                    _restart_xochitl(ssh_client)
+                    # Restart xochitl (unless deferred for a batch)
+                    restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
                     # Clear cache
                     ssh_client._documents = []
@@ -1355,8 +1426,9 @@ def register_write_tools():
                             "name": target.VissibleName,
                             "from": old_path,
                             "to": dest_folder,
+                            "refresh_pending": not restarted,
                         },
-                        "Document moved. Use remarkable_browse() to verify.",
+                        _write_result_message(restarted, "Document moved."),
                     )
 
                 except Exception as e:
@@ -1372,6 +1444,7 @@ def register_write_tools():
         async def remarkable_rename(
             document: str,
             new_name: str,
+            defer_restart: bool = False,
         ) -> str:
             """
             <usecase>Rename a document or folder on the reMarkable tablet.</usecase>
@@ -1385,6 +1458,9 @@ def register_write_tools():
             <parameters>
             - document: Current name or path of the document/folder
             - new_name: New display name
+            - defer_restart: SSH only. Skip the xochitl restart so a batch of
+              writes can refresh once via remarkable_refresh() instead of once
+              per write. Sets "refresh_pending": true. Ignored in cloud mode.
             </parameters>
             <examples>
             - remarkable_rename("Untitled", "Meeting Notes 2024-01-15")
@@ -1430,8 +1506,8 @@ def register_write_tools():
                     metadata["metadatamodified"] = True
                     _write_metadata(ssh_client, target.ID, metadata)
 
-                    # Restart xochitl
-                    _restart_xochitl(ssh_client)
+                    # Restart xochitl (unless deferred for a batch)
+                    restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
                     # Clear cache
                     ssh_client._documents = []
@@ -1442,8 +1518,9 @@ def register_write_tools():
                             "renamed": True,
                             "old_name": old_name,
                             "new_name": new_name,
+                            "refresh_pending": not restarted,
                         },
-                        "Document renamed. Use remarkable_browse() to verify.",
+                        _write_result_message(restarted, "Document renamed."),
                     )
 
                 except Exception as e:
@@ -1456,7 +1533,11 @@ def register_write_tools():
             return await asyncio.to_thread(_impl)
 
         @mcp.tool(annotations=DELETE_ANNOTATIONS)
-        async def remarkable_delete(document: str, ctx: Optional[Context] = None) -> str:
+        async def remarkable_delete(
+            document: str,
+            defer_restart: bool = False,
+            ctx: Optional[Context] = None,
+        ) -> str:
             """
             <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
             <instructions>
@@ -1474,6 +1555,9 @@ def register_write_tools():
             </instructions>
             <parameters>
             - document: Name or path of the document/folder to delete
+            - defer_restart: SSH only. Skip the xochitl restart so a batch of
+              deletes can refresh once via remarkable_refresh() instead of once
+              per delete. Sets "refresh_pending": true. Ignored in cloud mode.
             </parameters>
             <examples>
             - remarkable_delete("Old Notes")
@@ -1522,8 +1606,8 @@ def register_write_tools():
                     metadata["metadatamodified"] = True
                     _write_metadata(ssh_client, target.ID, metadata)
 
-                    # Restart xochitl
-                    _restart_xochitl(ssh_client)
+                    # Restart xochitl (unless deferred for a batch)
+                    restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
                     # Clear cache
                     ssh_client._documents = []
@@ -1535,8 +1619,13 @@ def register_write_tools():
                             "name": target.VissibleName,
                             "path": doc_path,
                             "type": "folder" if target.is_folder else "document",
+                            "refresh_pending": not restarted,
                         },
-                        "Document deleted. It will no longer appear on the tablet.",
+                        _write_result_message(
+                            restarted,
+                            "Document deleted.",
+                            "It will no longer appear on the tablet.",
+                        ),
                     )
 
                 except Exception as e:
@@ -1547,3 +1636,57 @@ def register_write_tools():
                     )
 
             return await asyncio.to_thread(_impl)
+
+    async def remarkable_refresh() -> str:
+        """
+        <usecase>Restart xochitl once to apply writes made with
+        defer_restart=True (or with REMARKABLE_DEFER_RESTART set).</usecase>
+        <instructions>
+        SSH only. Each write normally restarts xochitl so the change becomes
+        visible, but every restart forces a full document-store rescan that
+        briefly destabilises the SSH link. For a batch of writes, pass
+        defer_restart=True to each one and then call this tool ONCE at the end:
+        it pays the restart cost a single time instead of once per write,
+        eliminating the per-write race and the redundant rescans.
+
+        Calling it when nothing is pending is harmless — it just restarts the UI.
+        Requires write mode (the default; disabled with --read-only).
+        </instructions>
+        <parameters>(none)</parameters>
+        <examples>
+        - remarkable_upload("/tmp/a.pdf", defer_restart=True)
+          remarkable_upload("/tmp/b.pdf", defer_restart=True)
+          remarkable_refresh()
+        </examples>
+        """
+
+        def _impl() -> str:
+            error = _require_write_transport()
+            if error:
+                return error
+
+            try:
+                ssh_client = _get_ssh_client()
+                _restart_xochitl(ssh_client)
+                # Drop any cache populated while restarts were deferred so the
+                # next read reflects the just-applied changes.
+                ssh_client._documents = []
+                ssh_client._documents_by_id = {}
+                return make_response(
+                    {"refreshed": True, "transport": "ssh"},
+                    "xochitl restarted; any deferred changes are now visible. "
+                    "Use remarkable_browse() to verify.",
+                )
+            except Exception as e:
+                return make_error(
+                    error_type="refresh_failed",
+                    message=f"Failed to refresh tablet UI: {e}",
+                    suggestion="Check SSH connection and try again.",
+                )
+
+        return await asyncio.to_thread(_impl)
+
+    # Refreshing is meaningful only for the SSH transport's xochitl restart;
+    # cloud/USB clients have no equivalent, so the tool is hidden there.
+    if _is_ssh_mode():
+        mcp.tool(annotations=WRITE_ANNOTATIONS)(remarkable_refresh)

--- a/test_server.py
+++ b/test_server.py
@@ -4787,3 +4787,91 @@ class TestGetDocumentFileType:
             assert get_document_file_type(zpath) == ""
         finally:
             zpath.unlink(missing_ok=True)
+
+
+class TestRestartXochitl:
+    """_restart_xochitl waits for the UI to come back before returning.
+
+    Restarting xochitl forces a document-store rescan that briefly starves the
+    SSH daemon. The readiness wait is what prevents a following write from
+    landing mid-rescan and racing on a refused/dropped connection.
+    """
+
+    @staticmethod
+    def _ssh_client(is_active_sequence):
+        """Mock SSHClient whose `_ssh_command` dispatches on the command text.
+
+        `is_active_sequence` is consumed one entry per `systemctl is-active`
+        call: a string is returned as stdout; a RuntimeError instance is raised
+        (mirroring how the SSH layer surfaces a non-zero `is-active` exit while
+        the unit is still activating).
+        """
+        states = iter(is_active_sequence)
+        calls = []
+
+        def _command(command, timeout=30):
+            calls.append(command)
+            if "is-active" in command:
+                state = next(states)
+                if isinstance(state, Exception):
+                    raise state
+                return state
+            return ""
+
+        client = Mock(spec=["_ssh_command"])
+        client._ssh_command.side_effect = _command
+        client.calls = calls
+        return client
+
+    def test_restarts_then_reports_ready_on_first_active(self):
+        from remarkable_mcp import write_tools
+
+        client = self._ssh_client(["active\n"])
+        with patch("remarkable_mcp.write_tools.time.sleep") as mock_sleep:
+            write_tools._restart_xochitl(client)
+
+        assert client.calls[0] == "systemctl restart xochitl"
+        assert any("is-active" in c for c in client.calls)
+        # No poll-interval sleeps when active on the first probe; only the final
+        # settle delay runs.
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args_list[0].args[0] == write_tools._RESTART_SETTLE_SECONDS
+
+    def test_polls_until_active(self):
+        from remarkable_mcp import write_tools
+
+        client = self._ssh_client(["activating\n", "activating\n", "active\n"])
+        with patch("remarkable_mcp.write_tools.time.sleep") as mock_sleep:
+            write_tools._restart_xochitl(client)
+
+        is_active_calls = [c for c in client.calls if "is-active" in c]
+        assert len(is_active_calls) == 3
+        # Two poll-interval waits between the three probes, then one settle wait.
+        sleeps = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleeps == [
+            write_tools._RESTART_POLL_INTERVAL,
+            write_tools._RESTART_POLL_INTERVAL,
+            write_tools._RESTART_SETTLE_SECONDS,
+        ]
+
+    def test_command_failure_is_treated_as_not_ready(self):
+        from remarkable_mcp import write_tools
+
+        # is-active raises (non-zero exit while activating) before succeeding;
+        # the error must not propagate — keep polling instead.
+        client = self._ssh_client([RuntimeError("SSH command failed"), "active\n"])
+        with patch("remarkable_mcp.write_tools.time.sleep"):
+            write_tools._restart_xochitl(client)
+
+        assert len([c for c in client.calls if "is-active" in c]) == 2
+
+    def test_wait_ready_false_skips_poll(self):
+        from remarkable_mcp import write_tools
+
+        client = self._ssh_client([])
+        with patch("remarkable_mcp.write_tools.time.sleep") as mock_sleep:
+            write_tools._restart_xochitl(client, wait_ready=False)
+
+        assert client.calls == ["systemctl restart xochitl"]
+        assert not any("is-active" in c for c in client.calls)
+        mock_sleep.assert_not_called()

--- a/test_server.py
+++ b/test_server.py
@@ -4875,3 +4875,174 @@ class TestRestartXochitl:
         assert client.calls == ["systemctl restart xochitl"]
         assert not any("is-active" in c for c in client.calls)
         mock_sleep.assert_not_called()
+
+
+class TestDeferRestart:
+    """Writes can defer the xochitl restart so a batch refreshes once.
+
+    Each write normally restarts xochitl; deferral lets N writes skip their
+    restarts and apply them all with a single remarkable_refresh, turning N
+    rescans (and N races) into one.
+    """
+
+    # Tool names registered by register_write_tools(); popped between tests so
+    # repeated registration across the suite stays hermetic.
+    _REGISTERED = [
+        "remarkable_upload",
+        "remarkable_mkdir",
+        "remarkable_move",
+        "remarkable_rename",
+        "remarkable_delete",
+        "remarkable_refresh",
+        "remarkable_author",
+    ]
+
+    @classmethod
+    def _cleanup_tools(cls):
+        for name in cls._REGISTERED:
+            mcp._tool_manager._tools.pop(name, None)
+
+    @staticmethod
+    def _make_ssh_client():
+        client = Mock(
+            spec=[
+                "get_meta_items",
+                "_ssh_command",
+                "_scp_download",
+                "_documents",
+                "_documents_by_id",
+            ]
+        )
+        client.get_meta_items.return_value = []
+        return client
+
+    def test_defer_restart_enabled_reads_env(self, monkeypatch):
+        from remarkable_mcp import write_tools
+
+        monkeypatch.delenv("REMARKABLE_DEFER_RESTART", raising=False)
+        assert write_tools._defer_restart_enabled() is False
+        monkeypatch.setenv("REMARKABLE_DEFER_RESTART", "1")
+        assert write_tools._defer_restart_enabled() is True
+
+    def test_maybe_restart_honors_per_call_defer(self):
+        from remarkable_mcp import write_tools
+
+        client = self._make_ssh_client()
+        with (
+            patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
+            patch("remarkable_mcp.write_tools._defer_restart_enabled", return_value=False),
+        ):
+            assert write_tools._maybe_restart_xochitl(client, defer_restart=True) is False
+            mock_restart.assert_not_called()
+            assert write_tools._maybe_restart_xochitl(client, defer_restart=False) is True
+            mock_restart.assert_called_once_with(client)
+
+    def test_maybe_restart_honors_env_defer(self):
+        from remarkable_mcp import write_tools
+
+        client = self._make_ssh_client()
+        with (
+            patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
+            patch("remarkable_mcp.write_tools._defer_restart_enabled", return_value=True),
+        ):
+            # env defers even though the per-call argument is False
+            assert write_tools._maybe_restart_xochitl(client, defer_restart=False) is False
+            mock_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_defer_skips_restart_and_flags_pending(self, tmp_path):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+        try:
+            client = self._make_ssh_client()
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                patch("remarkable_mcp.write_tools._upload_file_bytes"),
+                patch("remarkable_mcp.write_tools._write_metadata"),
+                patch("remarkable_mcp.write_tools._write_content_file"),
+                patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
+                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            ):
+                result = await mcp.call_tool(
+                    "remarkable_upload",
+                    {"file_path": str(pdf), "defer_restart": True},
+                )
+                data = json.loads(result[0][0].text)
+                assert data["uploaded"] is True
+                assert data["refresh_pending"] is True
+                mock_restart.assert_not_called()
+        finally:
+            self._cleanup_tools()
+
+    @pytest.mark.asyncio
+    async def test_upload_without_defer_restarts_and_clears_flag(self, tmp_path):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+        try:
+            client = self._make_ssh_client()
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                patch("remarkable_mcp.write_tools._upload_file_bytes"),
+                patch("remarkable_mcp.write_tools._write_metadata"),
+                patch("remarkable_mcp.write_tools._write_content_file"),
+                patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
+                patch("remarkable_mcp.write_tools._defer_restart_enabled", return_value=False),
+                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            ):
+                result = await mcp.call_tool(
+                    "remarkable_upload",
+                    {"file_path": str(pdf)},
+                )
+                data = json.loads(result[0][0].text)
+                assert data["uploaded"] is True
+                assert data["refresh_pending"] is False
+                mock_restart.assert_called_once_with(client)
+        finally:
+            self._cleanup_tools()
+
+    @pytest.mark.asyncio
+    async def test_refresh_tool_registered_in_ssh_and_restarts_once(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+        try:
+            tools = await mcp.list_tools()
+            assert "remarkable_refresh" in [t.name for t in tools]
+
+            client = self._make_ssh_client()
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
+                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            ):
+                result = await mcp.call_tool("remarkable_refresh", {})
+                data = json.loads(result[0][0].text)
+                assert data["refreshed"] is True
+                mock_restart.assert_called_once_with(client)
+        finally:
+            self._cleanup_tools()
+
+    @pytest.mark.asyncio
+    async def test_refresh_tool_hidden_in_cloud_mode(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        env = {k: v for k, v in os.environ.items() if k != "REMARKABLE_USE_SSH"}
+        env.pop("REMARKABLE_USE_USB_WEB", None)
+        with patch.dict(os.environ, env, clear=True):
+            register_write_tools()
+            try:
+                tools = await mcp.list_tools()
+                assert "remarkable_refresh" not in [t.name for t in tools]
+            finally:
+                self._cleanup_tools()


### PR DESCRIPTION
## Problem

In SSH mode every write (`upload`/`mkdir`/`move`/`rename`/`delete`) restarts `xochitl` so the change becomes visible. Each restart forces a full rescan of the document store, which briefly starves the SSH daemon on the resource-constrained tablet. During a bulk operation, the next write lands mid-rescan and its connection is refused or torn down — a race that gets worse the larger the store grows.

## Changes

**1. Wait for `xochitl` to settle after a restart** (`c3114dc`)
`_restart_xochitl` now polls `systemctl is-active` until `xochitl` reports `active`, then waits a short settle delay before returning, so the next operation reconnects *after* the rescan spike rather than during it. Tunable via env vars (with sensible defaults):
- `REMARKABLE_RESTART_TIMEOUT` (30s) — max wait for `active`
- `REMARKABLE_RESTART_POLL_INTERVAL` (1s) — poll cadence
- `REMARKABLE_RESTART_SETTLE` (3s) — post-active settle delay

**2. Defer the restart to batch writes** (`17bcf21`)
Every write tool gains an opt-in `defer_restart: bool = False` parameter. When `True`, the write skips its own restart and reports `"refresh_pending": true`. A new `remarkable_refresh()` tool (SSH-only) restarts `xochitl` exactly once at the end of a batch. A `REMARKABLE_DEFER_RESTART=1` env var makes deferral the default. This turns an N-write import from N restarts (and N races) into 0-during-the-writes + 1 at refresh.

```
remarkable_upload("/tmp/a.pdf", defer_restart=True)
remarkable_upload("/tmp/b.pdf", defer_restart=True)
remarkable_refresh()
```

## Backwards compatibility

Fully backwards compatible. `defer_restart` defaults to `False` everywhere, so existing calls behave exactly as before (just with the sturdier restart wait). Responses only gain an additive `refresh_pending` field. `remarkable_refresh` is new and SSH-only. The one non-append-only signature change is `remarkable_delete` (the param is inserted before the framework-injected `ctx`), which is safe because tools are invoked by name.

## Verification

- Full suite: **219 passed**.
- **Live PID-counted test against a real tablet**: a non-deferred write restarts `xochitl` (PID changes); a batch of 3 deferred writes leaves the PID unchanged (zero restarts); `remarkable_refresh()` restarts exactly once and the deferred changes become visible.
- **Real-world bulk import**: recreated a 6-folder / 24-PDF directory tree as **31 deferred writes + one refresh**. `xochitl` MainPID stayed frozen through all 31 writes (0 restarts), the single refresh applied everything, and all 24 PDFs landed in the correct subfolders. On `main` this same import would have fired 31 restarts/rescans — the exact storm behind the original races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
