### PR TITLE
Fix and complete render_merged for imported PDFs

### DIFF
--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -67,6 +67,7 @@ def _rm_units_per_point(paper_size: Optional[tuple] = None) -> float:
     """
     return REMARKABLE_COORD_DPI / 72.0
 
+
 # Standard reMarkable background color (light cream/gray)
 # Can be overridden via REMARKABLE_BACKGROUND_COLOR environment variable
 _DEFAULT_BACKGROUND_COLOR = "#FBFBFB"
@@ -1149,9 +1150,7 @@ def _get_page_order(tmpdir_path: Path) -> List[str]:
     return []
 
 
-def _select_rm_file_for_page(
-    tmpdir_path: Path, rm_files: List[Path], page: int
-) -> Optional[Path]:
+def _select_rm_file_for_page(tmpdir_path: Path, rm_files: List[Path], page: int) -> Optional[Path]:
     """Return the .rm stroke file for a 1-based page, matched by page id.
 
     ``_get_ordered_rm_files`` is compacted (only pages that actually have

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -42,6 +42,31 @@ def _rm_to_svg(rm_file_path: Path, output_svg_path: Path) -> bool:
 REMARKABLE_WIDTH = 1404
 REMARKABLE_HEIGHT = 1872
 
+# reMarkable stores stroke and highlight coordinates in a fixed internal grid
+# whose resolution is the original rM1/rM2 screen pitch, 226 dpi. Current devices
+# (including the Paper Pro) normalise onto this same grid regardless of their
+# physical screen, so SceneInfo.paper_size reports (1404, 1872) accordingly and
+# an imported PDF rendered at native size maps 1 point -> 226/72 units.
+REMARKABLE_COORD_DPI = 226.0
+
+
+def _rm_units_per_point(paper_size: Optional[tuple] = None) -> float:
+    """rmscene coordinate units per PDF point, for placing annotations on a page.
+
+    Returns a constant (``REMARKABLE_COORD_DPI / 72``) that holds for every device
+    normalising onto the standard 1404x1872 grid -- verified on a reMarkable Paper
+    Pro across A4, US-Letter and Springer page sizes.
+
+    ``paper_size`` (from rmscene ``SceneInfo``) is accepted but unused for now, on
+    purpose: this function is the single seam for making the scale device-derived.
+    A device reporting a non-standard ``paper_size`` (the smaller reMarkable Move
+    reportedly normalises differently) may use a different grid; when a sample
+    from such a device is available, derive the scale here from ``paper_size``
+    instead of assuming the constant. Callers must go through this function rather
+    than hard-coding the ratio.
+    """
+    return REMARKABLE_COORD_DPI / 72.0
+
 # Standard reMarkable background color (light cream/gray)
 # Can be overridden via REMARKABLE_BACKGROUND_COLOR environment variable
 _DEFAULT_BACKGROUND_COLOR = "#FBFBFB"
@@ -1585,21 +1610,19 @@ def render_merged_page_from_document_zip(
             if target_rm_file is not None and _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
-                # rmscene emits stroke coordinates in the reMarkable device
-                # coordinate system (~226 dpi), NOT in PDF points: x=0 is the
-                # horizontal centre of the page and y=0 the top, and one unit is
-                # 72/226 pt. So a point on the page at (px, py) pt corresponds to
-                # rmscene ((px - W/2)/S, py/S) with S = 72/226. To map the whole
-                # page [0,W]x[0,H] pt into the output canvas we set the SVG
-                # viewBox to the rmscene rectangle that covers it:
-                #   (-W/(2S), 0, W/S, H/S).
-                # (The previous code assumed S=1, i.e. rmscene units == points,
-                # which placed strokes far outside the page and filled it black.)
-                # Validated against A4 imports on a reMarkable Paper Pro; the
-                # 226-dpi constant is the reMarkable display resolution.
+                # rmscene emits stroke/highlight coordinates in the reMarkable
+                # device coordinate grid, NOT in PDF points: x=0 is the horizontal
+                # centre of the page and y=0 the top, and one PDF point is
+                # `_rm_units_per_point()` units (see that function for the scale
+                # and how to make it device-derived). To map the whole page
+                # [0,W]x[0,H] pt into the output canvas, set the SVG viewBox to the
+                # rmscene rectangle that covers it: (-W*k/2, 0, W*k, H*k) with
+                # k = units-per-point. (The previous code assumed k=1, i.e.
+                # rmscene units == points, which placed strokes far outside the
+                # page and filled it black.)
                 svg_content = ann_svg_path.read_text()
 
-                rm_units_per_point = 226.0 / 72.0
+                rm_units_per_point = _rm_units_per_point()
                 vb_w = pdf_w_pt * rm_units_per_point
                 vb_h = pdf_h_pt * rm_units_per_point
                 svg_content = re.sub(

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1085,6 +1085,27 @@ def _get_ordered_rm_files(tmpdir_path: Path) -> List[Path]:
     return rm_files
 
 
+def _get_page_order(tmpdir_path: Path) -> List[str]:
+    """Return the ordered list of page ids from the .content file.
+
+    formatVersion 2 stores them under ``cPages.pages[].id``; formatVersion 1 as
+    a flat ``pages`` list of ids. Returns an empty list if unavailable. This is
+    the full page order (including pages that have no strokes), unlike
+    ``_get_ordered_rm_files`` which is compacted to pages that do.
+    """
+    for content_file in tmpdir_path.glob("*.content"):
+        try:
+            data = json.loads(content_file.read_text())
+            if "cPages" in data and "pages" in data["cPages"]:
+                return [p.get("id") for p in data["cPages"]["pages"] if p.get("id")]
+            if isinstance(data.get("pages"), list):
+                return [p for p in data["pages"] if isinstance(p, str)]
+        except Exception:
+            pass
+        break
+    return []
+
+
 def render_page_from_document_zip_svg(
     zip_path: Path, page: int = 1, background_color: Optional[str] = None
 ) -> Optional[str]:
@@ -1476,11 +1497,24 @@ def render_merged_page_from_document_zip(
         pdf_bytes = pdf_path.read_bytes()
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
+        page_order = _get_page_order(tmpdir_path)
+        total_pages = len(page_order) or len(rm_files)
 
-        if page < 1 or page > len(rm_files):
-            return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
+        if page < 1 or page > total_pages:
+            return None, f"Page {page} out of range (document has {total_pages} pages)."
 
-        target_rm_file = rm_files[page - 1]
+        # Select the .rm for this page BY PAGE ID. _get_ordered_rm_files returns
+        # only pages that actually have strokes (compacted), so indexing it by
+        # page number pairs the wrong strokes with the page whenever an earlier
+        # page is un-annotated (e.g. page 4 would get page 6's ink). Map through
+        # the full .content page order instead. A page with no strokes yields
+        # target_rm_file=None and composites to the bare PDF page.
+        target_rm_file: Optional[Path] = None
+        if page_order and page <= len(page_order):
+            page_id = page_order[page - 1]
+            target_rm_file = next((p for p in rm_files if p.stem == page_id), None)
+        elif page <= len(rm_files):
+            target_rm_file = rm_files[page - 1]
 
         # Determine which PDF page this reMarkable page maps to. Handles both the
         # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
@@ -1490,6 +1524,8 @@ def render_merged_page_from_document_zip(
 
         if pdf_page_index is None:
             # No redirect — this page may be a user-added blank page
+            if target_rm_file is None:
+                return None, "Page has no PDF underlay and no annotations."
             png = render_rm_file_to_png(target_rm_file, background_color=background_color)
             return png, "Page has no PDF underlay (user-added page); annotation-only render."
 
@@ -1528,7 +1564,7 @@ def render_merged_page_from_document_zip(
             with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
                 ann_svg_path = Path(tmp_svg.name)
 
-            if _rm_to_svg(target_rm_file, ann_svg_path):
+            if target_rm_file is not None and _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
                 # rmscene emits stroke coordinates in the reMarkable device

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1278,6 +1278,58 @@ def _pdf_page_index_for_cpages_entry(entry: Dict[str, Any]) -> Optional[int]:
     return None
 
 
+def _read_redirection_page_map(tmpdir_path: Path) -> List[Any]:
+    """Read the legacy (formatVersion 1) redirectionPageMap from .content.
+
+    formatVersion 1 documents have no cPages structure; instead the reMarkable
+    page -> original PDF page mapping is a flat list where the index is the
+    0-based reMarkable page and the value is the 0-based PDF page index (-1 for
+    user-added pages). Many cloud-imported PDFs use this layout.
+
+    Returns the list, or an empty list if not found.
+    """
+    content_file = next(tmpdir_path.glob("*.content"), None)
+    if content_file is None:
+        return []
+    try:
+        data = json.loads(content_file.read_text())
+        rpm = data.get("redirectionPageMap")
+        if isinstance(rpm, list):
+            return rpm
+    except Exception:
+        pass
+    return []
+
+
+def _resolve_pdf_page_index(tmpdir_path: Path, page: int) -> Optional[int]:
+    """Resolve the 0-based PDF page index for a 1-based reMarkable page.
+
+    Handles both document layouts:
+    - formatVersion 2: ``cPages.pages[i].redir.value``
+    - formatVersion 1: ``redirectionPageMap[i]`` (legacy; used by many
+      cloud-imported PDFs)
+
+    Returns None only when the page genuinely has no PDF underlay (a user-added
+    page). This lets render_merged composite annotations onto imported PDFs that
+    use either layout, instead of falling back to an annotation-only render.
+    """
+    # formatVersion 2 (cPages)
+    entries = _read_cpages_entries(tmpdir_path)
+    if entries and page <= len(entries):
+        idx = _pdf_page_index_for_cpages_entry(entries[page - 1])
+        if idx is not None:
+            return idx
+
+    # formatVersion 1 (redirectionPageMap)
+    rpm = _read_redirection_page_map(tmpdir_path)
+    if rpm and page <= len(rpm):
+        val = rpm[page - 1]
+        if isinstance(val, int) and val >= 0:
+            return val
+
+    return None
+
+
 def _render_pdf_page_to_png(
     pdf_bytes: bytes, page_index: int, width: int, height: int
 ) -> Optional[bytes]:
@@ -1423,8 +1475,6 @@ def render_merged_page_from_document_zip(
         pdf_path = matching[0] if matching else sorted(pdf_files)[0]
         pdf_bytes = pdf_path.read_bytes()
 
-        # Read cPages to find PDF page mapping
-        cpages = _read_cpages_entries(tmpdir_path)
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
         if page < 1 or page > len(rm_files):
@@ -1432,10 +1482,11 @@ def render_merged_page_from_document_zip(
 
         target_rm_file = rm_files[page - 1]
 
-        # Determine which PDF page this reMarkable page maps to
-        pdf_page_index: Optional[int] = None
-        if cpages and page <= len(cpages):
-            pdf_page_index = _pdf_page_index_for_cpages_entry(cpages[page - 1])
+        # Determine which PDF page this reMarkable page maps to. Handles both the
+        # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
+        # layouts; the latter is used by many cloud-imported PDFs, which would
+        # otherwise be misread as user-added pages and rendered annotation-only.
+        pdf_page_index: Optional[int] = _resolve_pdf_page_index(tmpdir_path, page)
 
         if pdf_page_index is None:
             # No redirect — this page may be a user-added blank page

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1400,13 +1400,16 @@ def _resolve_pdf_page_index(tmpdir_path: Path, page: int) -> Optional[int]:
     Returns None only when the page genuinely has no PDF underlay (a user-added
     page). This lets render_merged composite annotations onto imported PDFs that
     use either layout, instead of falling back to an annotation-only render.
+
+    When cPages entries exist they are authoritative: an entry without ``redir``
+    is a user-added page, and we must NOT fall through to a redirectionPageMap a
+    v1->v2 migrated document may still carry — its stale, order-shifted indices
+    could composite the wrong PDF page under a user-added page.
     """
-    # formatVersion 2 (cPages)
+    # formatVersion 2 (cPages) — authoritative when present
     entries = _read_cpages_entries(tmpdir_path)
     if entries and page <= len(entries):
-        idx = _pdf_page_index_for_cpages_entry(entries[page - 1])
-        if idx is not None:
-            return idx
+        return _pdf_page_index_for_cpages_entry(entries[page - 1])
 
     # formatVersion 1 (redirectionPageMap)
     rpm = _read_redirection_page_map(tmpdir_path)

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1578,9 +1578,16 @@ def render_merged_page_from_document_zip(
 
         # Select the .rm for this page by id (see _select_rm_file_for_page). A
         # page with no strokes yields None and composites to the bare PDF page.
-        target_rm_file: Optional[Path] = _select_rm_file_for_page(
-            tmpdir_path, rm_files, page
-        )
+        target_rm_file: Optional[Path] = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+
+        def annotation_only(reason: str) -> Tuple[Optional[bytes], Optional[str]]:
+            """Fallback when the PDF side of the merge fails: render just the
+            page's own strokes — or nothing, for a strokeless page (every
+            fallback path must tolerate ``target_rm_file`` being None)."""
+            if target_rm_file is None:
+                return None, f"{reason}; page has no annotation strokes."
+            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
+            return png, f"{reason}; annotation-only render."
 
         # Determine which PDF page this reMarkable page maps to. Handles both the
         # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
@@ -1600,8 +1607,7 @@ def render_merged_page_from_document_zip(
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")
             try:
                 if pdf_page_index >= len(doc):
-                    png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-                    return png, "PDF page index out of range; annotation-only render."
+                    return annotation_only("PDF page index out of range")
 
                 pdf_page = doc[pdf_page_index]
                 pdf_w_pt = pdf_page.rect.width  # PDF width in points
@@ -1609,8 +1615,7 @@ def render_merged_page_from_document_zip(
             finally:
                 doc.close()
         except Exception:
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "Could not read PDF dimensions; annotation-only render."
+            return annotation_only("Could not read PDF dimensions")
 
         # Determine output canvas size
         out_w = canvas_width or int(pdf_w_pt * 2)  # 2x for decent resolution
@@ -1619,8 +1624,7 @@ def render_merged_page_from_document_zip(
         # 1. Rasterize the PDF page
         pdf_png = _render_pdf_page_to_png(pdf_bytes, pdf_page_index, out_w, out_h)
         if pdf_png is None:
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "PDF rasterization failed; annotation-only render."
+            return annotation_only("PDF rasterization failed")
 
         # 2. Render annotation layer to SVG, then to PNG with transparent background
         ann_svg_path = None
@@ -1712,8 +1716,7 @@ def render_merged_page_from_document_zip(
             return buf.getvalue(), merged_note
         except Exception:
             # Last resort: return annotation-only from already-extracted .rm file
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "Compositing failed; annotation-only render."
+            return annotation_only("Compositing failed")
 
 
 def get_document_page_count(zip_path: Path) -> int:

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1770,6 +1770,50 @@ def get_document_file_type(zip_path: Path) -> str:
     return ""
 
 
+def _extract_page_annotations(rm_file: Path) -> Tuple[List[str], bool]:
+    """Extract a page's text highlights and whether it has pen strokes.
+
+    reMarkable text highlights are stored as ``GlyphRange`` scene items inside the
+    page's v6 ``.rm`` file (each carries the selected ``text`` and its bounding
+    ``rectangles``); freehand ink is stored as ``Line`` items. The legacy
+    ``.highlights`` JSON scanned elsewhere does not cover current firmware, so
+    read them here.
+
+    Returns ``(highlighted_texts_in_reading_order, has_pen_strokes)``. Returns
+    ``([], False)`` if the file cannot be parsed.
+    """
+    try:
+        import rmscene
+    except Exception:
+        return [], False
+    try:
+        with rm_file.open("rb") as fh:
+            tree = rmscene.read_tree(fh)
+    except Exception:
+        return [], False
+
+    highlights: list = []
+    has_strokes = False
+    try:
+        for item in tree.walk():
+            kind = type(item).__name__
+            if kind == "Line":
+                has_strokes = True
+            elif kind == "GlyphRange":
+                text = getattr(item, "text", None)
+                if not text:
+                    continue
+                rects = getattr(item, "rectangles", None) or []
+                y = rects[0].y if rects else 0.0
+                x = rects[0].x if rects else 0.0
+                highlights.append((y, x, text))
+    except Exception:
+        pass
+
+    highlights.sort(key=lambda t: (t[0], t[1]))  # top-to-bottom, left-to-right
+    return [t[2] for t in highlights], has_strokes
+
+
 def extract_text_from_document_zip(
     zip_path: Path, include_ocr: bool = False, doc_id: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -1784,10 +1828,16 @@ def extract_text_from_document_zip(
     Returns:
         {
             "typed_text": [...],      # From rmscene parsing (list of strings)
-            "highlights": [...],       # From PDF annotations
+            "highlights": [...],       # Highlighted text (GlyphRange + legacy JSON)
             "handwritten_text": [...], # From OCR (if enabled) - one per page, in order
             "pages": int,
             "page_ids": [...],         # Page UUIDs in order
+            "annotated_pages": [       # Only pages that carry annotations
+                {"page": int,          # 1-based page number
+                 "page_id": str,
+                 "has_handwriting": bool,   # page has pen strokes
+                 "highlights": [str]}, # highlighted text on the page
+            ],
             "ocr_backend": str,        # Which OCR backend was used (if any)
         }
     """
@@ -1805,6 +1855,7 @@ def extract_text_from_document_zip(
         "handwritten_text": None,
         "pages": 0,
         "page_ids": [],
+        "annotated_pages": [],
         "ocr_backend": None,
         "tags": [],
     }
@@ -1859,6 +1910,27 @@ def extract_text_from_document_zip(
         for rm_file in rm_files:
             text_lines = extract_text_from_rm_file(rm_file)
             result["typed_text"].extend(text_lines)
+
+        # Extract per-page text highlights (GlyphRange items) and note-presence
+        # from the .rm files, indexed by real page number. This powers "show only
+        # the annotated pages / the highlighted text" without paging through the
+        # whole document. (The legacy .highlights JSON scanned below only covers
+        # older firmware exports.)
+        page_pos = {pid: i for i, pid in enumerate(page_order)}
+        for order_pos, rm_file in enumerate(rm_files):
+            page_num = page_pos.get(rm_file.stem, order_pos) + 1
+            page_highlights, has_strokes = _extract_page_annotations(rm_file)
+            if page_highlights or has_strokes:
+                result["annotated_pages"].append(
+                    {
+                        "page": page_num,
+                        "page_id": rm_file.stem,
+                        "has_handwriting": has_strokes,
+                        "highlights": page_highlights,
+                    }
+                )
+                result["highlights"].extend(page_highlights)
+        result["annotated_pages"].sort(key=lambda a: a["page"])
 
         # Extract text from .txt and .md files
         for txt_file in tmpdir_path.glob("**/*.txt"):

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1552,10 +1552,14 @@ def render_merged_page_from_document_zip(
         # selection is deterministic.
         pdf_files = list(tmpdir_path.glob("**/*.pdf"))
         if not pdf_files:
+            # Notebook (no PDF underlay): render the page's own strokes,
+            # selected by id so multi-page notebooks with a blank page don't
+            # shift (see _select_rm_file_for_page).
             rm_files = _get_ordered_rm_files(tmpdir_path)
-            if page < 1 or page > len(rm_files):
-                return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
-            png = render_rm_file_to_png(rm_files[page - 1], background_color=background_color)
+            target = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+            if target is None:
+                return None, f"Page {page} has no annotation strokes."
+            png = render_rm_file_to_png(target, background_color=background_color)
             return png, "No PDF underlay found; returned annotation-only render."
 
         content_stems = {p.stem for p in tmpdir_path.glob("*.content")}

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1531,23 +1531,40 @@ def render_merged_page_from_document_zip(
             if _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
-                # rmscene's v6 renderer emits stroke coordinates with the
-                # origin at the top of the page and x=0 in the horizontal
-                # center (so x ranges roughly from -W/2 to +W/2). Setting the
-                # viewBox to (-W_pt/2, 0, W_pt, H_pt) maps that coordinate
-                # system to the PDF page bounds so annotations align. If the
-                # upstream coordinate convention changes, this alignment will
-                # need to be revisited.
+                # rmscene emits stroke coordinates in the reMarkable device
+                # coordinate system (~226 dpi), NOT in PDF points: x=0 is the
+                # horizontal centre of the page and y=0 the top, and one unit is
+                # 72/226 pt. So a point on the page at (px, py) pt corresponds to
+                # rmscene ((px - W/2)/S, py/S) with S = 72/226. To map the whole
+                # page [0,W]x[0,H] pt into the output canvas we set the SVG
+                # viewBox to the rmscene rectangle that covers it:
+                #   (-W/(2S), 0, W/S, H/S).
+                # (The previous code assumed S=1, i.e. rmscene units == points,
+                # which placed strokes far outside the page and filled it black.)
+                # Validated against A4 imports on a reMarkable Paper Pro; the
+                # 226-dpi constant is the reMarkable display resolution.
                 svg_content = ann_svg_path.read_text()
 
+                rm_units_per_point = 226.0 / 72.0
+                vb_w = pdf_w_pt * rm_units_per_point
+                vb_h = pdf_h_pt * rm_units_per_point
                 svg_content = re.sub(
                     r'viewBox="[^"]*"',
-                    f'viewBox="{-pdf_w_pt / 2:.1f} 0 {pdf_w_pt:.1f} {pdf_h_pt:.1f}"',
+                    f'viewBox="{-vb_w / 2:.2f} 0 {vb_w:.2f} {vb_h:.2f}"',
                     svg_content,
                 )
-                # Also set explicit width/height to match output canvas
-                svg_content = re.sub(r'width="[^"]*"', f'width="{out_w}"', svg_content)
-                svg_content = re.sub(r'height="[^"]*"', f'height="{out_h}"', svg_content)
+                # Also set explicit width/height to match output canvas. Only
+                # the root <svg> element's attributes (the first occurrence), and
+                # a negative lookbehind so we never rewrite `stroke-width="..."`
+                # (a plain `width="[^"]*"` also matches inside `stroke-width`,
+                # which blows every stroke up to `out_w` units wide and fills the
+                # page solid black).
+                svg_content = re.sub(
+                    r'(?<![-\w])width="[^"]*"', f'width="{out_w}"', svg_content, count=1
+                )
+                svg_content = re.sub(
+                    r'(?<![-\w])height="[^"]*"', f'height="{out_h}"', svg_content, count=1
+                )
 
                 # Render SVG to PNG with transparent background
                 import cairosvg

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -533,6 +533,24 @@ def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
         if not hasattr(block, "item") or not hasattr(block.item, "value"):
             continue
         line = block.item.value
+
+        # Text highlights are GlyphRange items: they carry `rectangles`
+        # (highlight boxes over selected text) rather than stroke `points`.
+        # Emit a translucent filled rect per rectangle in the highlight colour.
+        if getattr(line, "rectangles", None):
+            hl_color = getattr(line, "color", 9)
+            hl_color = hl_color.value if hasattr(hl_color, "value") else hl_color
+            hl_fill = COLOR_MAP.get(hl_color, "#FFD700")
+            for r in line.rectangles:
+                paths.append(
+                    f'<rect x="{r.x:.1f}" y="{r.y:.1f}" '
+                    f'width="{r.w:.1f}" height="{r.h:.1f}" '
+                    f'fill="{hl_fill}" opacity="0.35" stroke="none"/>'
+                )
+                all_coords.append((r.x, r.y))
+                all_coords.append((r.x + r.w, r.y + r.h))
+            continue
+
         if not hasattr(line, "points") or not line.points:
             continue
 

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1149,6 +1149,30 @@ def _get_page_order(tmpdir_path: Path) -> List[str]:
     return []
 
 
+def _select_rm_file_for_page(
+    tmpdir_path: Path, rm_files: List[Path], page: int
+) -> Optional[Path]:
+    """Return the .rm stroke file for a 1-based page, matched by page id.
+
+    ``_get_ordered_rm_files`` is compacted (only pages that actually have
+    strokes), so indexing it by page number pairs the wrong ink with a page
+    whenever an earlier page is un-annotated. Map through the full ``.content``
+    page order and match by id instead. Returns None when the page has no
+    strokes (a page with a PDF underlay but no annotation), or when the page is
+    out of range; callers should treat None as "no annotation layer".
+    """
+    page_order = _get_page_order(tmpdir_path)
+    if page_order:
+        if 1 <= page <= len(page_order):
+            page_id = page_order[page - 1]
+            return next((p for p in rm_files if p.stem == page_id), None)
+        return None
+    # No page order available (unusual): fall back to positional selection.
+    if 1 <= page <= len(rm_files):
+        return rm_files[page - 1]
+    return None
+
+
 def render_page_from_document_zip_svg(
     zip_path: Path, page: int = 1, background_color: Optional[str] = None
 ) -> Optional[str]:
@@ -1172,12 +1196,12 @@ def render_page_from_document_zip_svg(
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
-        # Validate page number
-        if page < 1 or page > len(rm_files):
+        # Select the page's .rm by id (see _select_rm_file_for_page); None means
+        # the page has no annotation layer.
+        target_rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+        if target_rm_file is None:
             return None
 
-        # Render the requested page
-        target_rm_file = rm_files[page - 1]
         return render_rm_file_to_svg(target_rm_file, background_color=background_color)
 
 
@@ -1204,12 +1228,12 @@ def render_page_from_document_zip(
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
-        # Validate page number
-        if page < 1 or page > len(rm_files):
+        # Select the page's .rm by id (see _select_rm_file_for_page); None means
+        # the page has no annotation layer.
+        target_rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+        if target_rm_file is None:
             return None
 
-        # Render the requested page
-        target_rm_file = rm_files[page - 1]
         return render_rm_file_to_png(target_rm_file, background_color=background_color)
 
 
@@ -1540,24 +1564,16 @@ def render_merged_page_from_document_zip(
         pdf_bytes = pdf_path.read_bytes()
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
-        page_order = _get_page_order(tmpdir_path)
-        total_pages = len(page_order) or len(rm_files)
+        total_pages = len(_get_page_order(tmpdir_path)) or len(rm_files)
 
         if page < 1 or page > total_pages:
             return None, f"Page {page} out of range (document has {total_pages} pages)."
 
-        # Select the .rm for this page BY PAGE ID. _get_ordered_rm_files returns
-        # only pages that actually have strokes (compacted), so indexing it by
-        # page number pairs the wrong strokes with the page whenever an earlier
-        # page is un-annotated (e.g. page 4 would get page 6's ink). Map through
-        # the full .content page order instead. A page with no strokes yields
-        # target_rm_file=None and composites to the bare PDF page.
-        target_rm_file: Optional[Path] = None
-        if page_order and page <= len(page_order):
-            page_id = page_order[page - 1]
-            target_rm_file = next((p for p in rm_files if p.stem == page_id), None)
-        elif page <= len(rm_files):
-            target_rm_file = rm_files[page - 1]
+        # Select the .rm for this page by id (see _select_rm_file_for_page). A
+        # page with no strokes yields None and composites to the bare PDF page.
+        target_rm_file: Optional[Path] = _select_rm_file_for_page(
+            tmpdir_path, rm_files, page
+        )
 
         # Determine which PDF page this reMarkable page maps to. Handles both the
         # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -539,7 +539,25 @@ async def remarkable_read(
                 annotation_parts = []
                 if content.get("typed_text"):
                     annotation_parts.extend(content["typed_text"])
-                if content.get("highlights"):
+                # Per-page index of highlights / handwritten notes: surfaces only
+                # the annotated pages (and their highlighted text) so the reader
+                # need not page through the whole document to find them.
+                annotated_pages = content.get("annotated_pages") or []
+                if annotated_pages:
+                    annotation_parts.append("\n--- Annotated pages ---")
+                    for ap in annotated_pages:
+                        marks = []
+                        if ap.get("has_handwriting"):
+                            marks.append("handwritten notes")
+                        n_hl = len(ap.get("highlights") or [])
+                        if n_hl:
+                            marks.append(f"{n_hl} highlight" + ("s" if n_hl != 1 else ""))
+                        annotation_parts.append(
+                            f"Page {ap['page']}: " + (", ".join(marks) or "annotated")
+                        )
+                        for h in ap.get("highlights") or []:
+                            annotation_parts.append(f"  • {h}")
+                elif content.get("highlights"):
                     annotation_parts.append("\n--- Highlights ---")
                     annotation_parts.extend(content["highlights"])
                 if content.get("handwritten_text"):

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -543,6 +543,7 @@ async def remarkable_read(
                 # the annotated pages (and their highlighted text) so the reader
                 # need not page through the whole document to find them.
                 annotated_pages = content.get("annotated_pages") or []
+                shown_highlights = set()
                 if annotated_pages:
                     annotation_parts.append("\n--- Annotated pages ---")
                     for ap in annotated_pages:
@@ -557,9 +558,17 @@ async def remarkable_read(
                         )
                         for h in ap.get("highlights") or []:
                             annotation_parts.append(f"  • {h}")
-                elif content.get("highlights"):
+                            shown_highlights.add(h)
+                # Highlights not covered by the per-page index above — e.g. from
+                # the legacy .highlights JSON (older firmware), which has no page
+                # attribution. Without this, a doc whose pages carry pen strokes
+                # would suppress its legacy highlight text entirely.
+                other_highlights = [
+                    h for h in content.get("highlights") or [] if h not in shown_highlights
+                ]
+                if other_highlights:
                     annotation_parts.append("\n--- Highlights ---")
-                    annotation_parts.extend(content["highlights"])
+                    annotation_parts.extend(other_highlights)
                 if content.get("handwritten_text"):
                     annotation_parts.append("\n--- Handwritten (OCR) ---")
                     annotation_parts.extend(content["handwritten_text"])

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -58,6 +58,30 @@ def test_formatversion2_cpages_redir_still_works():
         assert _resolve_pdf_page_index(tmp, 2) == 1
 
 
+def test_cpages_is_authoritative_over_stale_redirection_page_map():
+    """A v2 user-added page (cPages entry without redir) must resolve to None.
+
+    A v1->v2 migrated document can retain a stale redirectionPageMap whose
+    order-shifted indices would otherwise composite a wrong PDF underlay.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(
+            tmp,
+            {
+                "cPages": {
+                    "pages": [
+                        {"id": "a", "redir": {"value": 0}},
+                        {"id": "b"},  # user-added page, no underlay
+                    ]
+                },
+                "redirectionPageMap": [0, 1],  # stale: would wrongly map page 2
+            },
+        )
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 2) is None
+
+
 def test_no_mapping_returns_none():
     """Without cPages or redirectionPageMap the page has no resolvable underlay."""
     with tempfile.TemporaryDirectory() as td:

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -1,0 +1,61 @@
+"""Unit tests for render_merged PDF page-index resolution.
+
+Regression coverage for formatVersion 1 documents (flat ``pages`` list plus a
+``redirectionPageMap``), which were previously misread as user-added pages so
+``render_merged`` fell back to an annotation-only render for cloud-imported
+PDFs. See ``_resolve_pdf_page_index`` in ``remarkable_mcp/extract.py``.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from remarkable_mcp.extract import _resolve_pdf_page_index
+
+
+def _write_content(tmp: Path, content: dict) -> None:
+    (tmp / "doc.content").write_text(json.dumps(content))
+
+
+def test_formatversion1_redirection_page_map():
+    """formatVersion 1 imports map via redirectionPageMap (index -> PDF page)."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "redirectionPageMap": [0, 1, 2, 3]})
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 3) == 2
+
+
+def test_formatversion1_user_added_page_is_none():
+    """A -1 entry marks a user-added page with no PDF underlay."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "redirectionPageMap": [0, -1, 1]})
+        assert _resolve_pdf_page_index(tmp, 2) is None
+
+
+def test_formatversion2_cpages_redir_still_works():
+    """The existing cPages.redir path (formatVersion 2) is unchanged."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(
+            tmp,
+            {
+                "cPages": {
+                    "pages": [
+                        {"id": "a", "redir": {"value": 0}},
+                        {"id": "b", "redir": {"value": 1}},
+                    ]
+                }
+            },
+        )
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 2) == 1
+
+
+def test_no_mapping_returns_none():
+    """Without cPages or redirectionPageMap the page has no resolvable underlay."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "pages": ["a", "b"]})
+        assert _resolve_pdf_page_index(tmp, 1) is None

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 from remarkable_mcp.extract import (
+    _extract_page_annotations,
     _get_ordered_rm_files,
     _resolve_pdf_page_index,
     _select_rm_file_for_page,
@@ -97,3 +98,12 @@ def test_select_rm_file_positional_without_page_order():
         rm_files = _get_ordered_rm_files(tmp)
         assert _select_rm_file_for_page(tmp, rm_files, 1) is not None
         assert _select_rm_file_for_page(tmp, rm_files, 5) is None
+
+
+def test_extract_page_annotations_handles_unparseable_file():
+    """A missing or non-.rm file yields no highlights and no strokes, not an error."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = Path(td) / "not_real.rm"
+        bad.write_bytes(b"this is not a valid rm file")
+        assert _extract_page_annotations(bad) == ([], False)
+        assert _extract_page_annotations(Path(td) / "missing.rm") == ([], False)

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -10,7 +10,11 @@ import json
 import tempfile
 from pathlib import Path
 
-from remarkable_mcp.extract import _resolve_pdf_page_index
+from remarkable_mcp.extract import (
+    _get_ordered_rm_files,
+    _resolve_pdf_page_index,
+    _select_rm_file_for_page,
+)
 
 
 def _write_content(tmp: Path, content: dict) -> None:
@@ -59,3 +63,37 @@ def test_no_mapping_returns_none():
         tmp = Path(td)
         _write_content(tmp, {"formatVersion": 1, "pages": ["a", "b"]})
         assert _resolve_pdf_page_index(tmp, 1) is None
+
+
+def test_select_rm_file_by_page_id_on_sparse_document():
+    """The .rm is chosen by page id, not positional index in the compacted list.
+
+    An 8-page doc annotated on pages 2,3,4,6,7,8 must render page 4's own strokes
+    (p4.rm), not the 4th entry of the compacted rm list (p6.rm).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        ids = [f"p{i}" for i in range(1, 9)]
+        _write_content(tmp, {"cPages": {"pages": [{"id": i} for i in ids]}})
+        for pid in ("p2", "p3", "p4", "p6", "p7", "p8"):
+            (tmp / f"{pid}.rm").write_bytes(b"")
+        rm_files = _get_ordered_rm_files(tmp)
+
+        assert _select_rm_file_for_page(tmp, rm_files, 4).stem == "p4"
+        assert _select_rm_file_for_page(tmp, rm_files, 8).stem == "p8"
+        # Un-annotated pages have no stroke layer.
+        assert _select_rm_file_for_page(tmp, rm_files, 1) is None
+        assert _select_rm_file_for_page(tmp, rm_files, 5) is None
+        # Out of range.
+        assert _select_rm_file_for_page(tmp, rm_files, 9) is None
+
+
+def test_select_rm_file_positional_without_page_order():
+    """With no .content page order, fall back to positional selection."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        (tmp / "a.rm").write_bytes(b"")
+        (tmp / "b.rm").write_bytes(b"")
+        rm_files = _get_ordered_rm_files(tmp)
+        assert _select_rm_file_for_page(tmp, rm_files, 1) is not None
+        assert _select_rm_file_for_page(tmp, rm_files, 5) is None

--- a/test_server.py
+++ b/test_server.py
@@ -730,6 +730,55 @@ class TestRemarkableRead:
             or ("coroutine" not in data["_error"].get("message", ""))
         ), f"Got coroutine error: {data}"
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.extract_text_from_document_zip")
+    @patch("remarkable_mcp.tools.get_file_type")
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_read_legacy_highlights_shown_alongside_annotated_pages(
+        self, mock_get_rmapi, mock_get_file_type, mock_extract
+    ):
+        """Legacy-JSON highlights must still be listed when annotated_pages exists.
+
+        Regression test: highlights without page attribution (older-firmware
+        .highlights JSON) were suppressed whenever the per-page annotated_pages
+        index was non-empty (e.g. a page with pen strokes but no GlyphRange).
+        """
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+
+        doc = Mock()
+        doc.VissibleName = "Annotated PDF"
+        doc.ID = "pdf-123"
+        doc.Parent = ""
+        doc.ModifiedClient = "2024-01-15T10:30:00Z"
+        doc.is_folder = False
+        doc.tags = []
+        mock_client.get_meta_items.return_value = [doc]
+        mock_client.download.return_value = b"zip-bytes-unused-by-mocked-extraction"
+
+        mock_get_file_type.return_value = "pdf"
+        mock_extract.return_value = {
+            "typed_text": [],
+            "highlights": ["A legacy highlighted sentence."],
+            "handwritten_text": None,
+            "pages": 3,
+            "page_ids": [],
+            "annotated_pages": [
+                {"page": 2, "page_id": "p2", "has_handwriting": True, "highlights": []}
+            ],
+            "ocr_backend": None,
+            "tags": [],
+        }
+
+        result = await mcp.call_tool(
+            "remarkable_read", {"document": "Annotated PDF", "content_type": "annotations"}
+        )
+        data = json.loads(result[0][0].text)
+
+        assert "_error" not in data, f"Unexpected error: {data}"
+        assert "Page 2: handwritten notes" in data["content"]
+        assert "A legacy highlighted sentence." in data["content"]
+
 
 # =============================================================================
 # Test remarkable_image Tool


### PR DESCRIPTION

`render_merged=True` on `remarkable_image` did not work for cloud-imported PDFs
annotated on a reMarkable Paper Pro: it returned cropped/annotation-only images,
mis-placed strokes, or a page filled solid black, and never showed text
highlights. This branch fixes the pipeline end-to-end (and fixes a couple of the
same bugs in the non-merged render paths). Rendering/extraction changes are in
`remarkable_mcp/extract.py`; the annotated-pages output of `remarkable_read` is
in `remarkable_mcp/tools.py` (+ tests in `test_page_mapping.py` and
`test_server.py`).

Validated on **5 real documents** (Paper Pro, cloud transport): A4 / US-Letter /
Springer page sizes, `.content` formatVersion 1 and 2, single- and multi-page,
pen strokes and text highlights.

## 1. Page mapping ignored formatVersion 1 (`redirectionPageMap`)
Only `cPages.pages[].redir.value` (formatVersion 2) was handled. Many
cloud-imported PDFs are formatVersion 1: no `cPages`; the reMarkable→PDF page map
is a flat `redirectionPageMap`. Those fell through to "user-added page" →
annotation-only. Added `_resolve_pdf_page_index` (cPages → redirectionPageMap →
None).

## 2. Wrong annotation coordinate transform
The viewBox rewrite assumed rmscene emits coordinates in PDF points
(`-W/2, 0, W, H`). rmscene actually uses the reMarkable device grid: x=0 at the
page's horizontal centre, y=0 at the top, `1 unit = 72/226 pt` (226 = reMarkable
coordinate dpi; all current devices normalise onto this 1404×1872 grid). Set the
viewBox to the rmscene rectangle covering the page. The scale is centralised in
`_rm_units_per_point()` (a documented seam that takes `SceneInfo.paper_size` so a
device with a non-standard grid can be handled later). Also fixed a regex that
matched inside `stroke-width="..."` and blew every stroke up to the canvas
width, filling the page black. Confirmed page-size independent (A4/Letter/Springer).

## 3. Wrong `.rm` chosen on multi-page docs
`rm_files[page-1]` indexed the *compacted* stroke-file list (only pages that
have strokes), so a page's ink came from the wrong page when an earlier page was
un-annotated (an 8-page PDF annotated on 2,3,4,6,7,8 rendered page 6's ink for
page 4). Added `_select_rm_file_for_page`, which maps through the full `.content`
page order (`_get_page_order`) and matches by page id, and used it in **all**
render paths (merged, non-merged PNG/SVG, and the no-PDF notebook branch). A page
with no strokes returns None → the caller falls back to the bare PDF page.

## 4. Text highlights were dropped
`_build_svg_paths_from_blocks` only emitted stroke paths and skipped items
without `.points`, so reMarkable text highlights (`GlyphRange` items, which carry
`rectangles` + a colour) never rendered. Emit a translucent filled `<rect>` per
rectangle in the highlight colour, in the same coordinate system as strokes.

## 5. Highlighted text and annotated-page index were unavailable
`extract_text_from_document_zip` populated `highlights` only from the legacy
`.highlights` JSON, which current firmware does not write — so highlighted text
from cloud-imported PDFs came back empty, and there was no way to find annotated
pages without paging through the whole document. Added
`_extract_page_annotations` (reads `GlyphRange` text + rectangles and detects
pen `Line` strokes via rmscene); `extract_text_from_document_zip` now fills
`highlights` from `GlyphRange` and adds an `annotated_pages` index
(`[{page, page_id, has_handwriting, highlights}]`, real 1-based page numbers).
`remarkable_read(content_type="annotations")` renders a per-page section listing
only the annotated pages, whether each has handwritten notes, and its
highlighted text — so a reader can jump straight to annotated pages.

Caveat: highlight text is the reMarkable's stored text selection, so it can
occasionally glitch (e.g. a dropped letter) or split a sentence across entries;
it is meant for locating annotated passages, not as a perfect transcript.

Legacy highlights (from the old `.highlights` JSON, which has no page
attribution) are still listed in a separate `--- Highlights ---` section rather
than being suppressed by the per-page index.

## Robustness details
- When `cPages` entries exist they are authoritative for the page→PDF mapping:
  a v2 user-added page (entry without `redir`) does **not** fall through to a
  stale `redirectionPageMap` a v1→v2 migrated document may still carry.
- All merged-render fallback paths (bad PDF, rasterization/compositing failure)
  tolerate a strokeless page (`target_rm_file is None`) and report it in the
  render note instead of erroring.

## Tests
`test_page_mapping.py` covers both `.content` formats, the user-added/no-mapping
cases, cPages-over-stale-`redirectionPageMap` precedence, the sparse /
no-page-order `.rm` selection, and `_extract_page_annotations` robustness on
unparseable input. `test_server.py` gains a regression test that legacy-JSON
highlights are still shown when the annotated-pages index is non-empty.

## Notes
- rmscene 0.8.0 parses the Paper Pro `.rm` fine; the "Some data has not been
  read … newer format" warning is non-fatal.
- The 226-dpi constant held across every tested page size; if a device with a
  different normalization appears (the smaller Move reportedly differs),
  `_rm_units_per_point` is the single place to make it `SceneInfo.paper_size`-derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZFjgHEoSB33fUim2Ahd5s
