### PR TITLE
fix(render): translate text-anchored ink groups; extract typed text via TextDocument

### DIFF
--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -280,25 +280,26 @@ def extract_text_from_rm_file(rm_file_path: Path) -> List[str]:
     try:
         from rmscene import read_blocks
         from rmscene.scene_items import Text
-        from rmscene.scene_tree import SceneTree
+        from rmscene.text import TextDocument
 
         with open(rm_file_path, "rb") as f:
-            tree = SceneTree()
-            for block in read_blocks(f):
-                tree.add_block(block)
+            blocks = list(read_blocks(f))
 
-        text_lines = []
+        # The page's typed text lives on the RootTextBlock, not among the
+        # root group's children (those are the ink layers), so scan the raw
+        # blocks the same way the renderer does.
+        text_item = next(
+            (b.value for b in blocks if isinstance(getattr(b, "value", None), Text)),
+            None,
+        )
+        if text_item is None:
+            return []
 
-        # Extract text from the scene tree
-        for item in tree.root.children.values():
-            if hasattr(item, "value") and isinstance(item.value, Text):
-                text_obj = item.value
-                if hasattr(text_obj, "items"):
-                    for text_item in text_obj.items:
-                        if hasattr(text_item, "value") and text_item.value:
-                            text_lines.append(str(text_item.value))
-
-        return text_lines
+        # TextDocument resolves the CRDT character sequence into ordered,
+        # styled paragraphs; iterating Text.items directly yields CRDT ids
+        # and fragments in insertion order, not readable lines.
+        doc = TextDocument.from_scene_item(text_item)
+        return [line for line in (str(para).strip() for para in doc.contents) if line]
 
     except ImportError:
         return []  # rmscene not available
@@ -505,8 +506,75 @@ def _v6_paper_size(blocks: list) -> Tuple[float, float]:
     return float(REMARKABLE_WIDTH), float(REMARKABLE_HEIGHT)
 
 
-def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
-    """Build SVG ``<path>`` strings + a flat coordinate list from v6 blocks."""
+def _v6_group_offsets(blocks: list, anchor_pos: dict) -> dict:
+    """Map group node ``CrdtId``s to cumulative ``(dx, dy)`` anchor offsets.
+
+    In the v6 format a group of strokes can be anchored to a typed-text
+    character (``Group.anchor_id``): its ink is stored relative to that anchor
+    and the device translates it to the anchored line's Y as text reflows.
+    ``anchor_pos`` comes from :func:`_v6_text_elements_with_bounds`. Offsets
+    accumulate up the parent chain so groups nested under an anchored group
+    inherit its translation. Returns ``{}`` when there is nothing to anchor.
+    """
+    if not anchor_pos:
+        return {}
+
+    parents: dict = {}
+    own: dict = {}
+    for block in blocks:
+        # SceneTreeBlock links a node to its parent.
+        tree_id = getattr(block, "tree_id", None)
+        if tree_id is not None and hasattr(block, "parent_id"):
+            parents[tree_id] = block.parent_id
+        # TreeNodeBlock carries the group's anchor attributes.
+        group = getattr(block, "group", None)
+        if group is None:
+            continue
+        anchor_id = getattr(group, "anchor_id", None)
+        if anchor_id is None:
+            continue
+        anchor_key = getattr(anchor_id, "value", None)
+        if anchor_key not in anchor_pos:
+            continue
+        origin_x = getattr(group, "anchor_origin_x", None)
+        dx = float(origin_x.value) if origin_x is not None else 0.0
+        own[group.node_id] = (dx, float(anchor_pos[anchor_key]))
+
+    if not own:
+        return {}
+
+    offsets: dict = {}
+
+    def resolve(node_id) -> Tuple[float, float]:
+        if node_id in offsets:
+            return offsets[node_id]
+        dx = dy = 0.0
+        cur = node_id
+        seen = set()
+        while cur is not None and cur not in seen:
+            seen.add(cur)
+            if cur in own:
+                odx, ody = own[cur]
+                dx += odx
+                dy += ody
+            cur = parents.get(cur)
+        offsets[node_id] = (dx, dy)
+        return offsets[node_id]
+
+    for node_id in set(parents) | set(own):
+        resolve(node_id)
+    return offsets
+
+
+def _v6_paths_from_blocks(blocks: list, anchor_pos: Optional[dict] = None) -> Tuple[list, list]:
+    """Build SVG ``<path>`` strings + a flat coordinate list from v6 blocks.
+
+    ``anchor_pos`` (from :func:`_v6_text_elements_with_bounds`) enables
+    text-anchored ink translation: strokes whose parent group is anchored to a
+    typed-text line are shifted to that line's position, matching where the
+    device draws them. Without it strokes render at their stored coordinates,
+    which for anchored groups is on top of the typed text block.
+    """
     # Integer pen/color values (rmscene exposes ints on blocks).
     HIGHLIGHTER_PENS = {5, 18}  # HIGHLIGHTER_1, HIGHLIGHTER_2
     ERASER_PENS = {6, 8}  # ERASER, ERASER_AREA
