### PR TITLE
Update mcp dependency version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.27.0",
+    "mcp>=1.27.0,<2.0.0",
     "rmscene>=0.8.0",
     "pytesseract>=0.3.10",
     "Pillow>=10.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1389,7 +1389,7 @@ requires-dist = [
     { name = "cairosvg", specifier = ">=2.9.0" },
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "google-cloud-vision", marker = "extra == 'ocr'", specifier = ">=3.0.0" },
-    { name = "mcp", specifier = ">=1.27.0" },
+    { name = "mcp", specifier = ">=1.27.0,<2.0.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pymupdf", specifier = ">=1.26.7" },
     { name = "pytesseract", specifier = ">=0.3.10" },


### PR DESCRIPTION
Thank you for this project! 

I thought I could help out by doing a quick PR to update the dependency that is currently makes the `uvx remarkable-mcp` command fail...

This allows the `uvx` command to pull down the correct version of `mcp`.

A later contribution would probably be to update the usage to fit the new structure in `mcp` v2+.

Closes #143 
Closes #141
Closes #139 