### PR TITLE
feat: add read-only local directory transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,55 @@ See [SSH Setup Guide](docs/ssh-setup.md) for detailed instructions.
 
 ---
 
+### 💻 Local Directory Mode (Desktop App)
+
+Read the official **reMarkable desktop app's** sync folder straight from disk — fully offline, no cable, no cloud round-trip, and the tablet doesn't even need to be on. The desktop app keeps the folder synced whenever it is running. Strictly read-only.
+
+<details>
+<summary>📋 Local Directory Configuration</summary>
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--local-dir"]
+    }
+  }
+}
+```
+
+With no path, the desktop app's data folder is auto-detected:
+
+- **macOS (current app):** `~/Library/Containers/com.remarkable.desktop/Data/Library/Application Support/remarkable/desktop`
+- **macOS (legacy app):** `~/Library/Application Support/remarkable/desktop`
+- **Windows:** `%APPDATA%\remarkable\desktop`
+- **Linux:** `~/.local/share/remarkable/desktop`
+
+Or point at any xochitl-style directory (e.g. a tablet backup):
+
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--local-dir", "/path/to/xochitl-data"]
+    }
+  }
+}
+```
+
+**Notes:**
+- Content freshness depends on the desktop app syncing — keep it running and signed in
+- This mode is read-only by design: the folder is the desktop app's private sync cache, and writing to it directly would bypass sync and could corrupt the app's state
+- If the directory can't be found and a cloud token is configured, the server falls back to cloud mode (same behaviour as USB/SSH)
+
+</details>
+
+---
+
 ### ☁️ Cloud Mode (Wireless)
 
 Wireless access with **no device connection required** — your reMarkable syncs to the cloud and the MCP reads from there, so it works from anywhere. Requires a reMarkable Connect subscription.
@@ -182,21 +231,25 @@ AI assistants use the tools to read documents, search content, and more:
 
 All three modes share the same read, render, and upload tools. **Cloud and SSH additionally support full library management** — create folders, move, rename, and delete (all enabled by default) — so capability is near-identical and you can genuinely pick whichever matches how your tablet is connected:
 
+- **💻 Local Directory** — *device-free AND offline.* Reads the official desktop app's sync folder straight from disk — no cable, no cloud round-trip, no subscription beyond what the app itself needs, and the tablet can be off. Read/render only (the folder is the app's private sync cache, so writes are disabled by design). Best when the desktop app is already part of your workflow.
 - **☁️ Cloud** — *device-free, works from anywhere.* Reads your library straight from reMarkable's cloud over Wi‑Fi with a Connect subscription — no cable, no developer mode. Full read/render plus full write (upload, create folder, move, rename, delete → trash). Parallel fetching and an on-disk blob cache make it fast after the first sync. Best for remote/headless setups or when you don't want to plug in.
 - **🔌 USB Web Interface** — *best when the tablet is plugged in.* Enable the web interface in Storage Settings — no subscription, no developer mode. Full read/render plus upload (to your root folder). The tablet's USB web firmware exposes no folder/move/rename/delete endpoints, so for those over a cable use SSH.
 - **⚡ SSH** — *for power users who want filesystem-level access.* Requires developer mode over USB. Full read/render plus full write including folder create/move/rename/delete, straight from the tablet filesystem.
 
-| Mode | Setup | Subscription | Offline | Read + render | Raw PDF/EPUB | Upload | Folder ops¹ |
-|------|-------|--------------|---------|---------------|--------------|--------|-------------|
-| **☁️ Cloud** | One-time code | Connect | ❌ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
-| **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ | ✅ PDF | ✅ (to root) | ❌ |
-| **⚡ SSH** | Developer mode | Not required | ✅ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
+| Mode | Setup | Subscription | Offline | Tablet needed | Read + render | Raw PDF/EPUB | Upload | Folder ops¹ |
+|------|-------|--------------|---------|---------------|---------------|--------------|--------|-------------|
+| **💻 Local Dir** | Desktop app installed | Not required² | ✅ | ❌ | ✅ | ✅ PDF/EPUB | ❌ | ❌ |
+| **☁️ Cloud** | One-time code | Connect | ❌ | ❌ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
+| **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ | ✅ | ✅ PDF | ✅ (to root) | ❌ |
+| **⚡ SSH** | Developer mode | Not required | ✅ | ✅ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
 
 ¹ Folder ops = create folder / move / rename / delete. Upload and folder ops are enabled by default; pass `--read-only` to expose a read-only server. Deletes move items to the trash and prompt for confirmation when your client supports elicitation, and are refused without it unless `REMARKABLE_SKIP_CONFIRM=1` is set.
 
+² The desktop app itself signs in to the reMarkable cloud to sync; local directory mode just reads whatever the app has already synced to disk.
+
 ### Automatic cloud fallback
 
-If you select a device transport (`--usb` or `--ssh`) but the tablet isn't reachable at startup **and** a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server automatically falls back to cloud mode and logs a warning. This means a single configuration works whether or not the tablet is plugged in — plug in for fast local access, unplug to keep working over the cloud. `remarkable_status` reports the effective transport and a `fell_back_to_cloud` flag when this happens.
+If you select a device transport (`--usb`, `--ssh`, or `--local-dir`) but it isn't reachable at startup **and** a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server automatically falls back to cloud mode and logs a warning. This means a single configuration works whether or not the tablet is plugged in — plug in for fast local access, unplug to keep working over the cloud. `remarkable_status` reports the effective transport and a `fell_back_to_cloud` flag when this happens.
 
 Pass `--no-cloud-fallback` (or set `REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) to disable this and fail instead when the device is unreachable.
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ If you select a device transport (`--usb`, `--ssh`, or `--local-dir`) but it isn
 
 Pass `--no-cloud-fallback` (or set `REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) to disable this and fail instead when the device is unreachable.
 
+> **Troubleshooting:** the transport is resolved once and cached for the MCP server's lifetime. If the server fell back to cloud (for example, the desktop app only started syncing after the server launched), **restart the MCP server** to pick up the local directory again — `remarkable_status` shows the active transport and a `fell_back_to_cloud` flag so you can tell when this has happened.
+
 **📖 Detailed Setup Guides:**
 - [USB Web Interface Setup](docs/usb-web-setup.md) — **recommended** — simple setup, full feature support
 - [SSH Setup Guide](docs/ssh-setup.md) — for advanced users who need filesystem access

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Or point at any xochitl-style directory (e.g. a tablet backup):
 **Notes:**
 - Content freshness depends on the desktop app syncing — keep it running and signed in
 - This mode is read-only by design: the folder is the desktop app's private sync cache, and writing to it directly would bypass sync and could corrupt the app's state
-- If the directory can't be found and a cloud token is configured, the server falls back to cloud mode (same behaviour as USB/SSH)
+- If the directory can't be found and a cloud token is configured, the server falls back to cloud mode for read access (the server remains read-only because it was launched in local-directory mode)
 
 </details>
 
@@ -229,7 +229,7 @@ AI assistants use the tools to read documents, search content, and more:
 
 ## Connection Modes
 
-All three modes share the same read, render, and upload tools. **Cloud and SSH additionally support full library management** — create folders, move, rename, and delete (all enabled by default) — so capability is near-identical and you can genuinely pick whichever matches how your tablet is connected:
+All four modes support reading and rendering. **Cloud and SSH support full library management**, USB web supports upload-to-root, and local-directory mode is strictly read-only:
 
 - **💻 Local Directory** — *device-free AND offline.* Reads the official desktop app's sync folder straight from disk — no cable, no cloud round-trip, no subscription beyond what the app itself needs, and the tablet can be off. Read/render only (the folder is the app's private sync cache, so writes are disabled by design). Best when the desktop app is already part of your workflow.
 - **☁️ Cloud** — *device-free, works from anywhere.* Reads your library straight from reMarkable's cloud over Wi‑Fi with a Connect subscription — no cable, no developer mode. Full read/render plus full write (upload, create folder, move, rename, delete → trash). Parallel fetching and an on-disk blob cache make it fast after the first sync. Best for remote/headless setups or when you don't want to plug in.
@@ -249,7 +249,7 @@ All three modes share the same read, render, and upload tools. **Cloud and SSH a
 
 ### Automatic cloud fallback
 