@@ -527,6 +595,8 @@ def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
         13: "#FFD700",  # YELLOW_2
     }
 
+    group_offsets = _v6_group_offsets(blocks, anchor_pos) if anchor_pos else {}
+
     paths: list = []
     all_coords: list = []
     for block in blocks:
@@ -535,6 +605,7 @@ def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
         line = block.item.value
         if not hasattr(line, "points") or not line.points:
             continue
+        dx, dy = group_offsets.get(getattr(block, "parent_id", None), (0.0, 0.0))
 
         tool = line.tool if hasattr(line, "tool") else None
         color = line.color if hasattr(line, "color") else 0
@@ -565,9 +636,9 @@ def _v6_paths_from_blocks(blocks: list) -> Tuple[list, list]:
             stroke_width = max(0.5, min(avg_width * 0.8, 5.0))
             opacity = ""
 
-        d = f"M {line.points[0].x:.1f} {line.points[0].y:.1f}"
-        d += "".join(f" L {p.x:.1f} {p.y:.1f}" for p in line.points[1:])
-        all_coords.extend((p.x, p.y) for p in line.points)
+        d = f"M {line.points[0].x + dx:.1f} {line.points[0].y + dy:.1f}"
+        d += "".join(f" L {p.x + dx:.1f} {p.y + dy:.1f}" for p in line.points[1:])
+        all_coords.extend((p.x + dx, p.y + dy) for p in line.points)
 
         paths.append(
             f'<path d="{d}" stroke="{stroke_color}" '
@@ -634,33 +705,46 @@ def _v6_text_svg_elements(blocks: list) -> list:
     return _v6_text_elements_with_bounds(blocks)[0]
 
 
-def _v6_text_elements_with_bounds(blocks: list) -> Tuple[list, list]:
-    """Build SVG ``<text>`` strings plus their bounding coords for typed text.
+# Special anchor CrdtIds the device uses for ink groups pinned to the page
+# itself rather than to a typed character: (0, 281474976710654) anchors at the
+# top of the text block, (0, 281474976710655) below its last line.
+_ANCHOR_TEXT_TOP = (0, 281474976710654)
+_ANCHOR_TEXT_BOTTOM = (0, 281474976710655)
 
-    Returns ``(elements, coords)`` where ``coords`` is a flat list of ``(x, y)``
-    extent points (in the page's stroke/screen units, center-origin X) so a
-    content-cropped render can size its viewBox to include the text. Returns
-    ``([], [])`` when the page has no typed text (the common case for
-    handwritten notebooks) or when rmscene's text helpers are unavailable.
+
+def _v6_text_elements_with_bounds(blocks: list) -> Tuple[list, list, dict]:
+    """Build SVG ``<text>`` strings, bounding coords and anchor map for typed text.
+
+    Returns ``(elements, coords, anchor_pos)``. ``coords`` is a flat list of
+    ``(x, y)`` extent points (in the page's stroke/screen units, center-origin
+    X) so a content-cropped render can size its viewBox to include the text.
+    ``anchor_pos`` maps text-character ``CrdtId``s (plus the special
+    top/bottom-of-text ids) to the page-space Y of the line holding that
+    character: ink groups anchored to a character must be translated by that Y
+    (see :func:`_v6_paths_from_blocks`), which is how the device keeps
+    handwriting positioned relative to text as the typed block reflows.
+    Returns ``([], [], {})`` when the page has no typed text (the common case
+    for handwritten notebooks) or when rmscene's text helpers are unavailable.
     """
     try:
         from rmscene.scene_items import ParagraphStyle, Text
+        from rmscene.tagged_block_common import CrdtId
         from rmscene.text import TextDocument
     except ImportError:
-        return [], []
+        return [], [], {}
 
     text_item = next(
         (b.value for b in blocks if isinstance(getattr(b, "value", None), Text)),
         None,
     )
     if text_item is None:
-        return [], []
+        return [], [], {}
 
     # Blank pages we synthesize carry an empty RootTextBlock; skip them so we
     # neither emit empty <text> nodes nor trigger rmscene's empty-item warning.
     try:
         if not any(isinstance(v, str) and v.strip() for v in text_item.items.values()):
-            return [], []
+            return [], [], {}
     except Exception:
         pass
 
@@ -681,7 +765,7 @@ def _v6_text_elements_with_bounds(blocks: list) -> Tuple[list, list]:
     try:
         doc = TextDocument.from_scene_item(text_item)
     except Exception:
-        return [], []
+        return [], [], {}
 
     pos_x = float(getattr(text_item, "pos_x", 0.0) or 0.0)
     pos_y = float(getattr(text_item, "pos_y", 0.0) or 0.0)
@@ -695,12 +779,25 @@ def _v6_text_elements_with_bounds(blocks: list) -> Tuple[list, list]:
 
     elements: list = []
     coords: list = []
+    anchor_pos: dict = {}
     y_offset = _TEXT_TOP_Y * scale
+    anchor_pos[CrdtId(*_ANCHOR_TEXT_TOP)] = pos_y + y_offset
     for para in doc.contents:
         style = para.style.value if getattr(para, "style", None) is not None else None
         line_height = line_heights.get(style, _TEXT_DEFAULT_LINE_HEIGHT) * scale
         size = font_sizes.get(style, _TEXT_DEFAULT_FONT_SIZE) * scale
         text = str(para).strip()
+        # Every character in this paragraph anchors ink at the paragraph's own
+        # Y (the running offset before this paragraph consumes its lines), the
+        # same reference point the device and the rmc exporter use.
+        para_anchor_y = pos_y + y_offset
+        try:
+            anchor_pos[para.start_id] = para_anchor_y
+            for subpara in para.contents:
+                for char_id in getattr(subpara, "i", []) or []:
+                    anchor_pos[char_id] = para_anchor_y
+        except Exception:
+            pass
         if not text:
             # A blank paragraph still consumes a line (e.g. spacing under a title).
             y_offset += line_height
@@ -725,7 +822,8 @@ def _v6_text_elements_with_bounds(blocks: list) -> Tuple[list, list]:
                 est_width = min(est_width, box_width)
             coords.append((pos_x, baseline - size))
             coords.append((pos_x + est_width, baseline + size * 0.3))
-    return elements, coords
+    anchor_pos[CrdtId(*_ANCHOR_TEXT_BOTTOM)] = pos_y + y_offset
+    return elements, coords, anchor_pos
 
 
 def _render_rm_v6_to_svg(rm_file_path: Path) -> Optional[str]:
@@ -741,8 +839,8 @@ def _render_rm_v6_to_svg(rm_file_path: Path) -> Optional[str]:
     if blocks is None:
         return None
     try:
-        paths, all_coords = _v6_paths_from_blocks(blocks)
-        text_elements, text_coords = _v6_text_elements_with_bounds(blocks)
+        text_elements, text_coords, anchor_pos = _v6_text_elements_with_bounds(blocks)
+        paths, all_coords = _v6_paths_from_blocks(blocks, anchor_pos)
         # Typed text is drawn under strokes (handwriting layers on top), and its
         # extent is folded into the crop so a text-only page still renders.
         return _svg_from_paths(text_elements + paths, all_coords + text_coords)
@@ -924,8 +1022,8 @@ def render_rm_file_full_page_png(
     if blocks is None:
         return None
     try:
-        paths, _ = _v6_paths_from_blocks(blocks)
-        text_elements = _v6_text_svg_elements(blocks)
+        text_elements, _, anchor_pos = _v6_text_elements_with_bounds(blocks)
+        paths, _ = _v6_paths_from_blocks(blocks, anchor_pos)
         paper_w, paper_h = _v6_paper_size(blocks)
     except Exception:
         return None

--- a/test_server.py
+++ b/test_server.py
@@ -4787,3 +4787,201 @@ class TestGetDocumentFileType:
             assert get_document_file_type(zpath) == ""
         finally:
             zpath.unlink(missing_ok=True)
+
+
+def _make_v6_anchored_rm_bytes():
+    """Build a v6 page with typed text plus a stroke group anchored to a character.
+
+    Returns ``(rm_bytes, anchor_char_id, raw_points)`` where the single stroke's
+    group is anchored to the first character of the SECOND paragraph with
+    ``anchor_origin_x=25.0``, and ``raw_points`` are the stroke's stored
+    coordinates (i.e. pre-translation).
+    """
+    import io
+
+    from rmscene import scene_items as si
+    from rmscene import simple_text_document, write_blocks
+    from rmscene.crdt_sequence import CrdtSequenceItem
+    from rmscene.scene_items import LwwValue
+    from rmscene.scene_stream import SceneLineItemBlock, SceneTreeBlock, TreeNodeBlock
+    from rmscene.tagged_block_common import CrdtId
+    from rmscene.text import TextDocument
+
+    blocks = list(simple_text_document("Title line\nBody line"))
+
+    text = next(b.value for b in blocks if isinstance(getattr(b, "value", None), si.Text))
+    doc = TextDocument.from_scene_item(text)
+    anchor_char = doc.contents[1].contents[0].i[0]
+
+    # Parent the anchored group under an existing drawable group node.
+    layer_node = next(
+        b.group.node_id
+        for b in blocks
+        if getattr(b, "group", None) is not None and b.group.node_id != CrdtId(0, 1)
+    )
+
+    raw_points = [(-50.0, 10.0), (0.0, 20.0), (50.0, 30.0)]
+    line = si.Line(
+        color=si.PenColor.BLACK,
+        tool=si.Pen.BALLPOINT_1,
+        points=[
+            si.Point(x=x, y=y, speed=0, direction=0, width=2, pressure=0) for x, y in raw_points
+        ],
+        thickness_scale=1.0,
+        starting_length=0.0,
+    )
+    anchored_id = CrdtId(0, 900)
+    blocks += [
+        SceneTreeBlock(
+            tree_id=anchored_id,
+            node_id=CrdtId(0, 0),
+            is_update=True,
+            parent_id=layer_node,
+        ),
+        TreeNodeBlock(
+            group=si.Group(
+                node_id=anchored_id,
+                anchor_id=LwwValue(timestamp=CrdtId(0, 30), value=anchor_char),
+                anchor_type=LwwValue(timestamp=CrdtId(0, 31), value=2),
+                anchor_threshold=LwwValue(timestamp=CrdtId(0, 32), value=100.0),
+                anchor_origin_x=LwwValue(timestamp=CrdtId(0, 33), value=25.0),
+            )
+        ),
+        SceneLineItemBlock(
+            parent_id=anchored_id,
+            item=CrdtSequenceItem(
+                item_id=CrdtId(0, 901),
+                left_id=CrdtId(0, 0),
+                right_id=CrdtId(0, 0),
+                deleted_length=0,
+                value=line,
+            ),
+        ),
+    ]
+    buf = io.BytesIO()
+    write_blocks(buf, blocks)
+    return buf.getvalue(), anchor_char, raw_points
+
+
+class TestTextAnchoredInk:
+    """Ink groups anchored to typed text render at the anchored line's position."""
+
+    def _blocks(self, data: bytes):
+        import tempfile
+
+        from remarkable_mcp.extract import _v6_blocks
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as tmp:
+            tmp.write(data)
+            path = Path(tmp.name)
+        try:
+            return _v6_blocks(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_text_layout_exposes_anchor_positions(self):
+        from rmscene.tagged_block_common import CrdtId
+
+        from remarkable_mcp.extract import (
+            _ANCHOR_TEXT_BOTTOM,
+            _ANCHOR_TEXT_TOP,
+            _v6_text_elements_with_bounds,
+        )
+
+        data, anchor_char, _ = _make_v6_anchored_rm_bytes()
+        elements, _, anchor_pos = _v6_text_elements_with_bounds(self._blocks(data))
+
+        assert elements, "typed text should render"
+        assert anchor_char in anchor_pos
+        top = anchor_pos[CrdtId(*_ANCHOR_TEXT_TOP)]
+        bottom = anchor_pos[CrdtId(*_ANCHOR_TEXT_BOTTOM)]
+        # The second paragraph's characters anchor strictly between the top of
+        # the text block and below its last line.
+        assert top < anchor_pos[anchor_char] < bottom
+
+    def test_anchored_stroke_is_translated(self):
+        from remarkable_mcp.extract import (
+            _v6_paths_from_blocks,
+            _v6_text_elements_with_bounds,
+        )
+
+        data, anchor_char, raw_points = _make_v6_anchored_rm_bytes()
+        blocks = self._blocks(data)
+        _, _, anchor_pos = _v6_text_elements_with_bounds(blocks)
+
+        unshifted, _ = _v6_paths_from_blocks(blocks)
+        shifted, shifted_coords = _v6_paths_from_blocks(blocks, anchor_pos)
+
+        assert len(unshifted) == len(shifted) == 1
+        expected_dy = anchor_pos[anchor_char]
+        x0, y0 = raw_points[0]
+        assert f"M {x0:.1f} {y0:.1f}" in unshifted[0]
+        assert f"M {x0 + 25.0:.1f} {y0 + expected_dy:.1f}" in shifted[0]
+        # The crop-box coordinates shift with the ink.
+        assert shifted_coords[0] == (x0 + 25.0, y0 + expected_dy)
+
+    def test_full_render_places_ink_below_text(self):
+        import tempfile
+
+        from remarkable_mcp.extract import _render_rm_v6_to_svg
+
+        data, _, raw_points = _make_v6_anchored_rm_bytes()
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as tmp:
+            tmp.write(data)
+            path = Path(tmp.name)
+        try:
+            svg = _render_rm_v6_to_svg(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+        assert svg is not None
+        # The stroke's raw stored Y must not appear: it renders translated.
+        assert f"M {raw_points[0][0]:.1f} {raw_points[0][1]:.1f}" not in svg
+        assert "<text " in svg and "<path " in svg
+
+    def test_unanchored_stroke_unchanged_when_anchor_map_present(self):
+        import tempfile
+
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp.extract import (
+            _v6_blocks,
+            _v6_paths_from_blocks,
+            _v6_text_elements_with_bounds,
+        )
+        from remarkable_mcp.strokes import append_strokes
+
+        data = append_strokes(
+            nb.page_rm_bytes("Hello world"),
+            [{"points": [[0.1, 0.1], [0.2, 0.2]]}],
+        )
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as tmp:
+            tmp.write(data)
+            path = Path(tmp.name)
+        try:
+            blocks = _v6_blocks(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+        _, _, anchor_pos = _v6_text_elements_with_bounds(blocks)
+        assert anchor_pos, "text page should produce an anchor map"
+        plain, _ = _v6_paths_from_blocks(blocks)
+        with_map, _ = _v6_paths_from_blocks(blocks, anchor_pos)
+        # A stroke on the plain drawable layer has no anchored ancestor: the
+        # anchor map must not move it.
+        assert plain == with_map
+
+
+class TestTypedTextExtraction:
+    def test_extract_text_from_rm_file_reads_typed_paragraphs(self):
+        import tempfile
+
+        from remarkable_mcp import notebooks as nb
+        from remarkable_mcp.extract import extract_text_from_rm_file
+
+        with tempfile.NamedTemporaryFile(suffix=".rm", delete=False) as tmp:
+            tmp.write(nb.page_rm_bytes("Hello world\nSecond line"))
+            path = Path(tmp.name)
+        try:
+            assert extract_text_from_rm_file(path) == ["Hello world", "Second line"]
+        finally:
+            path.unlink(missing_ok=True)


### PR DESCRIPTION
Fixes #135.

## What this fixes

Pages mixing typed text with handwriting rendered the two layers overlapping, and `remarkable_read` returned no typed text from those same pages. Details and real-device evidence in #135.

## Changes

### 1. Text-anchored ink translation (`_v6_paths_from_blocks`)

- `_v6_text_elements_with_bounds` now returns a third value: an **anchor map** from text-character `CrdtId`s to the page-space Y of the line holding that character, plus the special top/bottom-of-text ids (`CrdtId(0, 281474976710654)` / `...655`). It is built inside the same loop that lays the text out, so anchors always agree with the calibrated text layout from #116 (including wrapped lines and blank paragraphs).
- New `_v6_group_offsets` maps group node ids to cumulative `(dx, dy)`: `dx` from `Group.anchor_origin_x`, `dy` from the anchor map, accumulated up the `SceneTreeBlock` parent chain so nested groups inherit their ancestors' translation. A visited-set guards against malformed CRDT trees with parent cycles.
- `_v6_paths_from_blocks` takes an optional `anchor_pos` and translates both the path data and the crop-box coordinate list (fixing only the paths would mis-crop the viewBox). Both render call sites (`_render_rm_v6_to_svg`, `render_rm_file_full_page_png`) pass it. Pages without typed text take the existing code path unchanged.

### 2. Typed-text extraction (`extract_text_from_rm_file`)

Rewritten to find the page text the same way the renderer does (scan blocks for the `RootTextBlock`'s `Text` value; it is not among `tree.root.children`) and to resolve readable paragraphs through `TextDocument` instead of iterating the raw CRDT sequence. `remarkable_read` now returns the typed text on pages where it previously reported `total_chars: 0` and suggested OCR.

## Validation

- **Real device**: a Paper Pro meeting-notes page (typed template header + handwriting, cloud sync). Before: ink drawn through the middle of the typed block, read returned empty. After: ink renders below the text exactly as the device draws it, and read returns the typed paragraphs (164 chars).
- **Tests**: new `TestTextAnchoredInk` (anchor map contents and ordering, anchored stroke translated by `(anchor_origin_x, line Y)` end to end, crop coords shifted, unanchored strokes untouched when a map is present) and `TestTypedTextExtraction`, built on a new `_make_v6_anchored_rm_bytes` fixture that authors a genuine anchored group with rmscene's writer. `pytest` 213 passed; `ruff check` and `ruff format --check` clean.

## Notes

- Anchor semantics follow the rmc exporter's reference behaviour (per-group translate of `anchor_origin_x` and the anchored line's Y) but the Y values come from this repo's own device-calibrated layout rather than rmc's constants, consistent with #116.
- `anchor_type` and `anchor_threshold` are intentionally not interpreted; the translate alone restores device-faithful placement for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSzyhkiyrrcovuhTr3g9oj
