### PR TITLE
Fix SSH upload ignoring configured key path

### DIFF
--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -152,6 +152,7 @@ def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str)
 
     ssh_args = [
         "ssh",
+        *ssh_client._auth_ssh_options(),
         "-o",
         "ConnectTimeout=5",
         "-o",
@@ -162,10 +163,7 @@ def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str)
         f"cat > '{remote_path}'",
     ]
 
-    if not ssh_client.password:
-        ssh_args.insert(1, "-o")
-        ssh_args.insert(2, "BatchMode=yes")
-    else:
+    if ssh_client.password:
         ssh_args = ["sshpass", "-p", ssh_client.password] + ssh_args
 
     with open(local_path, "rb") as f:

--- a/test_server.py
+++ b/test_server.py
@@ -3613,6 +3613,59 @@ class TestSSHKeyAuth:
         assert "IdentitiesOnly=yes" in argv
         assert "BatchMode=yes" in argv
 
+    def test_upload_file_bytes_pins_identity(self, monkeypatch, tmp_path):
+        import subprocess as subprocess_mod
+
+        from remarkable_mcp.ssh import SSHClient
+        from remarkable_mcp.write_tools import _upload_file_bytes
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            return Mock(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(subprocess_mod, "run", fake_run)
+        local = tmp_path / "page.rm"
+        local.write_bytes(b"data")
+
+        client = SSHClient(key_path="/keys/rm_ed25519")
+        _upload_file_bytes(client, str(local), "/home/root/remote.rm")
+
+        argv = captured["args"]
+        assert "sshpass" not in argv
+        assert "-i" in argv
+        assert "/keys/rm_ed25519" in argv
+        assert "IdentitiesOnly=yes" in argv
+        assert "BatchMode=yes" in argv
+        # Identity must be supplied before the destination/command.
+        assert argv.index("/keys/rm_ed25519") < argv.index("cat > '/home/root/remote.rm'")
+
+    def test_upload_file_bytes_password_uses_sshpass(self, monkeypatch, tmp_path):
+        import subprocess as subprocess_mod
+
+        from remarkable_mcp.ssh import SSHClient
+        from remarkable_mcp.write_tools import _upload_file_bytes
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            return Mock(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(subprocess_mod, "run", fake_run)
+        local = tmp_path / "page.rm"
+        local.write_bytes(b"data")
+
+        client = SSHClient(password="secret")
+        _upload_file_bytes(client, str(local), "/home/root/remote.rm")
+
+        argv = captured["args"]
+        assert argv[:3] == ["sshpass", "-p", "secret"]
+        # Password auth must not force BatchMode (it would block the password).
+        assert "BatchMode=yes" not in argv
+        assert "IdentitiesOnly=yes" not in argv
+
     def test_create_ssh_client_reads_key_env(self, monkeypatch):
         from remarkable_mcp.ssh import create_ssh_client
 


### PR DESCRIPTION
Write tools fail with `Permission denied (publickey)` when `REMARKABLE_SSH_KEY` points at a non-default key name (e.g. `~/.ssh/id_remarkable`). `_upload_file_bytes` builds its own ssh argument list with only `BatchMode=yes`, omitting the `-i <key>` / `IdentitiesOnly=yes` options that every read path gets from `_auth_ssh_options()`. This makes all write tools (upload, mkdir, author, ...) fail in SSH mode for anyone using a dedicated key, while reads work fine.

Fix: reuse `_auth_ssh_options()` in `_upload_file_bytes` so reads and writes authenticate identically. Password/`sshpass` behavior is unchanged (`_auth_ssh_options()` returns no options when a password is set).

Verified on-device (reMarkable 2, SSH over USB, dedicated ed25519 key): notebook creation failed before, succeeds after.