### PR TITLE
docs: add security review of the MCP server

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,32 @@
+# Caddy reverse proxy for a self-hosted remarkable-mcp.
+#
+# Caddy obtains and renews the TLS certificate automatically, so there is no
+# certbot step. Replace the domain with your own, then:
+#
+#   sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
+#   sudo systemctl reload caddy
+#
+# The MCP service itself listens only on 127.0.0.1:8080 — this is the single
+# door to it from the internet.
+
+rm.example.org {
+	# The MCP endpoint and every OAuth route (/authorize, /token, /register,
+	# /login, /.well-known/*) are served by the same backend.
+	reverse_proxy 127.0.0.1:8080
+
+	encode gzip
+
+	header {
+		# The login form and OAuth pages are the only HTML served here.
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "no-referrer"
+		-Server
+	}
+
+	log {
+		output file /var/log/caddy/remarkable-mcp.log
+		format json
+	}
+}

--- a/deploy/http_server.py
+++ b/deploy/http_server.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""HTTP entry point for a self-hosted remarkable-mcp.
+
+The packaged CLI only speaks stdio, which requires the MCP client to live on the
+same machine. This entry point serves the same server over streamable HTTP so a
+remote client — claude.ai, Claude Desktop, the mobile app — can reach it, with
+OAuth in front (see single_user_auth.py).
+
+Run it behind a TLS-terminating reverse proxy; it binds to 127.0.0.1 by default
+and must never be exposed directly.
+
+    RMMCP_PUBLIC_URL=https://rm.example.org \
+    RMMCP_PASSPHRASE='...' \
+    python deploy/http_server.py
+
+Environment:
+    RMMCP_PUBLIC_URL     Public HTTPS base URL (required)
+    RMMCP_PASSPHRASE     Login secret (required, >= 16 chars)
+    RMMCP_HOST           Bind address (default: 127.0.0.1)
+    RMMCP_PORT           Bind port (default: 8080)
+    RMMCP_ALLOW_WRITES   Set to 1 to expose the write tools (default: read-only)
+    RMMCP_STATE_DIR      Where OAuth state is persisted (default: ~/.remarkable-mcp)
+
+    plus the usual reMarkable variables (REMARKABLE_TOKEN or ~/.rmapi).
+"""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+logging.basicConfig(
+    level=os.environ.get("RMMCP_LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("remarkable-mcp-http")
+
+
+def _require(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        sys.exit(f"error: {name} is required. See deploy/README or docs/self-hosting.md.")
+    return value
+
+
+def main() -> None:
+    public_url = _require("RMMCP_PUBLIC_URL").rstrip("/")
+    passphrase = _require("RMMCP_PASSPHRASE")
+
+    if not public_url.startswith("https://"):
+        sys.exit(
+            "error: RMMCP_PUBLIC_URL must be an https:// URL. OAuth redirects and "
+            "bearer tokens over plaintext http would expose your library."
+        )
+
+    # Read-only unless writes are explicitly requested. An internet-reachable
+    # deployment is exactly where an unattended destructive tool call hurts
+    # most, and the read tools are what makes this useful in the first place.
+    if os.environ.get("RMMCP_ALLOW_WRITES", "").lower() not in ("1", "true", "yes"):
+        os.environ["REMARKABLE_READ_ONLY"] = "1"
+        logger.info("Write tools disabled (set RMMCP_ALLOW_WRITES=1 to enable).")
+    else:
+        logger.warning(
+            "Write tools ENABLED. Anything the model reads can drive uploads, moves, "
+            "renames and deletes on your library."
+        )
+
+    # Imported after the env is settled: remarkable_mcp.server decides which
+    # tools to register at import time.
+    from mcp.server.auth.provider import ProviderTokenVerifier
+    from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
+    from pydantic import AnyHttpUrl
+    from single_user_auth import SingleUserAuthProvider, register_login_routes
+
+    from remarkable_mcp.server import mcp
+
+    state_dir = os.environ.get("RMMCP_STATE_DIR")
+    provider = SingleUserAuthProvider(
+        public_url=public_url,
+        passphrase=passphrase,
+        state_dir=Path(state_dir) if state_dir else None,
+    )
+
+    # Attach the authorization server to the FastMCP instance the package built
+    # at import time. FastMCP reads these when it assembles the HTTP app, so
+    # setting them here is equivalent to passing them to its constructor.
+    mcp.settings.auth = AuthSettings(
+        issuer_url=AnyHttpUrl(public_url),
+        resource_server_url=AnyHttpUrl(public_url),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+    )
+    mcp._auth_server_provider = provider
+    mcp._token_verifier = ProviderTokenVerifier(provider)
+
+    register_login_routes(mcp, provider)
+
+    mcp.settings.host = os.environ.get("RMMCP_HOST", "127.0.0.1")
+    mcp.settings.port = int(os.environ.get("RMMCP_PORT", "8080"))
+
+    logger.info("Public URL:  %s", public_url)
+    logger.info("MCP endpoint: %s/mcp", public_url)
+    logger.info("Listening on %s:%s", mcp.settings.host, mcp.settings.port)
+
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,75 @@
+# nginx vhost for a self-hosted remarkable-mcp.
+#
+# Use this instead of deploy/Caddyfile when the host already serves other sites
+# with nginx. Caddy and nginx cannot both run: they compete for ports 80/443.
+#
+# Install:
+#   sudo cp deploy/nginx.conf /etc/nginx/sites-available/remarkable-mcp
+#   sudo sed -i 's/rm\.example\.org/YOUR.DOMAIN/' /etc/nginx/sites-available/remarkable-mcp
+#   sudo ln -s /etc/nginx/sites-available/remarkable-mcp /etc/nginx/sites-enabled/
+#   sudo nginx -t && sudo systemctl reload nginx
+#
+# Then obtain the certificate (nginx must be running and able to bind :80):
+#   sudo certbot --nginx -d YOUR.DOMAIN
+#
+# certbot rewrites the server blocks below to add the TLS lines. That is
+# expected — but do NOT let it replace the proxy settings in `location /`:
+# streamable HTTP keeps a long-lived response open and streams events, so
+# buffering must stay off and the read timeout long, which certbot's defaults
+# do not provide.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name rm.example.org;
+
+    # certbot adds its own redirect here once the certificate is issued.
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name rm.example.org;
+
+    # certbot fills these in with --nginx.
+    # ssl_certificate     /etc/letsencrypt/live/rm.example.org/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/rm.example.org/privkey.pem;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    server_tokens off;
+
+    access_log /var/log/nginx/remarkable-mcp.access.log;
+    error_log  /var/log/nginx/remarkable-mcp.error.log;
+
+    # The MCP endpoint and every OAuth route (/authorize, /token, /register,
+    # /login, /.well-known/*) are served by the same backend on loopback.
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection        "";
+
+        # Streamable HTTP holds the response open and pushes events as they
+        # happen. Buffering here would make the connection appear to hang.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        chunked_transfer_encoding on;
+    }
+}

--- a/deploy/remarkable-mcp.service
+++ b/deploy/remarkable-mcp.service
@@ -1,0 +1,54 @@
+# systemd unit for a self-hosted remarkable-mcp over HTTP.
+#
+# Install:
+#   sudo cp deploy/remarkable-mcp.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now remarkable-mcp
+#
+# Secrets live in /etc/remarkable-mcp.env (chmod 600, root-owned), NOT here:
+# this file is world-readable, that one is not.
+
+[Unit]
+Description=reMarkable MCP server (HTTP)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=remarkable
+Group=remarkable
+WorkingDirectory=/opt/remarkable-mcp
+
+# RMMCP_PUBLIC_URL, RMMCP_PASSPHRASE and (optionally) REMARKABLE_TOKEN.
+EnvironmentFile=/etc/remarkable-mcp.env
+
+ExecStart=/usr/local/bin/uv run --directory /opt/remarkable-mcp python deploy/http_server.py
+
+Restart=always
+RestartSec=5
+
+# Hardening. The service needs outbound HTTPS to the reMarkable cloud and write
+# access to its own state directory — nothing else.
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=false
+# State: OAuth records (~/.remarkable-mcp), the reMarkable token and blob cache.
+ReadWritePaths=/var/lib/remarkable-mcp
+Environment=HOME=/var/lib/remarkable-mcp
+Environment=RMMCP_STATE_DIR=/var/lib/remarkable-mcp/auth
+Environment=REMARKABLE_CACHE_DIR=/var/lib/remarkable-mcp/cache
+Environment=RMMCP_HOST=127.0.0.1
+Environment=RMMCP_PORT=8080
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/single_user_auth.py
+++ b/deploy/single_user_auth.py
@@ -1,0 +1,456 @@
+"""Single-user OAuth 2.1 authorization server for a self-hosted remarkable-mcp.
+
+Claude connects to a remote MCP server over HTTPS and expects it to speak OAuth
+2.1 with dynamic client registration — there is no field for pasting a static
+token. This module implements the smallest authorization server that satisfies
+that contract for a deployment with exactly one human user: you prove who you
+are with a single passphrase, and every token issued belongs to that same
+subject.
+
+The MCP SDK already implements the OAuth endpoints (``/authorize``, ``/token``,
+``/register``, and the discovery metadata) and verifies PKCE itself. What is
+left to supply is storage and a login screen, which is all this file is.
+
+Deliberately out of scope: multiple users, roles, per-scope consent, account
+recovery. If you need any of those, put a real identity provider in front and
+run FastMCP as a pure resource server (``token_verifier=``) instead.
+
+Configuration (environment):
+    RMMCP_PUBLIC_URL   Public HTTPS base URL, e.g. https://rm.example.org
+    RMMCP_PASSPHRASE   The login secret. Required. Use a long random string.
+    RMMCP_STATE_DIR    Where to persist clients/refresh tokens
+                       (default: ~/.remarkable-mcp)
+"""
+
+import json
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, Response
+
+logger = logging.getLogger(__name__)
+
+# Lifetimes. Authorization codes are single-use and short-lived; access tokens
+# are refreshed silently by the client; refresh tokens are what keep the
+# connector working across restarts without a new login.
+AUTH_CODE_TTL = 300  # 5 minutes
+ACCESS_TOKEN_TTL = 3600  # 1 hour
+REFRESH_TOKEN_TTL = 30 * 24 * 3600  # 30 days
+PENDING_LOGIN_TTL = 600  # 10 minutes to complete the login form
+
+# Brute-force protection for the login form. A single passphrase is the only
+# thing between the internet and the library, so failures are throttled and
+# eventually locked out for a cooling-off period.
+MAX_FAILED_ATTEMPTS = 5
+LOCKOUT_SECONDS = 900
+
+SUBJECT = "owner"  # the one and only user
+
+
+@dataclass
+class _PendingLogin:
+    """An authorization request parked while the human proves themselves."""
+
+    client_id: str
+    params: AuthorizationParams
+    created_at: float
+
+
+class SingleUserAuthProvider(OAuthAuthorizationServerProvider):
+    """OAuth authorization server backed by one passphrase.
+
+    Registered clients and refresh tokens are persisted to disk so that
+    restarting the service does not force you to reconnect the connector.
+    Authorization codes and access tokens are kept in memory only: they are
+    short-lived, and losing them on restart costs one silent refresh.
+    """
+
+    def __init__(
+        self,
+        public_url: str,
+        passphrase: str,
+        state_dir: Optional[Path] = None,
+    ):
+        if not passphrase:
+            raise ValueError("RMMCP_PASSPHRASE must be set to a non-empty value.")
+        if len(passphrase) < 16:
+            raise ValueError(
+                "RMMCP_PASSPHRASE is too short (minimum 16 characters). "
+                "Generate one with: openssl rand -base64 32"
+            )
+
+        self.public_url = public_url.rstrip("/")
+        self._passphrase = passphrase
+        self._state_path = (state_dir or Path.home() / ".remarkable-mcp") / "auth-state.json"
+
+        self._clients: Dict[str, OAuthClientInformationFull] = {}
+        self._refresh_tokens: Dict[str, RefreshToken] = {}
+        self._auth_codes: Dict[str, AuthorizationCode] = {}
+        self._access_tokens: Dict[str, AccessToken] = {}
+        self._pending: Dict[str, _PendingLogin] = {}
+
+        self._failed_attempts = 0
+        self._locked_until = 0.0
+
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _load_state(self) -> None:
+        if not self._state_path.is_file():
+            return
+        try:
+            data = json.loads(self._state_path.read_text())
+        except Exception as e:
+            logger.warning("Could not read auth state (%s); starting fresh.", e)
+            return
+
+        for raw in data.get("clients", []):
+            try:
+                client = OAuthClientInformationFull.model_validate(raw)
+                self._clients[client.client_id] = client
+            except Exception as e:
+                logger.debug("Skipping unreadable client record: %s", e)
+
+        now = time.time()
+        for raw in data.get("refresh_tokens", []):
+            try:
+                token = RefreshToken.model_validate(raw)
+            except Exception as e:
+                logger.debug("Skipping unreadable refresh token: %s", e)
+                continue
+            if token.expires_at and token.expires_at < now:
+                continue
+            self._refresh_tokens[token.token] = token
+
+        logger.info(
+            "Loaded %d client(s) and %d refresh token(s) from %s",
+            len(self._clients),
+            len(self._refresh_tokens),
+            self._state_path,
+        )
+
+    def _save_state(self) -> None:
+        """Persist clients and refresh tokens, owner-readable only.
+
+        These records are bearer credentials for the whole library, so the file
+        is created 0600 and the directory 0700 before anything is written.
+        """
+        payload = {
+            "clients": [
+                c.model_dump(mode="json", exclude_none=True) for c in self._clients.values()
+            ],
+            "refresh_tokens": [
+                t.model_dump(mode="json", exclude_none=True) for t in self._refresh_tokens.values()
+            ],
+        }
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            tmp = self._state_path.with_suffix(".tmp")
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                json.dump(payload, f)
+            os.replace(tmp, self._state_path)
+        except Exception as e:
+            logger.error("Failed to persist auth state: %s", e)
+
+    # ------------------------------------------------------------------
+    # Client registration (RFC 7591) — Claude registers itself on first connect
+    # ------------------------------------------------------------------
+
+    async def get_client(self, client_id: str) -> Optional[OAuthClientInformationFull]:
+        return self._clients.get(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        self._clients[client_info.client_id] = client_info
+        self._save_state()
+        logger.info(
+            "Registered OAuth client %s (%s)", client_info.client_id, client_info.client_name
+        )
+
+    # ------------------------------------------------------------------
+    # Authorization: park the request, send the human to the login form
+    # ------------------------------------------------------------------
+
+    async def authorize(
+        self, client: OAuthClientInformationFull, params: AuthorizationParams
+    ) -> str:
+        self._expire_pending()
+        request_id = secrets.token_urlsafe(24)
+        self._pending[request_id] = _PendingLogin(
+            client_id=client.client_id,
+            params=params,
+            created_at=time.time(),
+        )
+        return f"{self.public_url}/login?rid={request_id}"
+
+    def _expire_pending(self) -> None:
+        cutoff = time.time() - PENDING_LOGIN_TTL
+        for rid in [r for r, p in self._pending.items() if p.created_at < cutoff]:
+            del self._pending[rid]
+
+    # ------------------------------------------------------------------
+    # Login form (wired up by register_login_routes below)
+    # ------------------------------------------------------------------
+
+    def _lockout_remaining(self) -> int:
+        return max(0, int(self._locked_until - time.time()))
+
+    def render_login(self, request_id: str, error: Optional[str] = None) -> Response:
+        if request_id not in self._pending:
+            return HTMLResponse(
+                _page(
+                    "Lien expiré",
+                    "Cette demande de connexion a expiré. Relancez la connexion depuis Claude.",
+                ),
+                status_code=400,
+            )
+        remaining = self._lockout_remaining()
+        if remaining:
+            return HTMLResponse(
+                _page(
+                    "Trop de tentatives",
+                    f"Réessayez dans {remaining // 60 + 1} minute(s).",
+                ),
+                status_code=429,
+            )
+        return HTMLResponse(_login_form(request_id, error))
+
+    def complete_login(self, request_id: str, passphrase: str) -> Response:
+        """Validate the passphrase and hand an authorization code back to Claude."""
+        if self._lockout_remaining():
+            return self.render_login(request_id)
+
+        pending = self._pending.get(request_id)
+        if pending is None:
+            return HTMLResponse(
+                _page(
+                    "Lien expiré",
+                    "Cette demande de connexion a expiré. Relancez la connexion depuis Claude.",
+                ),
+                status_code=400,
+            )
+
+        if not secrets.compare_digest(passphrase, self._passphrase):
+            self._failed_attempts += 1
+            if self._failed_attempts >= MAX_FAILED_ATTEMPTS:
+                self._locked_until = time.time() + LOCKOUT_SECONDS
+                self._failed_attempts = 0
+                logger.warning("Login locked out after repeated failures.")
+            else:
+                logger.warning(
+                    "Failed login attempt (%d/%d)", self._failed_attempts, MAX_FAILED_ATTEMPTS
+                )
+            return self.render_login(request_id, error="Phrase secrète incorrecte.")
+
+        # Success: burn the pending request and mint a single-use code.
+        del self._pending[request_id]
+        self._failed_attempts = 0
+
+        code = secrets.token_urlsafe(32)
+        self._auth_codes[code] = AuthorizationCode(
+            code=code,
+            client_id=pending.client_id,
+            redirect_uri=pending.params.redirect_uri,
+            redirect_uri_provided_explicitly=pending.params.redirect_uri_provided_explicitly,
+            scopes=pending.params.scopes or [],
+            expires_at=time.time() + AUTH_CODE_TTL,
+            code_challenge=pending.params.code_challenge,
+            resource=pending.params.resource,
+            subject=SUBJECT,
+        )
+        logger.info("Login accepted; issuing authorization code to %s", pending.client_id)
+
+        return RedirectResponse(
+            construct_redirect_uri(
+                str(pending.params.redirect_uri),
+                code=code,
+                state=pending.params.state,
+            ),
+            status_code=302,
+        )
+
+    # ------------------------------------------------------------------
+    # Token issuance
+    # ------------------------------------------------------------------
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> Optional[AuthorizationCode]:
+        code = self._auth_codes.get(authorization_code)
+        if code is None or code.client_id != client.client_id:
+            return None
+        if code.expires_at < time.time():
+            del self._auth_codes[authorization_code]
+            return None
+        return code
+
+    async def exchange_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode
+    ) -> OAuthToken:
+        # Single use: the code is spent whether or not what follows succeeds.
+        self._auth_codes.pop(authorization_code.code, None)
+        return self._issue_tokens(
+            client.client_id, authorization_code.scopes, authorization_code.resource
+        )
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ) -> Optional[RefreshToken]:
+        token = self._refresh_tokens.get(refresh_token)
+        if token is None or token.client_id != client.client_id:
+            return None
+        if token.expires_at and token.expires_at < time.time():
+            del self._refresh_tokens[refresh_token]
+            self._save_state()
+            return None
+        return token
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        # Rotate: the presented refresh token is retired as the new pair is issued.
+        self._refresh_tokens.pop(refresh_token.token, None)
+        return self._issue_tokens(client.client_id, scopes or refresh_token.scopes, None)
+
+    def _issue_tokens(
+        self, client_id: str, scopes: list[str], resource: Optional[str]
+    ) -> OAuthToken:
+        self._expire_access_tokens()
+        access = secrets.token_urlsafe(32)
+        refresh = secrets.token_urlsafe(32)
+        now = time.time()
+
+        self._access_tokens[access] = AccessToken(
+            token=access,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=int(now + ACCESS_TOKEN_TTL),
+            resource=resource,
+            subject=SUBJECT,
+        )
+        self._refresh_tokens[refresh] = RefreshToken(
+            token=refresh,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=int(now + REFRESH_TOKEN_TTL),
+            subject=SUBJECT,
+        )
+        self._save_state()
+
+        return OAuthToken(
+            access_token=access,
+            token_type="Bearer",
+            expires_in=ACCESS_TOKEN_TTL,
+            scope=" ".join(scopes) if scopes else None,
+            refresh_token=refresh,
+        )
+
+    def _expire_access_tokens(self) -> None:
+        now = time.time()
+        for tok in [
+            t for t, a in self._access_tokens.items() if a.expires_at and a.expires_at < now
+        ]:
+            del self._access_tokens[tok]
+
+    async def load_access_token(self, token: str) -> Optional[AccessToken]:
+        access = self._access_tokens.get(token)
+        if access is None:
+            return None
+        if access.expires_at and access.expires_at < time.time():
+            del self._access_tokens[token]
+            return None
+        return access
+
+    async def revoke_token(self, token: Any) -> None:
+        value = getattr(token, "token", token)
+        self._access_tokens.pop(value, None)
+        if self._refresh_tokens.pop(value, None) is not None:
+            self._save_state()
+
+
+# ----------------------------------------------------------------------
+# Login pages — plain HTML, no external assets (nothing to fetch, nothing to
+# leak a referrer to).
+# ----------------------------------------------------------------------
+
+_STYLE = """
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         background: #1e1e1e; color: #e8e8e8; display: flex; min-height: 100vh;
+         align-items: center; justify-content: center; margin: 0; }
+  .card { background: #262626; padding: 2rem; border-radius: .6rem; width: min(26rem, 90vw);
+          box-shadow: 0 2px 16px rgba(0,0,0,.4); }
+  h1 { font-size: 1.15rem; margin: 0 0 .5rem; }
+  p { opacity: .75; font-size: .9rem; line-height: 1.5; }
+  input { width: 100%; box-sizing: border-box; font: inherit; padding: .6rem;
+          border-radius: .4rem; border: 1px solid rgba(255,255,255,.2);
+          background: #1a1a1a; color: inherit; margin: .75rem 0; }
+  button { width: 100%; font: inherit; padding: .6rem; border-radius: .4rem; cursor: pointer;
+           border: none; background: #4a7ec7; color: #fff; font-weight: 600; }
+  .err { color: #ff8a8a; font-size: .85rem; }
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return (
+        f"<!doctype html><html lang=fr><head><meta charset=utf-8>"
+        f"<meta name=viewport content='width=device-width,initial-scale=1'>"
+        f"<title>{title}</title><style>{_STYLE}</style></head>"
+        f"<body><div class=card><h1>{title}</h1><p>{body}</p></div></body></html>"
+    )
+
+
+def _login_form(request_id: str, error: Optional[str] = None) -> str:
+    err = f"<p class=err>{error}</p>" if error else ""
+    return (
+        f"<!doctype html><html lang=fr><head><meta charset=utf-8>"
+        f"<meta name=viewport content='width=device-width,initial-scale=1'>"
+        f"<title>Connexion reMarkable</title><style>{_STYLE}</style></head>"
+        f"<body><div class=card>"
+        f"<h1>Connecter Claude à votre reMarkable</h1>"
+        f"<p>Saisissez la phrase secrète de votre serveur pour autoriser l'accès.</p>"
+        f"{err}"
+        f'<form method="post" action="/login">'
+        f'<input type="hidden" name="rid" value="{request_id}">'
+        f'<input type="password" name="passphrase" placeholder="Phrase secrète" '
+        f'autocomplete="current-password" autofocus required>'
+        f"<button type=submit>Autoriser</button>"
+        f"</form></div></body></html>"
+    )
+
+
+def register_login_routes(mcp, provider: SingleUserAuthProvider) -> None:
+    """Attach the login form routes to a FastMCP instance."""
+
+    @mcp.custom_route("/login", methods=["GET"])
+    async def login_form(request: Request) -> Response:
+        return provider.render_login(request.query_params.get("rid", ""))
+
+    @mcp.custom_route("/login", methods=["POST"])
+    async def login_submit(request: Request) -> Response:
+        form = await request.form()
+        return provider.complete_login(str(form.get("rid", "")), str(form.get("passphrase", "")))
+
+    @mcp.custom_route("/healthz", methods=["GET"])
+    async def healthz(_: Request) -> Response:
+        return Response("ok", media_type="text/plain")

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -1,0 +1,382 @@
+# Revue de sécurité — remarkable-mcp
+
+Revue statique du dépôt `nanocorpintl/remarkable-mcp` (commit `e01f799`).
+Périmètre : l'intégralité du paquet `remarkable_mcp/`, les points d'entrée
+(`server.py`, `cli.py`), les workflows GitHub Actions, la chaîne de dépendances
+(`pyproject.toml` / `uv.lock`) et la documentation.
+
+Aucun test dynamique n'a été exécuté (pas de tablette ni de compte cloud
+disponibles) : les constats ci-dessous sont issus d'une lecture de code et
+d'une analyse de flux de données. Les niveaux d'exploitabilité sont indiqués
+pour chaque point.
+
+---
+
+## 1. Modèle de menace
+
+Ce serveur MCP est un pont entre trois domaines de confiance très différents :
+
+| Domaine | Contenu | Confiance |
+|---|---|---|
+| Hôte local | jetons, clés SSH, système de fichiers de l'utilisateur | élevée |
+| Tablette / cloud reMarkable | documents, métadonnées, `.content`, `.rm`, PDF/EPUB | **faible** |
+| Modèle / client MCP | arguments d'outils générés par un LLM | **faible** |
+
+Les deux surfaces d'attaque structurantes sont :
+
+1. **Contenu de document → contexte du modèle → appel d'outil.** Tout ce que le
+   serveur renvoie (texte extrait, OCR, noms de documents, descriptions de
+   ressources) entre dans le contexte du LLM. Un document piégé — reçu par
+   partage, synchronisé depuis le cloud, ou simplement un PDF téléchargé — peut
+   contenir des instructions qui pilotent les outils d'écriture du serveur.
+2. **Données de l'appareil → shell distant.** En mode SSH, des champs issus de
+   fichiers `.content` / de noms de fichiers de la tablette sont interpolés dans
+   des commandes shell exécutées **en root** sur l'appareil.
+
+---
+
+## 2. Synthèse
+
+| Réf | Gravité | Constat | Emplacement |
+|---|---|---|---|
+| H1 | Élevée | Écriture activée par défaut, sans confirmation sauf pour `delete` → surface directement pilotable par injection de prompt | `write_tools.py` |
+| H2 | Élevée | Les outils d'écriture ignorent le cloisonnement `REMARKABLE_ROOT_PATH` | `write_tools.py` |
+| H3 | Élevée | Injection de commande shell (root, sur la tablette) via interpolation non échappée | `ssh.py`, `write_tools.py` |
+| M1 | Moyenne | Mot de passe SSH passé en argument de processus (`sshpass -p`) | `ssh.py:159,207` ; `write_tools.py:169` |
+| M2 | Moyenne | Jeton cloud persisté en clair, permissions par défaut, écriture non sollicitée | `api.py:103,231` |
+| M3 | Moyenne | `remarkable_upload` = lecture de fichier local arbitraire → exfiltration vers le cloud | `write_tools.py:962-1007` |
+| M4 | Moyenne | Clé Google Vision en query string ; contenu manuscrit envoyé à un tiers ; échecs silencieux | `tools.py:255` ; `extract.py:1885` |
+| M5 | Moyenne | Bascule silencieuse d'un transport local (USB/SSH) vers le cloud | `api.py:176-184` |
+| M6 | Moyenne | Canvas MCP App : sink `innerHTML` + handler `message` sans contrôle d'origine | `app_canvas.py:151,180,548` |
+| M7 | Moyenne | Décompression d'archives sans plafond (zip bomb) | `extract.py:1107,1139,1186,1404,1568,1651` |
+| L1 | Faible | `StrictHostKeyChecking=accept-new` sans `known_hosts` dédié (TOFU) | `ssh.py:150,198` |
+| L2 | Faible | Transport USB web en HTTP clair, sans authentification | `usb_web.py:34,124` |
+| L3 | Faible | Cache de blobs en clair, sans restriction de permissions ni plafond | `sync.py:455-467` |
+| L4 | Faible | ReDoS possible via le paramètre `grep` | `tools.py:573,645` |
+| L5 | Faible | Chaîne CI : actions par tag mutable, binaire téléchargé sans vérification d'empreinte | `.github/workflows/publish.yml:125` |
+| L6 | Faible | Pas de CI sécurité (SAST / audit de dépendances), pas de `SECURITY.md` | dépôt |
+| L7 | Faible | Bornes basses de dépendances trop permissives (`ebooklib>=0.18`) | `pyproject.toml:22-32` |
+| L8 | Faible | ~90 `except Exception` silencieux ; aucune journalisation d'audit des écritures | tout le paquet |
+
+---
+
+## 3. Constats détaillés
+
+### H1 — Écriture activée par défaut, confirmation seulement sur `delete`
+
+`write_tools.write_enabled()` renvoie `True` sauf si `--read-only` /
+`REMARKABLE_READ_ONLY` est positionné (`write_tools.py:54-65`). Le serveur
+expose donc par défaut `remarkable_upload`, `remarkable_mkdir`,
+`remarkable_move`, `remarkable_rename`, `remarkable_delete` et, en SSH,
+`remarkable_author` (dessin, ajout de page, création de document).
+
+Seul `remarkable_delete` passe par `_confirm_delete()` (`write_tools.py:496`),
+qui **refuse** l'opération si le client ne sait pas afficher de prompt
+d'élicitation. C'est une conception fail-closed exemplaire — mais elle n'est
+appliquée qu'à `delete`. `move`, `rename`, `mkdir`, `upload` et `author`
+s'exécutent silencieusement.
+
+Impact : un document contenant des instructions du type « déplace tous les
+documents vers /Archive et renomme-les » est lu par `remarkable_read`, entre
+dans le contexte du modèle, et peut déclencher ces appels sans qu'aucune
+confirmation ne s'affiche. `remarkable_move` vers un dossier obscur est
+fonctionnellement équivalent à une suppression du point de vue de
+l'utilisateur, sans la garde de `delete`.
+
+Recommandations :
+- Étendre `_confirm_delete` en un `_confirm_mutation(kind, target)` appliqué à
+  `move`, `rename` et `upload` (au minimum quand la destination sort du dossier
+  courant).
+- Envisager `--read-only` comme **défaut**, l'écriture devenant opt-in explicite
+  (`--write`). C'est l'inverse du choix actuel, documenté dans l'en-tête du
+  module, mais c'est le défaut sûr pour un serveur qui ingère du contenu non
+  fiable.
+- Documenter explicitement dans le README que lire un document tiers avec ce
+  serveur en mode écriture équivaut à lui accorder un droit d'écriture sur la
+  bibliothèque.
+
+### H2 — Les outils d'écriture ignorent `REMARKABLE_ROOT_PATH`
+
+`REMARKABLE_ROOT_PATH` est le mécanisme de cloisonnement du serveur : il limite
+la vue à un sous-arbre. Il est correctement appliqué en lecture — `tools.py:349,
+363, 857, 937, 1081, 1396, 1590, 1604` et `resources.py:289` — via
+`_is_within_root()`.
+
+`write_tools.py` ne référence **aucun** de ces helpers. `_resolve_document()`
+(`write_tools.py:301`) et `_resolve_parent_id()` (`write_tools.py:274`) parcourent
+l'intégralité de `client.get_meta_items()`.
+
+Conséquence : avec `REMARKABLE_ROOT_PATH=/Work`, le modèle ne peut pas *lire*
+`/Personnel/Impôts`, mais peut le renommer, le déplacer, le supprimer, ou
+écraser son contenu via `remarkable_author`. Le cloisonnement est une barrière
+en lecture seule, ce que la documentation ne signale pas.
+
+Correctif : appliquer le filtre racine dans `_resolve_document` /
+`_resolve_parent_id`, ou factoriser les helpers de `tools.py` dans un module
+partagé et les invoquer avant toute mutation.
+
+### H3 — Injection de commande shell sur la tablette (exécution root)
+
+Toutes les commandes SSH sont construites par interpolation de chaînes, avec des
+guillemets simples posés à la main et **aucun** `shlex.quote` dans le dépôt :
+
+- `ssh.py:202` — `f"cat '{remote_path}'"`
+- `ssh.py:360` — `f"find '{doc_path}' -type f ..."`
+- `ssh.py:369,378,419` — `f"test -f '{...}'"`
+- `write_tools.py:139,146` — `f"cat > '{remote_path}' << 'REMARKABLE_EOF'\n{content}\n..."`
+- `write_tools.py:162` — `f"cat > '{remote_path}'"`
+- `write_tools.py:227` — `f"test -f '{remote_path}' && echo yes || echo no"`
+- `write_tools.py:790,1084` — `f"mkdir -p '{XOCHITL_PATH}/{doc_uuid}'"`
+
+Un guillemet simple dans une valeur interpolée termine la citation et permet
+d'injecter une commande arbitraire, exécutée en **root** sur la tablette
+(l'utilisateur SSH par défaut est `root`).
+
+Chaîne d'exploitation la plus directe, dans `_author_draw` :
+
+1. `content_data` est le JSON `.content` téléchargé depuis la tablette
+   (`write_tools.py:591`).
+2. `page_ids = _page_ids_from_content(content_data)` en extrait les identifiants
+   de page — aucune validation de format (`write_tools.py:199-213, 596`).
+3. `rm_path = f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm"` (`write_tools.py:612`).
+4. `rm_path` atteint `_remote_file_exists` puis `_upload_file_bytes`, où il est
+   interpolé dans la commande distante.
+
+Un `.content` dont un `pages[].id` vaut `a'; <commande>; echo '` provoque donc
+l'exécution de `<commande>` en root. La même faiblesse existe pour `doc.id`
+(dérivé des noms de fichiers de l'appareil) dans `download()` et
+`download_raw_file()`.
+
+Exploitabilité : nécessite qu'un document malveillant se retrouve dans la
+bibliothèque (partage, synchronisation cloud, import). Élevée en gravité,
+moyenne en probabilité.
+
+Correctif : `shlex.quote()` systématique sur toute valeur interpolée, et
+validation stricte des identifiants (`re.fullmatch(r"[0-9a-fA-F-]{36}", ...)`)
+avant toute construction de chemin distant. Le heredoc de `_write_metadata`
+est actuellement protégé de manière fortuite (l'échappement JSON empêche
+qu'une ligne égale le délimiteur) — protection fragile, à ne pas conserver
+telle quelle.
+
+### M1 — Mot de passe SSH exposé dans la table des processus
+
+`ssh.py:159`, `ssh.py:207` et `write_tools.py:169` construisent
+`["sshpass", "-p", self.password] + ssh_args`. Sous Linux, `/proc/<pid>/cmdline`
+est lisible par tout utilisateur local : le mot de passe apparaît dans un
+simple `ps aux` pendant toute la durée de l'appel.
+
+Correctif : utiliser `sshpass -e` avec le mot de passe dans l'environnement du
+sous-processus (`env={"SSHPASS": ...}`), ou mieux, `sshpass -f <fd>`. La
+documentation (`docs/ssh-setup.md:88`) recommande déjà l'authentification par
+clé — c'est le bon conseil, mais le chemin mot de passe doit rester sûr.
+
+### M2 — Gestion du jeton cloud
+
+Dans `api.py:_get_cloud_client()` :
+
+```python
+if REMARKABLE_TOKEN:
+    rmapi_file = Path.home() / ".rmapi"
+    rmapi_file.write_text(REMARKABLE_TOKEN)   # api.py:103
+```
+
+Deux problèmes :
+
+1. **Écriture non sollicitée.** Un utilisateur qui fournit le jeton uniquement
+   par variable d'environnement (par exemple depuis un gestionnaire de secrets)
+   voit ce jeton recopié sur disque à chaque résolution du client, sans y avoir
+   consenti.
+2. **Permissions par défaut.** `write_text` crée le fichier selon l'umask, soit
+   `0644` dans la configuration usuelle. Le jeton de périphérique reMarkable est
+   un secret longue durée qui donne accès à toute la bibliothèque.
+
+Même remarque pour `register_and_get_token` (`api.py:231`).
+
+Correctif : `os.open(path, O_WRONLY|O_CREAT|O_TRUNC, 0o600)` (ou `chmod(0o600)`
+juste après écriture), et n'écrire le fichier que lors d'un `--register`
+explicite, pas à chaque résolution depuis l'environnement.
+
+### M3 — `remarkable_upload` : lecture de fichier local arbitraire
+
+`remarkable_upload(file_path, ...)` ouvre n'importe quel chemin absolu de l'hôte
+(`write_tools.py:962-995`) et en téléverse le contenu vers la tablette ou le
+cloud. Les seuls contrôles sont l'existence du fichier et une extension
+`.pdf`/`.epub`.
+
+C'est une primitive d'exfiltration : un modèle sous injection de prompt peut
+copier n'importe quel PDF de l'hôte (contrat, scan de pièce d'identité, dossier
+médical) dans le cloud reMarkable de l'utilisateur, d'où il se synchronise vers
+tous ses appareils. Aucune vérification par rapport aux *roots* MCP déclarés par
+le client, aucune confirmation.
+
+Correctif : restreindre `file_path` aux roots MCP annoncés par le client (le
+serveur dispose déjà de `capabilities.py` pour interroger le client), ou à un
+répertoire configuré (`REMARKABLE_UPLOAD_DIR`), et exiger une confirmation pour
+les chemins hors périmètre.
+
+### M4 — OCR Google Vision
+
+- La clé API est transmise en **query string** :
+  `f"https://vision.googleapis.com/v1/images:annotate?key={api_key}"`
+  (`tools.py:255`, `extract.py:1885`). Les URLs complètes fuient plus facilement
+  que les en-têtes (journaux de proxy, traces d'exception, télémétrie de
+  bibliothèque HTTP). Préférer l'en-tête `X-Goog-Api-Key`.
+- Le contenu manuscrit — potentiellement le plus sensible de la bibliothèque —
+  est envoyé à un tiers. C'est un choix assumé et **correctement documenté**
+  (`docs/google-vision-setup.md:162`) ; à conserver, en le rappelant dans les
+  réponses d'outil qui déclenchent l'OCR distant.
+- Les erreurs sont avalées (`except Exception: pass`, `tools.py:271`), et un
+  `401`/`403` provoque un repli silencieux vers Tesseract (`extract.py:1905`).
+  L'utilisateur ne sait pas que sa clé est invalide ni que la qualité vient de
+  chuter.
+
+### M5 — Bascule silencieuse vers le cloud
+
+`get_rmapi()` (`api.py:153-189`) : si `--usb`/`--ssh` est demandé mais que la
+tablette est injoignable, et qu'un jeton cloud existe, le serveur bascule
+automatiquement en mode cloud. C'est pratique, mais c'est un changement de
+posture de sécurité : un utilisateur ayant délibérément choisi un transport
+local et hors-ligne voit sa bibliothèque transiter par le réseau. Le seul signal
+est un `logger.warning`, invisible dans la plupart des clients MCP.
+
+L'échappatoire existe (`REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) mais le défaut
+privilégie la commodité sur la confidentialité. Recommandation : inverser le
+défaut, ou au minimum faire remonter la bascule dans la réponse de
+`remarkable_status` et dans le premier résultat d'outil concerné.
+
+### M6 — Canvas MCP App (`app_canvas.py`)
+
+Trois faiblesses défensives dans l'iframe :
+
+1. `setStatus()` écrit via `innerHTML` (`app_canvas.py:151`) et est appelée avec
+   des données serveur : `"Error: " + data.error` (ligne 180),
+   `"Save failed: " + msg` (ligne 392), `"Failed to load page: " + err.message`
+   (ligne 516). Tout HTML présent dans ces chaînes est interprété.
+2. Le handler `message` (ligne 548) ne vérifie **jamais** `event.origin`. Toute
+   frame capable de poster un message dans l'iframe peut injecter un
+   `ui/notifications/tool-result` factice et donc du contenu arbitraire dans
+   `render()`.
+3. `post()` émet vers `window.parent` avec l'origine cible `"*"`
+   (ligne 137), ce qui diffuse le contenu des messages à n'importe quel parent.
+
+L'iframe est sandboxée par l'hôte et le rendu concerne les données de
+l'utilisateur lui-même, donc l'impact reste contenu — mais la défense en
+profondeur manque. Correctifs : `textContent` partout où le HTML n'est pas
+nécessaire, contrôle d'`event.origin` contre l'origine de l'hôte, et origine
+cible explicite dans `postMessage`.
+
+### M7 — Décompression d'archives sans plafond
+
+`zf.extractall(tmpdir_path)` est appelé en six endroits (`extract.py:1107, 1139,
+1186, 1404, 1568, 1651`) sur des archives issues de la tablette (`.rmdoc` en mode
+USB) ou reconstruites depuis le cloud.
+
+Le *zip slip* classique n'est pas exploitable : CPython neutralise les
+composants `..` dans `ZipFile._extract_member`. Le risque résiduel est
+l'**épuisement de ressources** — aucune vérification de `file_size` cumulé, du
+ratio de compression ni du nombre d'entrées avant extraction. Un `.rmdoc` piégé
+remplit le disque de l'hôte.
+
+Correctif : parcourir `zf.infolist()` avant extraction et rejeter au-delà de
+seuils (taille décompressée totale, ratio, nombre de membres).
+
+### Constats de gravité faible
+
+- **L1 — TOFU SSH.** `StrictHostKeyChecking=accept-new` (`ssh.py:150,198`)
+  accepte toute clé hôte au premier contact. Sur le lien USB `10.11.99.1` c'est
+  acceptable ; dès que `REMARKABLE_SSH_HOST` pointe vers une adresse Wi-Fi, un
+  MITM au premier contact devient possible. Envisager un `UserKnownHostsFile`
+  dédié et une option de vérification d'empreinte.
+- **L2 — USB web en clair.** `http://10.11.99.1`, sans authentification
+  (`usb_web.py:34`). Correctement documenté (`docs/usb-web-setup.md:164`).
+  `REMARKABLE_USB_HOST` accepte cependant n'importe quelle URL, y compris un
+  hôte distant en HTTP : valider que l'hôte reste sur le lien USB, ou avertir.
+- **L3 — Cache de blobs.** `~/.remarkable/cache/blobs` (`sync.py:455-467`)
+  stocke en clair métadonnées et contenus de documents (jusqu'à 4 Mo par blob),
+  avec les permissions par défaut, sans plafond global ni éviction. Ajouter
+  `0o700` sur le répertoire, `0o600` sur les fichiers, et une politique de
+  purge.
+- **L4 — ReDoS.** Le paramètre `grep` de `remarkable_read` est compilé tel quel
+  (`tools.py:573,645`). Une expression pathologique fournie par le modèle bloque
+  un thread de travail. Impact limité (auto-infligé), mais un plafond de
+  longueur et un timeout d'exécution seraient prudents.
+- **L5 — Chaîne CI.** Les actions tierces sont épinglées par tag mutable
+  (`softprops/action-gh-release@v3`, `astral-sh/setup-uv@v7`,
+  `SamMorrowDrums/mcp-conformance-action@v3`) : épingler par SHA. Surtout,
+  `publish.yml:125` télécharge `mcp-publisher` depuis la release `latest` via
+  `curl | tar`, sans vérification de somme de contrôle ni de signature, dans un
+  job disposant de `id-token: write` — compromettre cette release permettrait de
+  publier au nom du projet dans le registre MCP.
+- **L6 — Absence d'outillage sécurité.** Aucun workflow CodeQL / SAST, aucun
+  audit de dépendances (`pip-audit`, `uv pip audit`) en CI, pas de
+  `SECURITY.md` (donc pas de canal de divulgation responsable). Dependabot est
+  bien configuré pour pip et github-actions, ce qui couvre partiellement le
+  besoin.
+- **L7 — Bornes de dépendances.** `pyproject.toml` ne fixe que des bornes
+  basses. `ebooklib>=0.18` autorise des versions vulnérables à l'XXE (corrigé en
+  0.19) ; `uv.lock` épingle 0.20, mais le lock ne s'applique pas à une
+  installation `uvx remarkable-mcp` chez l'utilisateur final. Remonter les
+  planchers au-dessus des versions vulnérables connues. Les versions
+  verrouillées actuelles sont saines et à jour (Pillow 12.2.0, requests 2.33.0,
+  lxml 6.1.0, cryptography 49.0.0, urllib3 2.7.0).
+- **L8 — Silence des erreurs.** ~90 blocs `except Exception` avalent les
+  exceptions (36 dans `extract.py`, 12 dans `sync.py`, 10 dans `ssh.py` et
+  `tools.py`). Les échecs d'authentification, de vérification et de réseau
+  deviennent indiscernables d'un document vide. Aucune journalisation d'audit
+  des opérations d'écriture n'est produite : après un incident, rien ne permet
+  de reconstituer ce que le modèle a modifié.
+
+---
+
+## 4. Points positifs
+
+- `_confirm_delete` **refuse** de supprimer quand le client ne peut pas afficher
+  de confirmation, au lieu de continuer silencieusement (`write_tools.py:496-549`)
+  — conception fail-closed rare et bienvenue.
+- Annotations MCP correctes : `readOnlyHint`, `destructiveHint` sur `delete`,
+  `openWorldHint=False`, ce qui permet aux clients d'appliquer leurs propres
+  garde-fous.
+- `move` empêche les cycles (déplacement d'un dossier dans lui-même ou un
+  descendant), côté cloud et côté SSH.
+- SSH : `BatchMode=yes` (jamais de prompt interactif) et `IdentitiesOnly=yes`
+  quand une clé est fournie — évite les fuites d'identité vers un agent.
+- Écritures cloud protégées par génération (concurrence optimiste,
+  `sync.py:858-915`), avec réessais et *full jitter*.
+- Workflows GitHub Actions en permissions minimales (`contents: read` par
+  défaut), publication PyPI par *trusted publishing* (pas de jeton long terme),
+  aucun `pull_request_target`.
+- Aucun secret en dur, aucun secret dans l'historique Git (52 commits inspectés).
+- Documentation honnête sur les compromis : envoi du contenu à Google
+  (`google-vision-setup.md:162`), absence d'authentification en USB web
+  (`usb-web-setup.md:164`), accès root de SSH (`ssh-setup.md:231`).
+- Cache OCR en mémoire uniquement, avec TTL — pas de persistance du texte
+  reconnu sur disque.
+
+---
+
+## 5. Plan de remédiation proposé
+
+**Priorité 1 — à traiter avant tout usage avec des documents tiers**
+
+1. `shlex.quote()` sur toutes les interpolations de commandes SSH et validation
+   stricte des UUID/identifiants de page (H3).
+2. Appliquer `REMARKABLE_ROOT_PATH` dans `write_tools.py` (H2).
+3. Étendre la confirmation par élicitation à `move`, `rename` et `upload` (H1).
+
+**Priorité 2**
+
+4. `sshpass -e` au lieu de `-p` (M1).
+5. Permissions `0600` sur `~/.rmapi` et écriture uniquement sur `--register` (M2).
+6. Confiner `remarkable_upload` aux roots MCP ou à un répertoire configuré (M3).
+7. Plafonds de décompression avant `extractall` (M7).
+
+**Priorité 3**
+
+8. Clé Google Vision en en-tête, remontée explicite des erreurs d'OCR (M4).
+9. Signaler la bascule vers le cloud dans les réponses d'outil (M5).
+10. `textContent` + contrôle d'origine dans le canvas (M6).
+11. Permissions et purge du cache de blobs (L3).
+12. CI : épinglage par SHA, vérification d'empreinte du binaire `mcp-publisher`,
+    ajout de CodeQL et d'un audit de dépendances, création d'un `SECURITY.md`
+    (L5, L6).
+13. Journal d'audit des opérations d'écriture (L8).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,236 @@
+# Auto-hébergement — connecter Claude à votre reMarkable sans rien installer sur votre ordinateur
+
+Ce guide déploie `remarkable-mcp` sur votre propre serveur, exposé en HTTPS avec
+authentification OAuth, pour l'ajouter comme **connecteur personnalisé** dans
+Claude. Résultat : vos notes sont accessibles depuis claude.ai, l'application
+mobile ou Claude Desktop, sans rien installer localement, et sans confier vos
+documents à un service tiers.
+
+Le CLI du projet ne parle que stdio (le client doit alors tourner sur la même
+machine). Les fichiers de `deploy/` ajoutent la couche manquante : transport
+HTTP + serveur d'autorisation OAuth mono-utilisateur.
+
+**Temps estimé :** 45 à 60 minutes.
+
+---
+
+## Ce qu'il vous faut
+
+| | |
+|---|---|
+| Un VPS | 1 vCPU / 1 Go suffisent. Debian 12 ou Ubuntu 24.04. |
+| Un nom de domaine | Un sous-domaine suffit, ex. `rm.mondomaine.fr` |
+| Un abonnement reMarkable Connect | Sans lui, rien n'est synchronisé dans le cloud |
+
+---
+
+## Étape 1 — Le DNS
+
+Créez un enregistrement **A** pointant votre sous-domaine vers l'IP de votre VPS,
+puis vérifiez la propagation :
+
+```bash
+dig +short rm.mondomaine.fr
+```
+
+La commande doit renvoyer l'IP de votre serveur. Attendez que ce soit le cas
+avant de continuer : Caddy en a besoin pour obtenir le certificat TLS.
+
+Ouvrez les ports 80 et 443 dans le pare-feu de votre hébergeur.
+
+## Étape 2 — Préparer le serveur
+
+Connectez-vous en SSH, puis :
+
+```bash
+sudo apt update && sudo apt install -y git curl debian-keyring debian-archive-keyring apt-transport-https
+
+# uv (le lanceur Python)
+curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR=/usr/local/bin sh
+
+# Caddy (reverse proxy + TLS automatique)
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install -y caddy
+```
+
+Créez l'utilisateur de service et les répertoires :
+
+```bash
+sudo useradd --system --home /var/lib/remarkable-mcp --create-home remarkable
+sudo git clone https://github.com/SamMorrowDrums/remarkable-mcp /opt/remarkable-mcp
+sudo chown -R remarkable:remarkable /opt/remarkable-mcp /var/lib/remarkable-mcp
+```
+
+> Le rendu d'images de page nécessite Cairo. Si vous voulez que Claude puisse
+> afficher vos pages : `sudo apt install -y libcairo2`. L'extraction de texte
+> (PDF, EPUB, texte tapé) fonctionne sans.
+
+## Étape 3 — Le jeton reMarkable
+
+Générez un code sur [my.remarkable.com/device/desktop/connect](https://my.remarkable.com/device/desktop/connect)
+— il est à usage unique et expire en quelques minutes. Puis, **sur le serveur** :
+
+```bash
+sudo -u remarkable env HOME=/var/lib/remarkable-mcp \
+  uv run --directory /opt/remarkable-mcp python -m remarkable_mcp.cli --register VOTRE_CODE
+```
+
+Le jeton est enregistré dans `/var/lib/remarkable-mcp/.rmapi`. Verrouillez-le :
+
+```bash
+sudo chmod 600 /var/lib/remarkable-mcp/.rmapi
+```
+
+Vérifiez que la bibliothèque est lisible :
+
+```bash
+sudo -u remarkable env HOME=/var/lib/remarkable-mcp \
+  uv run --directory /opt/remarkable-mcp python -c \
+  "from remarkable_mcp.api import get_rmapi; print(len(get_rmapi().get_meta_items()), 'documents')"
+```
+
+## Étape 4 — La phrase secrète
+
+C'est le seul secret entre internet et votre bibliothèque. Générez-la, ne
+l'inventez pas :
+
+```bash
+openssl rand -base64 32
+```
+
+Créez le fichier d'environnement (lisible par root uniquement) :
+
+```bash
+sudo tee /etc/remarkable-mcp.env > /dev/null <<'EOF'
+RMMCP_PUBLIC_URL=https://rm.mondomaine.fr
+RMMCP_PASSPHRASE=collez-ici-la-phrase-generee
+EOF
+sudo chmod 600 /etc/remarkable-mcp.env
+```
+
+Conservez la phrase dans votre gestionnaire de mots de passe : elle vous sera
+demandée à chaque fois que vous connectez un nouveau client Claude.
+
+## Étape 5 — Lancer le service
+
+```bash
+sudo cp /opt/remarkable-mcp/deploy/remarkable-mcp.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now remarkable-mcp
+sudo systemctl status remarkable-mcp --no-pager
+```
+
+Le service écoute sur `127.0.0.1:8080` — inaccessible depuis l'extérieur, c'est
+voulu. Vérifiez :
+
+```bash
+curl -s http://127.0.0.1:8080/healthz   # doit répondre: ok
+```
+
+## Étape 6 — Le reverse proxy et le TLS
+
+```bash
+sudo cp /opt/remarkable-mcp/deploy/Caddyfile /etc/caddy/Caddyfile
+sudo sed -i 's/rm\.example\.org/rm.mondomaine.fr/' /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+Caddy obtient le certificat automatiquement (quelques secondes). Vérifiez depuis
+votre machine :
+
+```bash
+curl -s https://rm.mondomaine.fr/.well-known/oauth-authorization-server | head -c 200
+```
+
+Vous devez voir un JSON décrivant les points d'entrée OAuth. Si c'est le cas,
+tout est en place.
+
+## Étape 7 — Ajouter le connecteur dans Claude
+
+Dans **claude.ai → Réglages → Connecteurs → Ajouter un connecteur personnalisé**,
+saisissez l'URL du point d'entrée MCP :
+
+```
+https://rm.mondomaine.fr/mcp
+```
+
+Claude s'enregistre tout seul auprès de votre serveur (enregistrement dynamique),
+puis ouvre votre page de connexion. Saisissez la phrase secrète de l'étape 4 :
+vous êtes redirigé vers Claude, connecté.
+
+Testez : *« Liste mes documents reMarkable récents »*.
+
+---
+
+## Ce que ce déploiement fait — et ne fait pas
+
+**Le serveur démarre en lecture seule.** Claude peut lire, chercher et afficher
+vos documents, mais pas les modifier. C'est délibéré : un serveur exposé sur
+internet est exactement l'endroit où un appel d'outil destructeur non surveillé
+fait le plus de dégâts, et le contenu d'un document lu par le modèle peut
+contenir des instructions. Pour activer l'écriture (téléversement, dossiers,
+renommage, suppression), ajoutez `RMMCP_ALLOW_WRITES=1` dans
+`/etc/remarkable-mcp.env` et redémarrez — en connaissance de cause, et après
+avoir lu [la revue de sécurité](security-review.md).
+
+**L'écriture manuscrite est le point faible.** Le mode OCR le plus élégant du
+projet demande au modèle du client de lire l'image (« sampling ») — les
+connecteurs claude.ai ne le prennent pas en charge. Il vous reste Google Vision
+(clé API, facturé à la page, vos notes transitent par Google) via
+`GOOGLE_VISION_API_KEY` dans le fichier d'environnement, ou Tesseract
+(`apt install tesseract-ocr`, gratuit mais médiocre sur le manuscrit). Le texte
+tapé, les PDF et les EPUB se lisent parfaitement sans OCR.
+
+**Authentification mono-utilisateur.** Une phrase secrète, un seul sujet, pas de
+comptes ni de rôles. Si vous devez ouvrir l'accès à plusieurs personnes,
+remplacez le serveur d'autorisation intégré par un fournisseur d'identité réel
+et faites tourner FastMCP en simple serveur de ressources (`token_verifier=`).
+
+---
+
+## Exploitation
+
+**Les journaux**
+
+```bash
+sudo journalctl -u remarkable-mcp -f      # le service
+sudo tail -f /var/log/caddy/remarkable-mcp.log   # les accès HTTP
+```
+
+Surveillez les tentatives de connexion échouées (`Failed login attempt` dans le
+journal du service). Cinq échecs déclenchent un verrouillage de 15 minutes.
+
+**Le cache disque** grandit sans limite : `/var/lib/remarkable-mcp/cache`.
+Surveillez-le, ou désactivez-le avec `REMARKABLE_DISABLE_CACHE=1`.
+
+**Mettre à jour**
+
+```bash
+cd /opt/remarkable-mcp && sudo -u remarkable git pull
+sudo systemctl restart remarkable-mcp
+```
+
+**Révoquer un accès.** Pour déconnecter tous les clients d'un coup :
+
+```bash
+sudo rm /var/lib/remarkable-mcp/auth/auth-state.json
+sudo systemctl restart remarkable-mcp
+```
+
+Changez aussi la phrase secrète dans `/etc/remarkable-mcp.env` si vous pensez
+qu'elle a fuité.
+
+---
+
+## En cas de problème
+
+| Symptôme | Cause probable |
+|---|---|
+| Caddy n'obtient pas de certificat | DNS pas encore propagé, ou ports 80/443 fermés |
+| `502 Bad Gateway` | Le service est arrêté — `systemctl status remarkable-mcp` |
+| Claude dit « impossible de se connecter » | L'URL doit se terminer par `/mcp` |
+| La page de connexion s'affiche mais la redirection échoue | `RMMCP_PUBLIC_URL` ne correspond pas au domaine réel |
+| `0 documents` à l'étape 3 | Jeton expiré, ou pas d'abonnement Connect actif |


### PR DESCRIPTION
Static security review covering the transports (cloud/SSH/USB web), the write-tool surface, the MCP App canvas, extraction paths, CI workflows and the dependency chain.


Claude-Session: https://claude.ai/code/session_017gMX9goFYVUSwZYU7uKbEc