-If you select a device transport (`--usb`, `--ssh`, or `--local-dir`) but it isn't reachable at startup **and** a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server automatically falls back to cloud mode and logs a warning. This means a single configuration works whether or not the tablet is plugged in — plug in for fast local access, unplug to keep working over the cloud. `remarkable_status` reports the effective transport and a `fell_back_to_cloud` flag when this happens.
+If you select a device transport (`--usb`, `--ssh`, or `--local-dir`) but it isn't reachable at startup **and** a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server automatically falls back to cloud mode and logs a warning. This means a single configuration works whether or not the tablet is plugged in — plug in for fast local access, unplug to keep working over the cloud. A server launched with `--local-dir` remains read-only after fallback, preserving that mode's safety contract. `remarkable_status` reports the effective transport and a `fell_back_to_cloud` flag when this happens.
 
 Pass `--no-cloud-fallback` (or set `REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) to disable this and fail instead when the device is unreachable.
 
@@ -298,7 +298,7 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, `remarkable_refresh`, and `remarkable_author` for native ink/notebooks) are enabled by default — pass `--read-only` to disable them — see [Write Tools](#write-tools-cloud-ssh--usb-web). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
+These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, `remarkable_refresh`, and `remarkable_author` for native ink/notebooks) are enabled by default on transports that support them — pass `--read-only` to disable them — see [Write Tools](#write-tools-by-transport). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
 
 📖 **[Full Tools Documentation](docs/tools.md)**
 
@@ -463,37 +463,40 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 
 ---
 
-## SSH vs USB Web vs Cloud Comparison
+## Transport Comparison
 
-| Feature | SSH Mode | USB Web | Cloud API |
-|---------|----------|---------|-----------|
-| Speed | ⚡ 10-100x faster | ⚡ Fast | ⚡ Fast (parallel + cached) |
-| Offline | ✅ Yes | ✅ Yes | ❌ No |
-| Subscription | ✅ Not required | ✅ Not required | ❌ Connect required |
-| Raw files | ✅ PDFs, EPUBs | ✅ PDFs | ✅ PDFs, EPUBs |
-| Upload | ✅ (default) | ✅ (default) | ✅ (default) |
-| mkdir/move/rename/delete | ✅ (default) | ❌ | ✅ (default) |
-| Setup | Developer mode | Enable in Settings | One-time code |
+| Feature | Local Directory | SSH Mode | USB Web | Cloud API |
+|---------|-----------------|----------|---------|-----------|
+| Speed | ⚡ Local disk | ⚡ 10-100x faster | ⚡ Fast | ⚡ Fast (parallel + cached) |
+| Offline | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
+| Tablet needed | ❌ No | ✅ Yes | ✅ Yes | ❌ No |
+| Subscription | ✅ Not required¹ | ✅ Not required | ✅ Not required | ❌ Connect required |
+| Raw files | ✅ PDFs, EPUBs | ✅ PDFs, EPUBs | ✅ PDFs | ✅ PDFs, EPUBs |
+| Upload | ❌ | ✅ (default) | ✅ (default) | ✅ (default) |
+| mkdir/move/rename/delete | ❌ | ✅ (default) | ❌ | ✅ (default) |
+| Setup | Desktop app | Developer mode | Enable in Settings | One-time code |
+
+¹ The desktop app signs in to sync; this transport reads its existing local cache.
 
 📖 **[SSH Setup Guide](docs/ssh-setup.md)**
 
 ---
 
-## Write Tools (Cloud, SSH & USB Web)
+## Write Tools by Transport
 
-Write tools let you upload, organize, and manage documents on your reMarkable. **Enabled by default.** Cloud and SSH modes support the full set; USB web supports upload only (its firmware exposes no folder operations). Pass `--read-only` to expose a read-only server.
+Write tools let you upload, organize, and manage documents on your reMarkable. **Enabled by default on write-capable transports.** Cloud and SSH modes support the full set; USB web supports upload only (its firmware exposes no folder operations); local-directory mode is always read-only. Pass `--read-only` to expose a read-only server elsewhere.
 
-| Feature | Cloud Mode | SSH Mode | USB Web Mode |
-|---------|:----------:|:--------:|:------------:|
-| Upload | ✅ | ✅ | ✅ (to root) |
-| Mkdir | ✅ | ✅ | ❌ |
-| Move | ✅ | ✅ | ❌ |
-| Rename | ✅ | ✅ | ❌ |
-| Delete | ✅ (→ trash) | ✅ | ❌ |
+| Feature | Local Directory | Cloud Mode | SSH Mode | USB Web Mode |
+|---------|:---------------:|:----------:|:--------:|:------------:|
+| Upload | ❌ | ✅ | ✅ | ✅ (to root) |
+| Mkdir | ❌ | ✅ | ✅ | ❌ |
+| Move | ❌ | ✅ | ✅ | ❌ |
+| Rename | ❌ | ✅ | ✅ | ❌ |
+| Delete | ❌ | ✅ (→ trash) | ✅ | ❌ |
 
 ### Disabling Write Tools (read-only mode)
 
-Write tools are on by default in every mode. To run a read-only server, add the `--read-only` flag:
+Write tools are on by default in each write-capable mode. Local-directory mode is always read-only. To make another transport read-only, add the `--read-only` flag:
 
 ```json
 {
@@ -533,7 +536,7 @@ Or set the environment variable:
 
 | Tool | Description |
 |------|-------------|
-| `remarkable_upload(file_path, parent_folder, document_name, defer_restart)` | Upload a PDF or EPUB file (all modes; USB web ignores folder/name and uploads to root) |
+| `remarkable_upload(file_path, parent_folder, document_name, defer_restart)` | Upload a PDF or EPUB file (cloud, SSH, and USB web; USB web ignores folder/name and uploads to root) |
 | `remarkable_mkdir(folder_name, parent, defer_restart)` | Create a new folder (cloud and SSH) |
 | `remarkable_move(document, dest_folder, defer_restart)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name, defer_restart)` | Rename a document or folder (cloud and SSH) |
@@ -543,7 +546,7 @@ Or set the environment variable:
 
 ### Safety
 
-- **Upload registers in all modes** — cloud, SSH, and USB web.
+- **Upload registers in cloud, SSH, and USB web mode** — local-directory mode never exposes write tools.
 - **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
 - **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
 - After each write operation in SSH mode, the tablet UI (`xochitl`) restarts automatically to reflect changes; the call waits for it to come back before returning so the next write doesn't race a restarting daemon. For bulk operations, pass `defer_restart=True` to each write — or set `REMARKABLE_DEFER_RESTART=1` — and call `remarkable_refresh()` once at the end, so the batch triggers a single restart instead of one per write (each restart forces a full document-store rescan).

--- a/remarkable_mcp/api.py
+++ b/remarkable_mcp/api.py
@@ -23,6 +23,14 @@ REMARKABLE_USE_USB_WEB = os.environ.get("REMARKABLE_USE_USB_WEB", "").lower() in
     "true",
     "yes",
 )
+# Local-directory transport: read the reMarkable desktop app's sync folder (or
+# any xochitl-style directory) straight from disk. Enabled by the mode flag or
+# by pointing REMARKABLE_LOCAL_DIR at a directory.
+REMARKABLE_USE_LOCAL_DIR = os.environ.get("REMARKABLE_USE_LOCAL_DIR", "").lower() in (
+    "1",
+    "true",
+    "yes",
+) or bool(os.environ.get("REMARKABLE_LOCAL_DIR"))
 # When a device transport (USB web / SSH) is selected but the tablet is not
 # reachable at startup, automatically fall back to cloud mode if a cloud token
 # is configured. This lets the *same* configuration work whether or not the
@@ -135,29 +143,52 @@ def get_rmapi():
     Get or initialize the reMarkable API client.
 
     Priority order:
-    1. USB web interface (if REMARKABLE_USE_USB_WEB=1)
-    2. SSH (if REMARKABLE_USE_SSH=1)
-    3. Cloud API (default, requires token)
+    1. Local directory (if REMARKABLE_USE_LOCAL_DIR=1 or REMARKABLE_LOCAL_DIR is set)
+    2. USB web interface (if REMARKABLE_USE_USB_WEB=1)
+    3. SSH (if REMARKABLE_USE_SSH=1)
+    4. Cloud API (default, requires token)
 
-    When a device transport (USB/SSH) is selected but the tablet is unreachable
+    When a device transport (local dir / USB / SSH) is selected but unreachable
     at startup, this falls back to cloud mode if a cloud token is configured
     (unless REMARKABLE_DISABLE_CLOUD_FALLBACK is set), so the same configuration
     works with or without the physical device connected.
 
-    Returns RemarkableClient, SSHClient, or USBWebClient (all have compatible interfaces).
+    Returns RemarkableClient, SSHClient, USBWebClient, or LocalDirClient
+    (all have compatible interfaces).
     """
     global _device_client, _fell_back_to_cloud
 
-    # Device transports (USB web / SSH) — probe once, cache the resolution, and
-    # optionally fall back to cloud if the device is unreachable.
-    if REMARKABLE_USE_USB_WEB or REMARKABLE_USE_SSH:
+    # Device transports (local dir / USB web / SSH) — probe once, cache the
+    # resolution, and optionally fall back to cloud if unreachable.
+    if REMARKABLE_USE_LOCAL_DIR or REMARKABLE_USE_USB_WEB or REMARKABLE_USE_SSH:
         with _device_resolve_lock:
             if _fell_back_to_cloud:
                 return _get_cloud_client()
             if _device_client is not None:
                 return _device_client
 
-            if REMARKABLE_USE_USB_WEB:
+            if REMARKABLE_USE_LOCAL_DIR:
+                from remarkable_mcp.local_dir import create_local_dir_client
+
+                mode_label = "Local directory"
+                try:
+                    client = create_local_dir_client()
+                except RuntimeError:
+                    # No usable local directory found. Fall back to cloud when
+                    # allowed (mirrors the unreachable-device behaviour below);
+                    # otherwise surface the resolution error directly.
+                    if not REMARKABLE_DISABLE_CLOUD_FALLBACK and _is_cloud_token_available():
+                        logger.warning(
+                            "%s is not available; falling back to cloud mode "
+                            "because a cloud token is configured. Set "
+                            "REMARKABLE_DISABLE_CLOUD_FALLBACK=1 to disable "
+                            "this fallback.",
+                            mode_label,
+                        )
+                        _fell_back_to_cloud = True
+                        return _get_cloud_client()
+                    raise
+            elif REMARKABLE_USE_USB_WEB:
                 from remarkable_mcp.usb_web import create_usb_web_client
 
                 client = create_usb_web_client()
@@ -193,7 +224,7 @@ def get_rmapi():
 
 
 def get_active_transport() -> str:
-    """Return the transport actually in use ("cloud", "ssh", or "usb-web").
+    """Return the transport actually in use ("cloud", "ssh", "usb-web", or "local-dir").
 
     Reflects the resolution performed by get_rmapi(): if a device transport was
     selected but the tablet was unreachable and we fell back to cloud, this
@@ -203,6 +234,8 @@ def get_active_transport() -> str:
     """
     if _fell_back_to_cloud:
         return "cloud"
+    if REMARKABLE_USE_LOCAL_DIR:
+        return "local-dir"
     if REMARKABLE_USE_USB_WEB:
         return "usb-web"
     if REMARKABLE_USE_SSH:

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -44,6 +44,12 @@ Examples:
   # Run with SSH transport (direct USB connection, requires dev mode)
   uvx remarkable-mcp --ssh
 
+  # Read the reMarkable desktop app's local sync folder (offline, read-only)
+  uvx remarkable-mcp --local-dir
+
+  # Same, with an explicit xochitl-style directory
+  uvx remarkable-mcp --local-dir /path/to/remarkable/desktop
+
   # SSH with custom host (e.g., using SSH config)
   REMARKABLE_SSH_HOST="remarkable" uvx remarkable-mcp --ssh
 
@@ -53,6 +59,11 @@ Examples:
 USB Web Interface Environment Variables:
   REMARKABLE_USB_HOST      USB web interface host (default: http://10.11.99.1)
   REMARKABLE_USB_TIMEOUT   Request timeout in seconds (default: 10)
+
+Local Directory Environment Variables:
+  REMARKABLE_USE_LOCAL_DIR Enable the local directory transport (1/true/yes)
+  REMARKABLE_LOCAL_DIR     Data directory path (default: auto-detect the
+                           reMarkable desktop app's sync folder)
 
 SSH Environment Variables:
   REMARKABLE_SSH_HOST      SSH host (default: 10.11.99.1 for USB)
@@ -91,6 +102,17 @@ Security Note:
         "--usb",
         action="store_true",
         help="Use USB web interface (connect via USB cable, enable in Storage Settings)",
+    )
+    parser.add_argument(
+        "--local-dir",
+        nargs="?",
+        const="auto",
+        metavar="PATH",
+        help=(
+            "Read from a local reMarkable data directory (read-only). With no "
+            "PATH, auto-detects the official desktop app's sync folder. Fully "
+            "offline and device-free; the desktop app keeps the folder synced."
+        ),
     )
     write_group = parser.add_mutually_exclusive_group()
     write_group.add_argument(
@@ -153,6 +175,16 @@ Security Note:
         except Exception as e:
             print(f"❌ Registration failed: {e}", file=sys.stderr)
             sys.exit(1)
+    elif args.local_dir:
+        # Local directory mode - read-only access to a local data directory
+        os.environ["REMARKABLE_USE_LOCAL_DIR"] = "1"
+        if args.local_dir != "auto":
+            os.environ["REMARKABLE_LOCAL_DIR"] = args.local_dir
+        if args.no_cloud_fallback:
+            os.environ["REMARKABLE_DISABLE_CLOUD_FALLBACK"] = "1"
+        from remarkable_mcp.server import run
+
+        run()
     elif args.usb:
         # USB web mode - set environment variable and run server
         os.environ["REMARKABLE_USE_USB_WEB"] = "1"

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -136,10 +136,9 @@ Security Note:
         "--no-cloud-fallback",
         action="store_true",
         help=(
-            "Disable the automatic cloud fallback. By default, if --usb/--ssh is "
-            "selected but the tablet is unreachable at startup and a cloud token "
-            "is configured, the server falls back to cloud mode so the same "
-            "configuration works with or without the device connected."
+            "Disable the automatic cloud fallback. By default, if --local-dir, "
+            "--usb, or --ssh is selected but unavailable at startup and a cloud "
+            "token is configured, the server falls back to cloud mode."
         ),
     )
     args = parser.parse_args()

--- a/remarkable_mcp/local_dir.py
+++ b/remarkable_mcp/local_dir.py
@@ -1,0 +1,253 @@
+"""
+reMarkable Local Directory Client
+
+Read documents from a local reMarkable data directory — most usefully the
+official desktop app's sync folder, which mirrors the tablet's xochitl store
+on your computer. This gives fully offline, device-free access: no cable, no
+cloud round-trip, no subscription. The desktop app keeps the folder fresh
+whenever it is running.
+
+Default locations probed (first one containing ``*.metadata`` wins):
+
+- macOS (sandboxed app): ``~/Library/Containers/com.remarkable.desktop/Data/
+  Library/Application Support/remarkable/desktop``
+- macOS (legacy app): ``~/Library/Application Support/remarkable/desktop``
+- Windows: ``%APPDATA%/remarkable/desktop``
+- Linux: ``~/.local/share/remarkable/desktop``
+
+Set ``REMARKABLE_LOCAL_DIR`` to point at any other xochitl-style directory
+(e.g. a backup copy of ``/home/root/.local/share/remarkable/xochitl``).
+
+The directory layout is the standard xochitl store:
+
+- ``{uuid}.metadata`` — JSON with visibleName, type, parent, etc.
+- ``{uuid}.content`` — JSON with file info (fileType, pages, ...)
+- ``{uuid}/`` — folder with .rm page files
+- ``{uuid}.pdf`` / ``{uuid}.epub`` — original source file, when present
+
+This transport is strictly read-only: the desktop app owns the directory and
+treats it as a private sync cache, so writing to it directly would not sync
+and could corrupt the app's state. Write tools are never registered in this
+mode.
+"""
+
+import io
+import json
+import logging
+import os
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Reuse the SSH transport's Document dataclass: the local directory has the
+# exact same xochitl layout, so documents carry the same fields. Importing it
+# performs no SSH activity.
+from remarkable_mcp.ssh import Document
+
+logger = logging.getLogger(__name__)
+
+# Candidate default locations for the reMarkable desktop app's sync folder.
+DEFAULT_DIR_CANDIDATES = (
+    # macOS sandboxed (Mac App Store / current) app
+    "~/Library/Containers/com.remarkable.desktop/Data/"
+    "Library/Application Support/remarkable/desktop",
+    # macOS legacy (non-sandboxed) app
+    "~/Library/Application Support/remarkable/desktop",
+    # Windows
+    "%APPDATA%/remarkable/desktop",
+    # Linux (community builds / synced copies)
+    "~/.local/share/remarkable/desktop",
+)
+
+
+def find_default_local_dir() -> Optional[Path]:
+    """Locate the desktop app's data directory on this machine.
+
+    Returns the first candidate that exists and contains at least one
+    ``*.metadata`` file, or None when nothing plausible is found.
+    """
+    for candidate in DEFAULT_DIR_CANDIDATES:
+        path = Path(os.path.expandvars(os.path.expanduser(candidate)))
+        try:
+            if path.is_dir() and next(path.glob("*.metadata"), None) is not None:
+                return path
+        except OSError:
+            continue
+    return None
+
+
+class LocalDirClient:
+    """Client reading a local xochitl-style directory (read-only)."""
+
+    def __init__(self, base_dir: str | Path):
+        self.base_dir = Path(os.path.expandvars(os.path.expanduser(str(base_dir))))
+        self._documents: List[Document] = []
+        self._documents_by_id: Dict[str, Document] = {}
+        self._file_type_cache: Optional[Dict[str, Optional[str]]] = None
+
+    def check_connection(self) -> bool:
+        """A local directory is "connected" when it exists and holds metadata."""
+        try:
+            return (
+                self.base_dir.is_dir() and next(self.base_dir.glob("*.metadata"), None) is not None
+            )
+        except OSError as e:
+            logger.debug(f"Local dir check failed: {e}")
+            return False
+
+    def get_meta_items(self, limit: Optional[int] = None) -> List[Document]:
+        """Read all document/folder metadata from the local directory."""
+        if self._documents and limit is None:
+            return self._documents
+        if self._documents and limit is not None and len(self._documents) >= limit:
+            return self._documents[:limit]
+
+        documents: List[Document] = []
+        for meta_file in sorted(self.base_dir.glob("*.metadata")):
+            if limit is not None and len(documents) >= limit:
+                break
+            doc_id = meta_file.stem
+            try:
+                metadata = json.loads(meta_file.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as e:
+                logger.debug(f"Failed to parse metadata for {doc_id}: {e}")
+                continue
+
+            if metadata.get("deleted", False):
+                continue
+
+            last_modified = None
+            if "lastModified" in metadata:
+                try:
+                    ts = int(metadata["lastModified"]) / 1000
+                    last_modified = datetime.fromtimestamp(ts)
+                except (ValueError, TypeError, OSError):
+                    pass
+
+            documents.append(
+                Document(
+                    id=doc_id,
+                    hash=doc_id,  # No content hash locally; ID is stable enough
+                    name=metadata.get("visibleName", doc_id),
+                    doc_type=metadata.get("type", "DocumentType"),
+                    parent=metadata.get("parent", ""),
+                    deleted=metadata.get("deleted", False),
+                    pinned=metadata.get("pinned", False),
+                    synced=metadata.get("synced", True),
+                    last_modified=last_modified,
+                    size=0,
+                    tags=metadata.get("tags", []),
+                    local_path=str(self.base_dir / doc_id),
+                )
+            )
+
+        self._documents = documents
+        self._documents_by_id = {d.id: d for d in documents}
+        logger.info(f"Loaded {len(documents)} documents from local dir {self.base_dir}")
+        return documents
+
+    def get_doc(self, doc_id: str) -> Optional[Document]:
+        """Get a document by ID."""
+        if not self._documents_by_id:
+            self.get_meta_items()
+        return self._documents_by_id.get(doc_id)
+
+    def download(self, doc: Document) -> bytes:
+        """Package a document as a zip, mirroring SSHClient.download().
+
+        Contains the document folder's files (page .rm files etc.), the
+        ``.content`` metadata, and any source ``.pdf``/``.epub`` so merged
+        rendering works. ZIP_STORED because the archive is an in-memory
+        transport container, never persisted.
+        """
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
+            doc_dir = self.base_dir / doc.id
+            if doc_dir.is_dir():
+                for path in sorted(doc_dir.rglob("*")):
+                    if path.is_file():
+                        try:
+                            zf.write(path, str(path.relative_to(doc_dir)))
+                        except OSError as e:
+                            logger.debug(f"Skipping unreadable file {path}: {e}")
+            for suffix in (".content", ".pdf", ".epub"):
+                side_file = self.base_dir / f"{doc.id}{suffix}"
+                if side_file.is_file():
+                    try:
+                        zf.write(side_file, side_file.name)
+                    except OSError as e:
+                        logger.debug(f"Skipping unreadable file {side_file}: {e}")
+
+        zip_buffer.seek(0)
+        return zip_buffer.read()
+
+    def download_raw_file(self, doc: Document, extension: str) -> Optional[bytes]:
+        """Return the original source file (PDF/EPUB) bytes, if present."""
+        ext = extension.lower().lstrip(".")
+        raw_file = self.base_dir / f"{doc.id}.{ext}"
+        try:
+            if raw_file.is_file():
+                return raw_file.read_bytes()
+        except OSError as e:
+            logger.debug(f"Failed to read raw file {raw_file}: {e}")
+        return None
+
+    def get_file_type(self, doc: Document) -> Optional[str]:
+        """Read fileType from the document's .content JSON."""
+        if self._file_type_cache is not None and doc.id in self._file_type_cache:
+            return self._file_type_cache[doc.id]
+        content_file = self.base_dir / f"{doc.id}.content"
+        try:
+            data = json.loads(content_file.read_text(encoding="utf-8"))
+            return data.get("fileType")
+        except (OSError, ValueError):
+            return None
+
+    def get_all_file_types(self) -> Dict[str, Optional[str]]:
+        """Batch-read fileType for every document (single directory pass)."""
+        if self._file_type_cache is not None:
+            return self._file_type_cache
+
+        cache: Dict[str, Optional[str]] = {}
+        for content_file in self.base_dir.glob("*.content"):
+            try:
+                data = json.loads(content_file.read_text(encoding="utf-8"))
+                cache[content_file.stem] = data.get("fileType")
+            except (OSError, ValueError):
+                cache[content_file.stem] = None
+        self._file_type_cache = cache
+        return cache
+
+
+def check_local_dir_available(base_dir: Optional[str] = None) -> bool:
+    """Check whether a usable local data directory is present."""
+    if base_dir:
+        return LocalDirClient(base_dir).check_connection()
+    return find_default_local_dir() is not None
+
+
+def create_local_dir_client(base_dir: Optional[str] = None) -> LocalDirClient:
+    """
+    Create a local directory client.
+
+    Resolution order for the directory:
+    1. Explicit ``base_dir`` argument
+    2. ``REMARKABLE_LOCAL_DIR`` environment variable
+    3. Auto-detected desktop app location (see ``find_default_local_dir``)
+
+    Raises RuntimeError when no directory can be resolved, with guidance.
+    """
+    resolved = base_dir or os.environ.get("REMARKABLE_LOCAL_DIR")
+    if resolved and resolved.lower() not in ("1", "true", "yes", "auto"):
+        return LocalDirClient(resolved)
+
+    detected = find_default_local_dir()
+    if detected is None:
+        raise RuntimeError(
+            "Could not locate a reMarkable desktop app data directory. "
+            "Install and sign in to the reMarkable desktop app, or set "
+            "REMARKABLE_LOCAL_DIR to a folder containing xochitl-style "
+            "document data (*.metadata files)."
+        )
+    return LocalDirClient(detected)

--- a/remarkable_mcp/local_dir.py
+++ b/remarkable_mcp/local_dir.py
@@ -240,7 +240,14 @@ def create_local_dir_client(base_dir: Optional[str] = None) -> LocalDirClient:
     """
     resolved = base_dir or os.environ.get("REMARKABLE_LOCAL_DIR")
     if resolved and resolved.lower() not in ("1", "true", "yes", "auto"):
-        return LocalDirClient(resolved)
+        client = LocalDirClient(resolved)
+        if client.check_connection():
+            return client
+        raise RuntimeError(
+            f"Local reMarkable data directory is not usable: {client.base_dir}. "
+            "The directory must exist and contain xochitl-style document data "
+            "(*.metadata files)."
+        )
 
     detected = find_default_local_dir()
     if detected is None:

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -65,6 +65,11 @@ def _build_instructions() -> str:
         "true",
         "yes",
     )
+    local_dir_mode = os.environ.get("REMARKABLE_USE_LOCAL_DIR", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    ) or bool(os.environ.get("REMARKABLE_LOCAL_DIR"))
     has_google_vision = bool(os.environ.get("GOOGLE_VISION_API_KEY"))
     ocr_backend = os.environ.get("REMARKABLE_OCR_BACKEND", "auto").lower()
 
@@ -73,7 +78,9 @@ def _build_instructions() -> str:
         "true",
         "yes",
     )
-    write_mode = not read_only_mode
+    # Local-directory mode is unconditionally read-only (the folder is the
+    # desktop app's private sync cache).
+    write_mode = not read_only_mode and not local_dir_mode
 
     read_only_note = "" if write_mode else " All operations are read-only."
 
@@ -128,7 +135,23 @@ Documents are registered as resources for direct access:
     )
 
     # Add transport-specific instructions
-    if ssh_mode:
+    if local_dir_mode:
+        instructions += """
+## Local Directory Mode (Active)
+
+Reading from a local reMarkable data directory (typically the official
+desktop app's sync folder). Fully offline and device-free:
+- **Raw file access**: Use `content_type="raw"` to get original PDF/EPUB text
+- **Read-only**: the folder is the desktop app's sync cache, so write tools
+  are disabled in this mode. Content freshness depends on the desktop app
+  syncing (keep it running/signed in).
+
+### Content Types for remarkable_read
+- `"text"` (default) - Full content: raw PDF/EPUB text + annotations
+- `"raw"` - Only original PDF/EPUB text (no annotations)
+- `"annotations"` - Only typed text, highlights, and OCR content
+"""
+    elif ssh_mode:
         instructions += """
 ## SSH Mode (Active)
 

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -294,8 +294,8 @@ async def lifespan(app: FastMCP) -> AsyncIterator[None]:
 
         task = asyncio.create_task(_ssh_background_load())
     else:
-        # Cloud/USB mode: load in background to not block startup
-        logger.info("Cloud/USB mode: starting background loader...")
+        # Cloud/USB/local-directory mode: load in background to not block startup
+        logger.info("Cloud/USB/local-directory mode: starting background loader...")
         task = start_background_loader()
 
     try:
@@ -316,10 +316,11 @@ from remarkable_mcp import (  # noqa: E402
 )
 
 # Conditionally register write tools when enabled.
-# Write works in all three transports: cloud (default), SSH, and USB web.
+# Write works in three transports: cloud (default), SSH, and USB web.
 # Cloud and SSH support the full set (upload/mkdir/move/rename/delete); the USB
 # web interface only supports upload, so only that tool registers in USB mode
-# (see the per-tool gating in write_tools.register_write_tools).
+# (see the per-tool gating in write_tools.register_write_tools). Local-directory
+# mode is strictly read-only and registers no write tools.
 from remarkable_mcp import write_tools as _write_tools  # noqa: E402
 
 if _write_tools.write_enabled():

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1308,6 +1308,7 @@ async def remarkable_status() -> str:
     import os
 
     from remarkable_mcp.api import (
+        REMARKABLE_USE_LOCAL_DIR,
         REMARKABLE_USE_SSH,
         REMARKABLE_USE_USB_WEB,
         get_active_transport,
@@ -1315,7 +1316,15 @@ async def remarkable_status() -> str:
     from remarkable_mcp.write_tools import write_enabled
 
     # Determine the *selected* transport from configuration (pre-fallback).
-    if REMARKABLE_USE_USB_WEB:
+    if REMARKABLE_USE_LOCAL_DIR:
+        from remarkable_mcp.local_dir import find_default_local_dir
+
+        selected_transport = "local-dir"
+        local_dir = os.environ.get("REMARKABLE_LOCAL_DIR") or str(
+            find_default_local_dir() or "(no directory found)"
+        )
+        connection_info = f"local directory at {local_dir}"
+    elif REMARKABLE_USE_USB_WEB:
         from remarkable_mcp.usb_web import DEFAULT_USB_HOST
 
         selected_transport = "usb-web"
@@ -1362,6 +1371,17 @@ async def remarkable_status() -> str:
             "read": True,
             "render": True,
             "upload": True,
+            "mkdir": False,
+            "move": False,
+            "rename": False,
+            "delete": False,
+        },
+        # Local directory is strictly read-only: the folder is the desktop
+        # app's private sync cache, so direct writes would bypass sync.
+        "local-dir": {
+            "read": True,
+            "render": True,
+            "upload": False,
             "mkdir": False,
             "move": False,
             "rename": False,
@@ -1481,6 +1501,15 @@ async def remarkable_status() -> str:
                 "1) Your reMarkable is connected via USB\n"
                 "2) USB web interface is enabled (Settings → Storage)\n"
                 "3) The device is on and unlocked"
+            )
+        elif transport == "local-dir":
+            hint = (
+                "Local data directory not usable. Make sure:\n"
+                "1) The reMarkable desktop app is installed and signed in "
+                "(it creates and syncs the folder), or\n"
+                "2) REMARKABLE_LOCAL_DIR points to a directory containing "
+                "xochitl-style data (*.metadata files)\n"
+                "Keep the desktop app running so the folder stays in sync."
             )
         else:
             hint = (

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1287,9 +1287,10 @@ async def remarkable_status() -> str:
     """
     <usecase>Check connection status, active transport, and write capabilities.</usecase>
     <instructions>
-    Returns authentication status, the active transport (cloud, ssh, or usb-web),
-    the document count, and a capability matrix describing what each transport can
-    do. Use this to verify your connection, choose a transport, or troubleshoot.
+    Returns authentication status, the active transport (cloud, local-dir, ssh, or
+    usb-web), the document count, and a capability matrix describing what each
+    transport can do. Use this to verify your connection, choose a transport, or
+    troubleshoot.
 
     Capability notes:
     - Cloud (default): full read/render/upload/mkdir/move/rename/delete — no device
@@ -1298,6 +1299,8 @@ async def remarkable_status() -> str:
     - USB web: read, render, and upload (to root) only — the tablet's USB web
       interface firmware exposes no folder/move/rename/delete endpoints. For full
       write parity over a USB cable, use SSH mode pointed at the USB IP.
+    - Local directory: fully offline read/render access to the desktop app's sync
+      cache. Strictly read-only to avoid corrupting app-managed state.
     Write tools (upload/mkdir/move/rename/delete) are enabled by default; run
     with --read-only (or REMARKABLE_READ_ONLY=1) to expose a read-only server.
     </instructions>
@@ -1398,7 +1401,7 @@ async def remarkable_status() -> str:
         fell_back = transport != selected_transport
         if fell_back:
             connection_info = (
-                f"cloud (fell back from {selected_transport}: device unreachable, "
+                f"cloud (fell back from {selected_transport}: transport unavailable, "
                 "cloud token configured)"
             )
 
@@ -1444,7 +1447,7 @@ async def remarkable_status() -> str:
         hint_parts = [f"Connected successfully via {transport}. Found {doc_count} documents."]
         if fell_back:
             hint_parts.append(
-                f"Note: {selected_transport} was selected but not reachable, so it "
+                f"Note: {selected_transport} was selected but unavailable, so it "
                 "fell back to cloud (a cloud token is configured). Set "
                 "REMARKABLE_DISABLE_CLOUD_FALLBACK=1 to disable this."
             )
@@ -1460,6 +1463,11 @@ async def remarkable_status() -> str:
                 hint_parts.append(
                     "Write is enabled: upload, mkdir, move, rename, and delete are available."
                 )
+        elif selected_transport == "local-dir":
+            hint_parts.append(
+                "Write tools are disabled because the local-directory transport "
+                "is strictly read-only."
+            )
         else:
             hint_parts.append(
                 "Read-only mode is active (--read-only / REMARKABLE_READ_ONLY=1). "

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -61,7 +61,14 @@ def read_only_enabled() -> bool:
 
 
 def write_enabled() -> bool:
-    """Write tools are enabled by default; disabled only in read-only mode."""
+    """Write tools are enabled by default; disabled only in read-only mode.
+
+    The local-directory transport is unconditionally read-only: the directory
+    is the desktop app's private sync cache, and writing to it directly would
+    bypass sync and could corrupt the app's state.
+    """
+    if _is_local_dir_mode():
+        return False
     return not read_only_enabled()
 
 
@@ -103,9 +110,18 @@ def _is_usb_web_mode() -> bool:
     )
 
 
+def _is_local_dir_mode() -> bool:
+    """Check if the local-directory transport is active."""
+    return os.environ.get("REMARKABLE_USE_LOCAL_DIR", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    ) or bool(os.environ.get("REMARKABLE_LOCAL_DIR"))
+
+
 def _is_cloud_mode() -> bool:
-    """Check if cloud transport is active (the default when SSH/USB are off)."""
-    return not _is_ssh_mode() and not _is_usb_web_mode()
+    """Check if cloud transport is active (the default when other modes are off)."""
+    return not _is_ssh_mode() and not _is_usb_web_mode() and not _is_local_dir_mode()
 
 
 def _require_managed_write_mode() -> Optional[str]:

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1,6 +1,8 @@
 """
 Write tools for reMarkable tablet via cloud, SSH, or USB web interface.
 
+The local-directory transport is always read-only and never registers these tools.
+
 These tools are enabled by default. Disable them (expose a read-only server) via:
 - CLI flag: remarkable-mcp --read-only  (works in any transport)
 - Environment variable: REMARKABLE_READ_ONLY=1
@@ -75,9 +77,10 @@ def write_enabled() -> bool:
 def _require_write_transport() -> Optional[str]:
     """Return an error string if writes are disabled, else None.
 
-    Upload works in all three transports (cloud, SSH, USB web). Write tools are
-    not registered when REMARKABLE_READ_ONLY is set, so this is mostly a
-    defensive check that returns a clear error if writes are somehow disabled.
+    Upload works in the three write-capable transports (cloud, SSH, USB web).
+    Write tools are not registered in read-only or local-directory mode, so this
+    is mostly a defensive check that returns a clear error if writes are somehow
+    disabled.
     """
     if not write_enabled():
         return make_error(
@@ -127,8 +130,8 @@ def _is_cloud_mode() -> bool:
 def _require_managed_write_mode() -> Optional[str]:
     """Return an error string unless in a mode that supports folder operations.
 
-    mkdir, move, rename and delete work in cloud and SSH modes. USB web
-    mode only supports uploads, so it is rejected here with guidance.
+    mkdir, move, rename and delete work in cloud and SSH modes. USB web only
+    supports uploads, while local-directory mode is read-only.
     """
     if _is_cloud_mode() or _is_ssh_mode():
         return None
@@ -137,7 +140,7 @@ def _require_managed_write_mode() -> Optional[str]:
         message="This operation isn't available in USB web mode",
         suggestion=(
             "mkdir, move, rename and delete work in cloud mode (the "
-            "default) and SSH mode. Upload works in all three modes.\n"
+            "default) and SSH mode. USB web supports upload only.\n"
             "Run with: remarkable-mcp  (cloud)  or  remarkable-mcp --ssh"
         ),
     )

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -11,10 +11,11 @@ work, tool by tool?"*
 ## Running it
 
 ```bash
-# All modes this machine can reach (cloud, then usb-web, then ssh)
+# All modes this machine can reach (local, then cloud, then usb-web, then ssh)
 uv run python smoke/run_smoke.py
 
 # Just one mode
+uv run python smoke/run_smoke.py --modes local
 uv run python smoke/run_smoke.py --modes cloud
 uv run python smoke/run_smoke.py --modes usb
 uv run python smoke/run_smoke.py --modes ssh
@@ -23,9 +24,9 @@ uv run python smoke/run_smoke.py --modes ssh
 uv run python smoke/run_smoke.py --read-only
 ```
 
-Modes run in the order **cloud → usb-web → ssh** on purpose: pushing files over
-SSH can reset the USB web interface, so the only filesystem-writing transport
-runs last.
+Modes run in the order **local → cloud → usb-web → ssh** on purpose: local is
+read-only and side-effect-free so it goes first, and pushing files over SSH can
+reset the USB web interface, so the only filesystem-writing transport runs last.
 
 ## Reading the result
 
@@ -48,17 +49,19 @@ tool visibility changes.
 
 ## Per-mode expectations
 
-| Tool | cloud | usb-web | ssh |
-| ---- | :---: | :-----: | :-: |
-| `remarkable_status` / `browse` / `recent` / `search` / `read` / `image` / `canvas` | PASS | PASS | PASS |
-| `remarkable_upload` | PASS | PASS | PASS |
-| `remarkable_mkdir` / `rename` / `move` / `delete` | PASS | **N/A** | PASS |
-| `remarkable_author` | **N/A** | **N/A** | PASS |
+| Tool | local | cloud | usb-web | ssh |
+| ---- | :---: | :---: | :-----: | :-: |
+| `remarkable_status` / `browse` / `recent` / `search` / `read` / `image` / `canvas` | PASS | PASS | PASS | PASS |
+| `remarkable_upload` | **N/A** | PASS | PASS | PASS |
+| `remarkable_mkdir` / `rename` / `move` / `delete` | **N/A** | PASS | **N/A** | PASS |
+| `remarkable_author` | **N/A** | **N/A** | **N/A** | PASS |
 
 USB web is read + render + upload-to-root only — the device firmware HTTP server
 exposes no folder/move/rename/delete endpoints, so those tools are not registered
-in that mode (shown as N/A). `remarkable_author` requires native `.rm` write-back
-and is SSH-only today.
+in that mode (shown as N/A). Local directory mode is strictly read-only (the
+folder is the desktop app's private sync cache), so no write tool registers
+there. `remarkable_author` requires native `.rm` write-back and is SSH-only
+today.
 
 ### Upload is verified end-to-end (cloud/ssh)
 

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -6,11 +6,12 @@ the protocol (stdio, via the official ``mcp`` client SDK -- no AI, no models, no
 mocks) and exercises EVERY available tool in EVERY available transport, in the
 order:
 
-    cloud  ->  usb-web  ->  ssh
+    local  ->  cloud  ->  usb-web  ->  ssh
 
-Why that order matters: pushing files over SSH can reset the USB web interface,
-so SSH (the only mode that writes to the device filesystem) runs LAST, after the
-USB-web checks are done.
+Why that order matters: local is read-only and side-effect-free so it runs
+first; pushing files over SSH can reset the USB web interface, so SSH (the only
+mode that writes to the device filesystem) runs LAST, after the USB-web checks
+are done.
 
 The server HIDES tools a transport cannot support (e.g. mkdir/move/rename/delete
 are not registered over USB web; remarkable_author is SSH-only). The harness is
@@ -117,6 +118,15 @@ WRITE_TOOLS = {
 # hatch. usb/ssh disable cloud fallback so a dead device cannot silently pass via
 # cloud.
 MODES = {
+    "local": {
+        "transport": "local-dir",
+        "args": ["--local-dir"],
+        "env": {
+            "REMARKABLE_USE_LOCAL_DIR": "1",
+            "REMARKABLE_DISABLE_CLOUD_FALLBACK": "1",
+        },
+        "probe_port": None,
+    },
     "cloud": {
         "transport": "cloud",
         "args": [],
@@ -176,6 +186,16 @@ def _tcp_open(host: str, port: int, timeout: float = 2.0) -> bool:
 def _mode_prescreen(mode: str) -> tuple[bool, str]:
     """Cheap reachability check before spawning the server (avoids long hangs)."""
     spec = MODES[mode]
+    if mode == "local":
+        from remarkable_mcp.local_dir import check_local_dir_available
+
+        base_dir = os.environ.get("REMARKABLE_LOCAL_DIR")
+        if check_local_dir_available(base_dir):
+            return True, "local data directory present"
+        return False, (
+            "no local data directory found (install/sign in to the reMarkable "
+            "desktop app, or set REMARKABLE_LOCAL_DIR)"
+        )
     if mode == "cloud":
         if _cloud_token_present():
             return True, "cloud token present"
@@ -706,8 +726,8 @@ def main():
     )
     parser.add_argument(
         "--modes",
-        default="cloud,usb,ssh",
-        help="Comma-separated subset of modes in run order (default: cloud,usb,ssh)",
+        default="local,cloud,usb,ssh",
+        help="Comma-separated subset of modes in run order (default: local,cloud,usb,ssh)",
     )
     parser.add_argument(
         "--read-only",
@@ -716,12 +736,14 @@ def main():
     )
     args = parser.parse_args()
 
-    order = ["cloud", "usb", "ssh"]
+    # local runs first: it is read-only and side-effect-free. SSH still runs
+    # last because its writes can reset the USB web interface.
+    order = ["local", "cloud", "usb", "ssh"]
     requested = [m.strip() for m in args.modes.split(",") if m.strip()]
     unknown = [m for m in requested if m not in MODES]
     if unknown:
         parser.error(f"unknown mode(s): {unknown}. Choose from {list(MODES)}")
-    # Always honour cloud -> usb -> ssh ordering regardless of input order.
+    # Always honour local -> cloud -> usb -> ssh ordering regardless of input order.
     args.modes = [m for m in order if m in requested]
 
     if not FIXTURE_PDF.exists():

--- a/test_local_dir.py
+++ b/test_local_dir.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Tests for the local-directory transport (remarkable_mcp.local_dir).
+
+Covers client behaviour against a fake xochitl-style directory, directory
+resolution, transport selection in api.get_rmapi(), and the read-only
+guarantee in write_tools.
+"""
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from remarkable_mcp import api
+from remarkable_mcp.local_dir import (
+    LocalDirClient,
+    check_local_dir_available,
+    create_local_dir_client,
+    find_default_local_dir,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+NOTEBOOK_ID = "11111111-1111-1111-1111-111111111111"
+PDF_ID = "22222222-2222-2222-2222-222222222222"
+FOLDER_ID = "33333333-3333-3333-3333-333333333333"
+DELETED_ID = "44444444-4444-4444-4444-444444444444"
+PAGE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+RM_V6_HEADER = b"reMarkable .lines file, version=6          " + b"\x00" * 16
+
+
+@pytest.fixture
+def xochitl_dir(tmp_path):
+    """Build a minimal fake desktop-app data directory."""
+    d = tmp_path / "desktop"
+    d.mkdir()
+
+    # A folder
+    (d / f"{FOLDER_ID}.metadata").write_text(
+        json.dumps(
+            {
+                "visibleName": "Work",
+                "type": "CollectionType",
+                "parent": "",
+                "lastModified": "1700000000000",
+            }
+        )
+    )
+
+    # A handwritten notebook inside the folder
+    (d / f"{NOTEBOOK_ID}.metadata").write_text(
+        json.dumps(
+            {
+                "visibleName": "Meeting Notes",
+                "type": "DocumentType",
+                "parent": FOLDER_ID,
+                "pinned": True,
+                "lastModified": "1700000001000",
+                "tags": ["important"],
+            }
+        )
+    )
+    (d / f"{NOTEBOOK_ID}.content").write_text(
+        json.dumps(
+            {
+                "fileType": "notebook",
+                "cPages": {"pages": [{"id": PAGE_ID}]},
+            }
+        )
+    )
+    nb_dir = d / NOTEBOOK_ID
+    nb_dir.mkdir()
+    (nb_dir / f"{PAGE_ID}.rm").write_bytes(RM_V6_HEADER)
+
+    # A PDF-backed document at root
+    (d / f"{PDF_ID}.metadata").write_text(
+        json.dumps(
+            {
+                "visibleName": "Paper",
+                "type": "DocumentType",
+                "parent": "",
+                "lastModified": "1700000002000",
+            }
+        )
+    )
+    (d / f"{PDF_ID}.content").write_text(json.dumps({"fileType": "pdf"}))
+    (d / f"{PDF_ID}.pdf").write_bytes(b"%PDF-1.4 fake pdf bytes")
+
+    # A deleted document (must be skipped)
+    (d / f"{DELETED_ID}.metadata").write_text(
+        json.dumps(
+            {
+                "visibleName": "Gone",
+                "type": "DocumentType",
+                "parent": "",
+                "deleted": True,
+            }
+        )
+    )
+
+    return d
+
+
+@pytest.fixture
+def client(xochitl_dir):
+    return LocalDirClient(xochitl_dir)
+
+
+# =============================================================================
+# Client behaviour
+# =============================================================================
+
+
+class TestLocalDirClient:
+    def test_check_connection(self, client):
+        assert client.check_connection() is True
+
+    def test_check_connection_missing_dir(self, tmp_path):
+        assert LocalDirClient(tmp_path / "nope").check_connection() is False
+
+    def test_check_connection_empty_dir(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert LocalDirClient(empty).check_connection() is False
+
+    def test_get_meta_items(self, client):
+        items = client.get_meta_items()
+        # Deleted document skipped
+        assert {d.id for d in items} == {NOTEBOOK_ID, PDF_ID, FOLDER_ID}
+
+        notebook = next(d for d in items if d.id == NOTEBOOK_ID)
+        assert notebook.name == "Meeting Notes"
+        assert notebook.parent == FOLDER_ID
+        assert notebook.pinned is True
+        assert notebook.tags == ["important"]
+        assert notebook.last_modified is not None
+        assert notebook.is_folder is False
+
+        folder = next(d for d in items if d.id == FOLDER_ID)
+        assert folder.is_folder is True
+
+    def test_get_meta_items_limit(self, client):
+        assert len(client.get_meta_items(limit=2)) == 2
+
+    def test_get_meta_items_cached(self, client):
+        first = client.get_meta_items()
+        assert client.get_meta_items() is first
+
+    def test_get_doc(self, client):
+        assert client.get_doc(NOTEBOOK_ID).name == "Meeting Notes"
+        assert client.get_doc("missing") is None
+
+    def test_compat_properties(self, client):
+        doc = client.get_doc(NOTEBOOK_ID)
+        # Cloud-client naming compatibility used across tools.py
+        assert doc.VissibleName == "Meeting Notes"
+        assert doc.ID == NOTEBOOK_ID
+        assert doc.Parent == FOLDER_ID
+
+    def test_download_notebook_zip(self, client):
+        doc = client.get_doc(NOTEBOOK_ID)
+        blob = client.download(doc)
+        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+            names = set(zf.namelist())
+            assert f"{PAGE_ID}.rm" in names
+            assert f"{NOTEBOOK_ID}.content" in names
+            assert zf.read(f"{PAGE_ID}.rm").startswith(b"reMarkable .lines file")
+
+    def test_download_pdf_zip_includes_source(self, client):
+        doc = client.get_doc(PDF_ID)
+        blob = client.download(doc)
+        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+            names = set(zf.namelist())
+            assert f"{PDF_ID}.content" in names
+            assert f"{PDF_ID}.pdf" in names
+
+    def test_download_raw_file(self, client):
+        doc = client.get_doc(PDF_ID)
+        assert client.download_raw_file(doc, "pdf").startswith(b"%PDF")
+        assert client.download_raw_file(doc, "epub") is None
+
+    def test_get_file_type(self, client):
+        assert client.get_file_type(client.get_doc(PDF_ID)) == "pdf"
+        assert client.get_file_type(client.get_doc(NOTEBOOK_ID)) == "notebook"
+
+    def test_get_all_file_types(self, client):
+        types = client.get_all_file_types()
+        assert types[PDF_ID] == "pdf"
+        assert types[NOTEBOOK_ID] == "notebook"
+
+
+# =============================================================================
+# Directory resolution
+# =============================================================================
+
+
+class TestDirectoryResolution:
+    def test_explicit_arg(self, xochitl_dir):
+        client = create_local_dir_client(str(xochitl_dir))
+        assert client.base_dir == xochitl_dir
+
+    def test_env_path(self, xochitl_dir, monkeypatch):
+        monkeypatch.setenv("REMARKABLE_LOCAL_DIR", str(xochitl_dir))
+        client = create_local_dir_client()
+        assert client.base_dir == xochitl_dir
+
+    def test_no_dir_found_raises(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("REMARKABLE_LOCAL_DIR", raising=False)
+        monkeypatch.setattr(
+            "remarkable_mcp.local_dir.DEFAULT_DIR_CANDIDATES",
+            (str(tmp_path / "missing"),),
+        )
+        with pytest.raises(RuntimeError, match="REMARKABLE_LOCAL_DIR"):
+            create_local_dir_client()
+
+    def test_find_default_local_dir(self, xochitl_dir, monkeypatch):
+        monkeypatch.setattr(
+            "remarkable_mcp.local_dir.DEFAULT_DIR_CANDIDATES",
+            (str(xochitl_dir),),
+        )
+        assert find_default_local_dir() == xochitl_dir
+
+    def test_check_local_dir_available(self, xochitl_dir, tmp_path):
+        assert check_local_dir_available(str(xochitl_dir)) is True
+        assert check_local_dir_available(str(tmp_path / "missing")) is False
+
+
+# =============================================================================
+# Transport selection (api.get_rmapi)
+# =============================================================================
+
+
+class TestTransportSelection:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        api.reset_client_cache()
+        yield
+        api.reset_client_cache()
+
+    def test_get_rmapi_local_dir(self, xochitl_dir, monkeypatch):
+        monkeypatch.setenv("REMARKABLE_LOCAL_DIR", str(xochitl_dir))
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        client = api.get_rmapi()
+        assert isinstance(client, LocalDirClient)
+        assert api.get_active_transport() == "local-dir"
+
+    def test_local_dir_takes_priority_over_ssh(self, xochitl_dir, monkeypatch):
+        monkeypatch.setenv("REMARKABLE_LOCAL_DIR", str(xochitl_dir))
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", True)
+        client = api.get_rmapi()
+        assert isinstance(client, LocalDirClient)
+
+    def test_missing_dir_falls_back_to_cloud(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("REMARKABLE_LOCAL_DIR", raising=False)
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        monkeypatch.setattr(
+            "remarkable_mcp.local_dir.DEFAULT_DIR_CANDIDATES",
+            (str(tmp_path / "missing"),),
+        )
+        monkeypatch.setattr(api, "_is_cloud_token_available", lambda: True)
+        sentinel = object()
+        monkeypatch.setattr(api, "_get_cloud_client", lambda: sentinel)
+        client = api.get_rmapi()
+        assert client is sentinel
+        assert api.get_active_transport() == "cloud"
+
+    def test_missing_dir_no_fallback_raises(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("REMARKABLE_LOCAL_DIR", raising=False)
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        monkeypatch.setattr(
+            "remarkable_mcp.local_dir.DEFAULT_DIR_CANDIDATES",
+            (str(tmp_path / "missing"),),
+        )
+        monkeypatch.setattr(api, "_is_cloud_token_available", lambda: False)
+        with pytest.raises(RuntimeError):
+            api.get_rmapi()
+
+
+# =============================================================================
+# Read-only guarantee
+# =============================================================================
+
+
+class TestReadOnlyGuarantee:
+    def test_write_disabled_in_local_dir_mode(self, monkeypatch):
+        from remarkable_mcp import write_tools
+
+        monkeypatch.setenv("REMARKABLE_USE_LOCAL_DIR", "1")
+        monkeypatch.delenv("REMARKABLE_READ_ONLY", raising=False)
+        assert write_tools.write_enabled() is False
+
+    def test_local_dir_not_cloud_mode(self, monkeypatch):
+        from remarkable_mcp import write_tools
+
+        monkeypatch.setenv("REMARKABLE_USE_LOCAL_DIR", "1")
+        assert write_tools._is_cloud_mode() is False
+        assert write_tools._is_local_dir_mode() is True
+
+    def test_write_enabled_without_local_dir(self, monkeypatch):
+        from remarkable_mcp import write_tools
+
+        monkeypatch.delenv("REMARKABLE_USE_LOCAL_DIR", raising=False)
+        monkeypatch.delenv("REMARKABLE_LOCAL_DIR", raising=False)
+        monkeypatch.delenv("REMARKABLE_READ_ONLY", raising=False)
+        assert write_tools.write_enabled() is True

--- a/test_local_dir.py
+++ b/test_local_dir.py
@@ -204,6 +204,10 @@ class TestDirectoryResolution:
         client = create_local_dir_client(str(xochitl_dir))
         assert client.base_dir == xochitl_dir
 
+    def test_invalid_explicit_arg_raises(self, tmp_path):
+        with pytest.raises(RuntimeError, match="not usable"):
+            create_local_dir_client(str(tmp_path / "missing"))
+
     def test_env_path(self, xochitl_dir, monkeypatch):
         monkeypatch.setenv("REMARKABLE_LOCAL_DIR", str(xochitl_dir))
         client = create_local_dir_client()
@@ -281,6 +285,27 @@ class TestTransportSelection:
         with pytest.raises(RuntimeError):
             api.get_rmapi()
 
+    def test_invalid_explicit_dir_no_fallback_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("REMARKABLE_LOCAL_DIR", str(tmp_path / "missing"))
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", True)
+        with pytest.raises(RuntimeError, match="not usable"):
+            api.get_rmapi()
+
+    def test_cloud_fallback_preserves_local_read_only_mode(self, monkeypatch, tmp_path):
+        from remarkable_mcp import write_tools
+
+        monkeypatch.setenv("REMARKABLE_LOCAL_DIR", str(tmp_path / "missing"))
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        monkeypatch.setattr(api, "REMARKABLE_DISABLE_CLOUD_FALLBACK", False)
+        monkeypatch.setattr(api, "_is_cloud_token_available", lambda: True)
+        monkeypatch.setattr(api, "_get_cloud_client", lambda: object())
+
+        api.get_rmapi()
+
+        assert api.get_active_transport() == "cloud"
+        assert write_tools.write_enabled() is False
+
 
 # =============================================================================
 # Read-only guarantee
@@ -309,3 +334,21 @@ class TestReadOnlyGuarantee:
         monkeypatch.delenv("REMARKABLE_LOCAL_DIR", raising=False)
         monkeypatch.delenv("REMARKABLE_READ_ONLY", raising=False)
         assert write_tools.write_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_status_explains_local_dir_read_only(self, client, monkeypatch):
+        from remarkable_mcp import tools
+
+        monkeypatch.setenv("REMARKABLE_USE_LOCAL_DIR", "1")
+        monkeypatch.delenv("REMARKABLE_READ_ONLY", raising=False)
+        monkeypatch.setattr(api, "REMARKABLE_USE_LOCAL_DIR", True)
+        monkeypatch.setattr(api, "REMARKABLE_USE_USB_WEB", False)
+        monkeypatch.setattr(api, "REMARKABLE_USE_SSH", False)
+        monkeypatch.setattr(tools, "get_rmapi", lambda: client)
+
+        result = await tools.remarkable_status()
+        data = json.loads(result)
+
+        assert data["transport"] == "local-dir"
+        assert data["write_enabled"] is False
+        assert "strictly read-only" in data["_hint"]

--- a/test_server.py
+++ b/test_server.py
@@ -300,8 +300,8 @@ class TestRemarkableStatus:
         assert "capabilities_by_transport" in data
 
         matrix = data["capabilities_by_transport"]
-        # All three transports are described.
-        assert set(matrix) == {"cloud", "ssh", "usb-web"}
+        # All four transports are described.
+        assert set(matrix) == {"cloud", "ssh", "usb-web", "local-dir"}
         # Read/render are universal.
         for caps in matrix.values():
             assert caps["read"] is True
@@ -311,6 +311,10 @@ class TestRemarkableStatus:
             assert all(matrix[mode][op] for op in ("upload", "mkdir", "move", "rename", "delete"))
         assert matrix["usb-web"]["upload"] is True
         assert not any(matrix["usb-web"][op] for op in ("mkdir", "move", "rename", "delete"))
+        # Local directory is strictly read-only.
+        assert not any(
+            matrix["local-dir"][op] for op in ("upload", "mkdir", "move", "rename", "delete")
+        )
 
         # Effective capabilities for the active transport always cover read/render.
         assert data["capabilities"]["read"] is True


### PR DESCRIPTION
## Summary

- add a read-only `LocalDirClient` for xochitl-style stores, including desktop-app cache auto-detection on macOS, Windows, and Linux
- add `--local-dir [PATH]` and `REMARKABLE_LOCAL_DIR` / `REMARKABLE_USE_LOCAL_DIR` selection with cached cloud fallback
- gate write tools and capabilities so local-directory mode stays read/render-only, including after cloud fallback
- add local mode to the smoke harness and document setup, fallback, status, and transport capabilities
- preserve current SSH key pinning from #148 and deferred/batched xochitl restart behavior from #131

This recreates and supersedes #144 on current `main`. The implementation and original commits are from @pdezwart; those commits retain Pieter's authorship, with follow-up integration fixes co-authored and credited here.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest test_server.py test_local_dir.py -v` — 250 passed
- `uv run python smoke/run_smoke.py --modes local --read-only` — safe prescreen passed; local mode skipped because this environment has no desktop cache

## Caveats

- No real desktop-app cache was available in this environment, so live cache rendering was not repeated here; #144 reports byte-identical validation against a real 713-document library.
- A server launched in local-directory mode remains read-only if it falls back to cloud, preserving the mode's safety contract.