### PR TITLE
fix(ssh): detach stdin so ssh cannot block on the MCP stdio pipe

### DIFF
--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -159,11 +159,16 @@ class SSHClient:
             ssh_args = ["sshpass", "-p", self.password] + ssh_args
 
         try:
+            # stdin must be detached: without it, ssh inherits the MCP server's
+            # stdin (the live JSON-RPC pipe). On Windows (msys/Git ssh.exe) the
+            # child blocks on that pipe and never exits, so every SSH call hits
+            # the timeout even though the remote command finished in <2s.
             result = subprocess.run(
                 ssh_args,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                stdin=subprocess.DEVNULL,
             )
             if result.returncode != 0:
                 raise RuntimeError(f"SSH command failed: {result.stderr}")
@@ -207,10 +212,13 @@ class SSHClient:
             ssh_args = ["sshpass", "-p", self.password] + ssh_args
 
         try:
+            # See _ssh_command: detach stdin so ssh cannot block on the MCP
+            # server's JSON-RPC pipe (hangs on Windows msys/Git ssh.exe).
             result = subprocess.run(
                 ssh_args,
                 capture_output=True,
                 timeout=timeout,
+                stdin=subprocess.DEVNULL,
             )
             if result.returncode != 0:
                 raise RuntimeError(f"SSH cat failed: {result.stderr.decode()}")


### PR DESCRIPTION
## Problem

Both `subprocess.run` calls in the SSH transport (`remarkable_mcp/ssh.py`) spawn `ssh` without an explicit `stdin`, so the child inherits the MCP server's stdin — the live JSON-RPC stdio pipe held open by the MCP client. On Windows with msys/Git `ssh.exe`, the ssh child blocks on that inherited pipe and never exits, so **every SSH operation hits its timeout** (`SSH command timed out after 60s` on startup's metadata load, and again on every tool call) even though the remote command completes in under two seconds.

What makes this nasty to diagnose: the byte-identical ssh command works instantly from a shell, and also works from Python reproductions where the inherited stdin pipe is merely *open but idle* — the hang needs the real MCP session, where the pipe carries protocol traffic. Confirmed by snapshotting the hung `ssh.exe` mid-hang (`Win32_Process`): its command line was identical to the working one, so the difference was the process environment, not the arguments.

## Fix

Pass `stdin=subprocess.DEVNULL` to both `subprocess.run` calls. No command in this module reads stdin, so detaching it is safe on all platforms (it's the same reason `ssh -n` exists).

Measured against a real reMarkable 2 over USB-SSH (firmware build 20260506, Windows 11, Git for Windows ssh): metadata load goes from a guaranteed 60s timeout to ~1.2s, and `remarkable_status`/`remarkable_read`/`remarkable_browse` all work.

Sweep of the other subprocess call sites: `write_tools.py` already passes an explicit stdin file handle, and the `extract.py` calls target inkscape — so these two are the complete set.

## Testing

`pytest test_server.py -k ssh`: 7 passed, 1 failed (`test_author_only_registered_in_ssh_mode`) — that failure is identical on a clean checkout of `main` in the same environment, i.e. pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)