### PR TITLE
Fix imported PDF rendering and annotation mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Your reMarkable tablet is a powerful tool for thinking, note-taking, and researc
 - **Full library access** — Browse folders, search documents, read any file
 - **Typed text extraction** — Native support for Type Folio and typed annotations
 - **Handwriting OCR** — Convert handwritten notes to searchable text
-- **PDF & EPUB support** — Extract text from documents, plus your annotations
+- **PDF & EPUB support** — Extract text plus an index of annotated pages, highlights, and notes
 - **Robust page rendering** — Renders pages locally and automatically falls back to a source PDF when the local stroke renderer can't (USB/SSH use the tablet's own PDF export; cloud uses the original source PDF), so images work across firmware versions and even without system graphics libraries installed
 - **Smart search** — Find content across your entire library
 - **Second brain integration** — Use with Obsidian, note-taking apps, or any AI workflow

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -663,6 +663,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         get_background_color,
         get_document_file_type,
         get_document_page_count,
+        render_mapped_pdf_page_from_document_zip,
         render_page_full_page_from_document_zip,
         render_tablet_pdf_page_to_png,
     )
@@ -751,11 +752,15 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
         else:
             png_data = None
         if png_data is None:
-            pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
-            if pdf_bytes:
-                png_data = await run_blocking(render_tablet_pdf_page_to_png, pdf_bytes, page)
-                if png_data is not None:
-                    render_source = "tablet_pdf"
+            png_data, has_source_pdf = await run_blocking(
+                render_mapped_pdf_page_from_document_zip, tmp_path, page
+            )
+            if png_data is None and not has_source_pdf:
+                pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
+                if pdf_bytes:
+                    png_data = await run_blocking(render_tablet_pdf_page_to_png, pdf_bytes, page)
+            if png_data is not None:
+                render_source = "tablet_pdf"
 
         if png_data is None:
             return make_error(

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1498,13 +1498,16 @@ def _resolve_pdf_page_index(tmpdir_path: Path, page: int) -> Optional[int]:
     Returns None only when the page genuinely has no PDF underlay (a user-added
     page). This lets render_merged composite annotations onto imported PDFs that
     use either layout, instead of falling back to an annotation-only render.
+
+    When cPages entries exist they are authoritative: an entry without ``redir``
+    is a user-added page, and we must NOT fall through to a redirectionPageMap a
+    v1->v2 migrated document may still carry — its stale, order-shifted indices
+    could composite the wrong PDF page under a user-added page.
     """
-    # formatVersion 2 (cPages)
+    # formatVersion 2 (cPages) — authoritative when present
     entries = _read_cpages_entries(tmpdir_path)
     if entries and page <= len(entries):
-        idx = _pdf_page_index_for_cpages_entry(entries[page - 1])
-        if idx is not None:
-            return idx
+        return _pdf_page_index_for_cpages_entry(entries[page - 1])
 
     # formatVersion 1 (redirectionPageMap)
     rpm = _read_redirection_page_map(tmpdir_path)

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -603,6 +603,24 @@ def _v6_paths_from_blocks(blocks: list, anchor_pos: Optional[dict] = None) -> Tu
         if not hasattr(block, "item") or not hasattr(block.item, "value"):
             continue
         line = block.item.value
+
+        # Text highlights are GlyphRange items: they carry `rectangles`
+        # (highlight boxes over selected text) rather than stroke `points`.
+        # Emit a translucent filled rect per rectangle in the highlight colour.
+        if getattr(line, "rectangles", None):
+            hl_color = getattr(line, "color", 9)
+            hl_color = hl_color.value if hasattr(hl_color, "value") else hl_color
+            hl_fill = COLOR_MAP.get(hl_color, "#FFD700")
+            for r in line.rectangles:
+                paths.append(
+                    f'<rect x="{r.x:.1f}" y="{r.y:.1f}" '
+                    f'width="{r.w:.1f}" height="{r.h:.1f}" '
+                    f'fill="{hl_fill}" opacity="0.35" stroke="none"/>'
+                )
+                all_coords.append((r.x, r.y))
+                all_coords.append((r.x + r.w, r.y + r.h))
+            continue
+
         if not hasattr(line, "points") or not line.points:
             continue
         dx, dy = group_offsets.get(getattr(block, "parent_id", None), (0.0, 0.0))

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1629,23 +1629,40 @@ def render_merged_page_from_document_zip(
             if _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
-                # rmscene's v6 renderer emits stroke coordinates with the
-                # origin at the top of the page and x=0 in the horizontal
-                # center (so x ranges roughly from -W/2 to +W/2). Setting the
-                # viewBox to (-W_pt/2, 0, W_pt, H_pt) maps that coordinate
-                # system to the PDF page bounds so annotations align. If the
-                # upstream coordinate convention changes, this alignment will
-                # need to be revisited.
+                # rmscene emits stroke coordinates in the reMarkable device
+                # coordinate system (~226 dpi), NOT in PDF points: x=0 is the
+                # horizontal centre of the page and y=0 the top, and one unit is
+                # 72/226 pt. So a point on the page at (px, py) pt corresponds to
+                # rmscene ((px - W/2)/S, py/S) with S = 72/226. To map the whole
+                # page [0,W]x[0,H] pt into the output canvas we set the SVG
+                # viewBox to the rmscene rectangle that covers it:
+                #   (-W/(2S), 0, W/S, H/S).
+                # (The previous code assumed S=1, i.e. rmscene units == points,
+                # which placed strokes far outside the page and filled it black.)
+                # Validated against A4 imports on a reMarkable Paper Pro; the
+                # 226-dpi constant is the reMarkable display resolution.
                 svg_content = ann_svg_path.read_text()
 
+                rm_units_per_point = 226.0 / 72.0
+                vb_w = pdf_w_pt * rm_units_per_point
+                vb_h = pdf_h_pt * rm_units_per_point
                 svg_content = re.sub(
                     r'viewBox="[^"]*"',
-                    f'viewBox="{-pdf_w_pt / 2:.1f} 0 {pdf_w_pt:.1f} {pdf_h_pt:.1f}"',
+                    f'viewBox="{-vb_w / 2:.2f} 0 {vb_w:.2f} {vb_h:.2f}"',
                     svg_content,
                 )
-                # Also set explicit width/height to match output canvas
-                svg_content = re.sub(r'width="[^"]*"', f'width="{out_w}"', svg_content)
-                svg_content = re.sub(r'height="[^"]*"', f'height="{out_h}"', svg_content)
+                # Also set explicit width/height to match output canvas. Only
+                # the root <svg> element's attributes (the first occurrence), and
+                # a negative lookbehind so we never rewrite `stroke-width="..."`
+                # (a plain `width="[^"]*"` also matches inside `stroke-width`,
+                # which blows every stroke up to `out_w` units wide and fills the
+                # page solid black).
+                svg_content = re.sub(
+                    r'(?<![-\w])width="[^"]*"', f'width="{out_w}"', svg_content, count=1
+                )
+                svg_content = re.sub(
+                    r'(?<![-\w])height="[^"]*"', f'height="{out_h}"', svg_content, count=1
+                )
 
                 # Render SVG to PNG with transparent background
                 import cairosvg

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -42,6 +42,31 @@ def _rm_to_svg(rm_file_path: Path, output_svg_path: Path) -> bool:
 REMARKABLE_WIDTH = 1404
 REMARKABLE_HEIGHT = 1872
 
+# reMarkable stores stroke and highlight coordinates in a fixed internal grid
+# whose resolution is the original rM1/rM2 screen pitch, 226 dpi. Current devices
+# (including the Paper Pro) normalise onto this same grid regardless of their
+# physical screen, so SceneInfo.paper_size reports (1404, 1872) accordingly and
+# an imported PDF rendered at native size maps 1 point -> 226/72 units.
+REMARKABLE_COORD_DPI = 226.0
+
+
+def _rm_units_per_point(paper_size: Optional[tuple] = None) -> float:
+    """rmscene coordinate units per PDF point, for placing annotations on a page.
+
+    Returns a constant (``REMARKABLE_COORD_DPI / 72``) that holds for every device
+    normalising onto the standard 1404x1872 grid -- verified on a reMarkable Paper
+    Pro across A4, US-Letter and Springer page sizes.
+
+    ``paper_size`` (from rmscene ``SceneInfo``) is accepted but unused for now, on
+    purpose: this function is the single seam for making the scale device-derived.
+    A device reporting a non-standard ``paper_size`` (the smaller reMarkable Move
+    reportedly normalises differently) may use a different grid; when a sample
+    from such a device is available, derive the scale here from ``paper_size``
+    instead of assuming the constant. Callers must go through this function rather
+    than hard-coding the ratio.
+    """
+    return REMARKABLE_COORD_DPI / 72.0
+
 # Standard reMarkable background color (light cream/gray)
 # Can be overridden via REMARKABLE_BACKGROUND_COLOR environment variable
 _DEFAULT_BACKGROUND_COLOR = "#FBFBFB"
@@ -1683,21 +1708,19 @@ def render_merged_page_from_document_zip(
             if target_rm_file is not None and _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
-                # rmscene emits stroke coordinates in the reMarkable device
-                # coordinate system (~226 dpi), NOT in PDF points: x=0 is the
-                # horizontal centre of the page and y=0 the top, and one unit is
-                # 72/226 pt. So a point on the page at (px, py) pt corresponds to
-                # rmscene ((px - W/2)/S, py/S) with S = 72/226. To map the whole
-                # page [0,W]x[0,H] pt into the output canvas we set the SVG
-                # viewBox to the rmscene rectangle that covers it:
-                #   (-W/(2S), 0, W/S, H/S).
-                # (The previous code assumed S=1, i.e. rmscene units == points,
-                # which placed strokes far outside the page and filled it black.)
-                # Validated against A4 imports on a reMarkable Paper Pro; the
-                # 226-dpi constant is the reMarkable display resolution.
+                # rmscene emits stroke/highlight coordinates in the reMarkable
+                # device coordinate grid, NOT in PDF points: x=0 is the horizontal
+                # centre of the page and y=0 the top, and one PDF point is
+                # `_rm_units_per_point()` units (see that function for the scale
+                # and how to make it device-derived). To map the whole page
+                # [0,W]x[0,H] pt into the output canvas, set the SVG viewBox to the
+                # rmscene rectangle that covers it: (-W*k/2, 0, W*k, H*k) with
+                # k = units-per-point. (The previous code assumed k=1, i.e.
+                # rmscene units == points, which placed strokes far outside the
+                # page and filled it black.)
                 svg_content = ann_svg_path.read_text()
 
-                rm_units_per_point = 226.0 / 72.0
+                rm_units_per_point = _rm_units_per_point()
                 vb_w = pdf_w_pt * rm_units_per_point
                 vb_h = pdf_h_pt * rm_units_per_point
                 svg_content = re.sub(

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1868,6 +1868,50 @@ def get_document_file_type(zip_path: Path) -> str:
     return ""
 
 
+def _extract_page_annotations(rm_file: Path) -> Tuple[List[str], bool]:
+    """Extract a page's text highlights and whether it has pen strokes.
+
+    reMarkable text highlights are stored as ``GlyphRange`` scene items inside the
+    page's v6 ``.rm`` file (each carries the selected ``text`` and its bounding
+    ``rectangles``); freehand ink is stored as ``Line`` items. The legacy
+    ``.highlights`` JSON scanned elsewhere does not cover current firmware, so
+    read them here.
+
+    Returns ``(highlighted_texts_in_reading_order, has_pen_strokes)``. Returns
+    ``([], False)`` if the file cannot be parsed.
+    """
+    try:
+        import rmscene
+    except Exception:
+        return [], False
+    try:
+        with rm_file.open("rb") as fh:
+            tree = rmscene.read_tree(fh)
+    except Exception:
+        return [], False
+
+    highlights: list = []
+    has_strokes = False
+    try:
+        for item in tree.walk():
+            kind = type(item).__name__
+            if kind == "Line":
+                has_strokes = True
+            elif kind == "GlyphRange":
+                text = getattr(item, "text", None)
+                if not text:
+                    continue
+                rects = getattr(item, "rectangles", None) or []
+                y = rects[0].y if rects else 0.0
+                x = rects[0].x if rects else 0.0
+                highlights.append((y, x, text))
+    except Exception:
+        pass
+
+    highlights.sort(key=lambda t: (t[0], t[1]))  # top-to-bottom, left-to-right
+    return [t[2] for t in highlights], has_strokes
+
+
 def extract_text_from_document_zip(
     zip_path: Path, include_ocr: bool = False, doc_id: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -1882,10 +1926,16 @@ def extract_text_from_document_zip(
     Returns:
         {
             "typed_text": [...],      # From rmscene parsing (list of strings)
-            "highlights": [...],       # From PDF annotations
+            "highlights": [...],       # Highlighted text (GlyphRange + legacy JSON)
             "handwritten_text": [...], # From OCR (if enabled) - one per page, in order
             "pages": int,
             "page_ids": [...],         # Page UUIDs in order
+            "annotated_pages": [       # Only pages that carry annotations
+                {"page": int,          # 1-based page number
+                 "page_id": str,
+                 "has_handwriting": bool,   # page has pen strokes
+                 "highlights": [str]}, # highlighted text on the page
+            ],
             "ocr_backend": str,        # Which OCR backend was used (if any)
         }
     """
@@ -1903,6 +1953,7 @@ def extract_text_from_document_zip(
         "handwritten_text": None,
         "pages": 0,
         "page_ids": [],
+        "annotated_pages": [],
         "ocr_backend": None,
         "tags": [],
     }
@@ -1957,6 +2008,27 @@ def extract_text_from_document_zip(
         for rm_file in rm_files:
             text_lines = extract_text_from_rm_file(rm_file)
             result["typed_text"].extend(text_lines)
+
+        # Extract per-page text highlights (GlyphRange items) and note-presence
+        # from the .rm files, indexed by real page number. This powers "show only
+        # the annotated pages / the highlighted text" without paging through the
+        # whole document. (The legacy .highlights JSON scanned below only covers
+        # older firmware exports.)
+        page_pos = {pid: i for i, pid in enumerate(page_order)}
+        for order_pos, rm_file in enumerate(rm_files):
+            page_num = page_pos.get(rm_file.stem, order_pos) + 1
+            page_highlights, has_strokes = _extract_page_annotations(rm_file)
+            if page_highlights or has_strokes:
+                result["annotated_pages"].append(
+                    {
+                        "page": page_num,
+                        "page_id": rm_file.stem,
+                        "has_handwriting": has_strokes,
+                        "highlights": page_highlights,
+                    }
+                )
+                result["highlights"].extend(page_highlights)
+        result["annotated_pages"].sort(key=lambda a: a["page"])
 
         # Extract text from .txt and .md files
         for txt_file in tmpdir_path.glob("**/*.txt"):

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1650,10 +1650,14 @@ def render_merged_page_from_document_zip(
         # selection is deterministic.
         pdf_files = list(tmpdir_path.glob("**/*.pdf"))
         if not pdf_files:
+            # Notebook (no PDF underlay): render the page's own strokes,
+            # selected by id so multi-page notebooks with a blank page don't
+            # shift (see _select_rm_file_for_page).
             rm_files = _get_ordered_rm_files(tmpdir_path)
-            if page < 1 or page > len(rm_files):
-                return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
-            png = render_rm_file_to_png(rm_files[page - 1], background_color=background_color)
+            target = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+            if target is None:
+                return None, f"Page {page} has no annotation strokes."
+            png = render_rm_file_to_png(target, background_color=background_color)
             return png, "No PDF underlay found; returned annotation-only render."
 
         content_stems = {p.stem for p in tmpdir_path.glob("*.content")}

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1676,9 +1676,16 @@ def render_merged_page_from_document_zip(
 
         # Select the .rm for this page by id (see _select_rm_file_for_page). A
         # page with no strokes yields None and composites to the bare PDF page.
-        target_rm_file: Optional[Path] = _select_rm_file_for_page(
-            tmpdir_path, rm_files, page
-        )
+        target_rm_file: Optional[Path] = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+
+        def annotation_only(reason: str) -> Tuple[Optional[bytes], Optional[str]]:
+            """Fallback when the PDF side of the merge fails: render just the
+            page's own strokes — or nothing, for a strokeless page (every
+            fallback path must tolerate ``target_rm_file`` being None)."""
+            if target_rm_file is None:
+                return None, f"{reason}; page has no annotation strokes."
+            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
+            return png, f"{reason}; annotation-only render."
 
         # Determine which PDF page this reMarkable page maps to. Handles both the
         # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
@@ -1698,8 +1705,7 @@ def render_merged_page_from_document_zip(
             doc = fitz.open(stream=pdf_bytes, filetype="pdf")
             try:
                 if pdf_page_index >= len(doc):
-                    png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-                    return png, "PDF page index out of range; annotation-only render."
+                    return annotation_only("PDF page index out of range")
 
                 pdf_page = doc[pdf_page_index]
                 pdf_w_pt = pdf_page.rect.width  # PDF width in points
@@ -1707,8 +1713,7 @@ def render_merged_page_from_document_zip(
             finally:
                 doc.close()
         except Exception:
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "Could not read PDF dimensions; annotation-only render."
+            return annotation_only("Could not read PDF dimensions")
 
         # Determine output canvas size
         out_w = canvas_width or int(pdf_w_pt * 2)  # 2x for decent resolution
@@ -1717,8 +1722,7 @@ def render_merged_page_from_document_zip(
         # 1. Rasterize the PDF page
         pdf_png = _render_pdf_page_to_png(pdf_bytes, pdf_page_index, out_w, out_h)
         if pdf_png is None:
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "PDF rasterization failed; annotation-only render."
+            return annotation_only("PDF rasterization failed")
 
         # 2. Render annotation layer to SVG, then to PNG with transparent background
         ann_svg_path = None
@@ -1810,8 +1814,7 @@ def render_merged_page_from_document_zip(
             return buf.getvalue(), merged_note
         except Exception:
             # Last resort: return annotation-only from already-extracted .rm file
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "Compositing failed; annotation-only render."
+            return annotation_only("Compositing failed")
 
 
 def get_document_page_count(zip_path: Path) -> int:

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1247,6 +1247,30 @@ def _get_page_order(tmpdir_path: Path) -> List[str]:
     return []
 
 
+def _select_rm_file_for_page(
+    tmpdir_path: Path, rm_files: List[Path], page: int
+) -> Optional[Path]:
+    """Return the .rm stroke file for a 1-based page, matched by page id.
+
+    ``_get_ordered_rm_files`` is compacted (only pages that actually have
+    strokes), so indexing it by page number pairs the wrong ink with a page
+    whenever an earlier page is un-annotated. Map through the full ``.content``
+    page order and match by id instead. Returns None when the page has no
+    strokes (a page with a PDF underlay but no annotation), or when the page is
+    out of range; callers should treat None as "no annotation layer".
+    """
+    page_order = _get_page_order(tmpdir_path)
+    if page_order:
+        if 1 <= page <= len(page_order):
+            page_id = page_order[page - 1]
+            return next((p for p in rm_files if p.stem == page_id), None)
+        return None
+    # No page order available (unusual): fall back to positional selection.
+    if 1 <= page <= len(rm_files):
+        return rm_files[page - 1]
+    return None
+
+
 def render_page_from_document_zip_svg(
     zip_path: Path, page: int = 1, background_color: Optional[str] = None
 ) -> Optional[str]:
@@ -1270,12 +1294,12 @@ def render_page_from_document_zip_svg(
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
-        # Validate page number
-        if page < 1 or page > len(rm_files):
+        # Select the page's .rm by id (see _select_rm_file_for_page); None means
+        # the page has no annotation layer.
+        target_rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+        if target_rm_file is None:
             return None
 
-        # Render the requested page
-        target_rm_file = rm_files[page - 1]
         return render_rm_file_to_svg(target_rm_file, background_color=background_color)
 
 
@@ -1302,12 +1326,12 @@ def render_page_from_document_zip(
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
-        # Validate page number
-        if page < 1 or page > len(rm_files):
+        # Select the page's .rm by id (see _select_rm_file_for_page); None means
+        # the page has no annotation layer.
+        target_rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+        if target_rm_file is None:
             return None
 
-        # Render the requested page
-        target_rm_file = rm_files[page - 1]
         return render_rm_file_to_png(target_rm_file, background_color=background_color)
 
 
@@ -1638,24 +1662,16 @@ def render_merged_page_from_document_zip(
         pdf_bytes = pdf_path.read_bytes()
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
-        page_order = _get_page_order(tmpdir_path)
-        total_pages = len(page_order) or len(rm_files)
+        total_pages = len(_get_page_order(tmpdir_path)) or len(rm_files)
 
         if page < 1 or page > total_pages:
             return None, f"Page {page} out of range (document has {total_pages} pages)."
 
-        # Select the .rm for this page BY PAGE ID. _get_ordered_rm_files returns
-        # only pages that actually have strokes (compacted), so indexing it by
-        # page number pairs the wrong strokes with the page whenever an earlier
-        # page is un-annotated (e.g. page 4 would get page 6's ink). Map through
-        # the full .content page order instead. A page with no strokes yields
-        # target_rm_file=None and composites to the bare PDF page.
-        target_rm_file: Optional[Path] = None
-        if page_order and page <= len(page_order):
-            page_id = page_order[page - 1]
-            target_rm_file = next((p for p in rm_files if p.stem == page_id), None)
-        elif page <= len(rm_files):
-            target_rm_file = rm_files[page - 1]
+        # Select the .rm for this page by id (see _select_rm_file_for_page). A
+        # page with no strokes yields None and composites to the bare PDF page.
+        target_rm_file: Optional[Path] = _select_rm_file_for_page(
+            tmpdir_path, rm_files, page
+        )
 
         # Determine which PDF page this reMarkable page maps to. Handles both the
         # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1376,6 +1376,58 @@ def _pdf_page_index_for_cpages_entry(entry: Dict[str, Any]) -> Optional[int]:
     return None
 
 
+def _read_redirection_page_map(tmpdir_path: Path) -> List[Any]:
+    """Read the legacy (formatVersion 1) redirectionPageMap from .content.
+
+    formatVersion 1 documents have no cPages structure; instead the reMarkable
+    page -> original PDF page mapping is a flat list where the index is the
+    0-based reMarkable page and the value is the 0-based PDF page index (-1 for
+    user-added pages). Many cloud-imported PDFs use this layout.
+
+    Returns the list, or an empty list if not found.
+    """
+    content_file = next(tmpdir_path.glob("*.content"), None)
+    if content_file is None:
+        return []
+    try:
+        data = json.loads(content_file.read_text())
+        rpm = data.get("redirectionPageMap")
+        if isinstance(rpm, list):
+            return rpm
+    except Exception:
+        pass
+    return []
+
+
+def _resolve_pdf_page_index(tmpdir_path: Path, page: int) -> Optional[int]:
+    """Resolve the 0-based PDF page index for a 1-based reMarkable page.
+
+    Handles both document layouts:
+    - formatVersion 2: ``cPages.pages[i].redir.value``
+    - formatVersion 1: ``redirectionPageMap[i]`` (legacy; used by many
+      cloud-imported PDFs)
+
+    Returns None only when the page genuinely has no PDF underlay (a user-added
+    page). This lets render_merged composite annotations onto imported PDFs that
+    use either layout, instead of falling back to an annotation-only render.
+    """
+    # formatVersion 2 (cPages)
+    entries = _read_cpages_entries(tmpdir_path)
+    if entries and page <= len(entries):
+        idx = _pdf_page_index_for_cpages_entry(entries[page - 1])
+        if idx is not None:
+            return idx
+
+    # formatVersion 1 (redirectionPageMap)
+    rpm = _read_redirection_page_map(tmpdir_path)
+    if rpm and page <= len(rpm):
+        val = rpm[page - 1]
+        if isinstance(val, int) and val >= 0:
+            return val
+
+    return None
+
+
 def _render_pdf_page_to_png(
     pdf_bytes: bytes, page_index: int, width: int, height: int
 ) -> Optional[bytes]:
@@ -1521,8 +1573,6 @@ def render_merged_page_from_document_zip(
         pdf_path = matching[0] if matching else sorted(pdf_files)[0]
         pdf_bytes = pdf_path.read_bytes()
 
-        # Read cPages to find PDF page mapping
-        cpages = _read_cpages_entries(tmpdir_path)
         rm_files = _get_ordered_rm_files(tmpdir_path)
 
         if page < 1 or page > len(rm_files):
@@ -1530,10 +1580,11 @@ def render_merged_page_from_document_zip(
 
         target_rm_file = rm_files[page - 1]
 
-        # Determine which PDF page this reMarkable page maps to
-        pdf_page_index: Optional[int] = None
-        if cpages and page <= len(cpages):
-            pdf_page_index = _pdf_page_index_for_cpages_entry(cpages[page - 1])
+        # Determine which PDF page this reMarkable page maps to. Handles both the
+        # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
+        # layouts; the latter is used by many cloud-imported PDFs, which would
+        # otherwise be misread as user-added pages and rendered annotation-only.
+        pdf_page_index: Optional[int] = _resolve_pdf_page_index(tmpdir_path, page)
 
         if pdf_page_index is None:
             # No redirect — this page may be a user-added blank page

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -42,30 +42,69 @@ def _rm_to_svg(rm_file_path: Path, output_svg_path: Path) -> bool:
 REMARKABLE_WIDTH = 1404
 REMARKABLE_HEIGHT = 1872
 
-# reMarkable stores stroke and highlight coordinates in a fixed internal grid
-# whose resolution is the original rM1/rM2 screen pitch, 226 dpi. Current devices
-# (including the Paper Pro) normalise onto this same grid regardless of their
-# physical screen, so SceneInfo.paper_size reports (1404, 1872) accordingly and
-# an imported PDF rendered at native size maps 1 point -> 226/72 units.
-REMARKABLE_COORD_DPI = 226.0
+# PDF points per stroke unit, keyed by the per-page SceneInfo.paper_size grid.
+# The 1404x1872 value was calibrated against a device PDF export. The Paper Pro
+# value follows its panel DPI and remains a best-effort calibration until a
+# ground-truth export reporting that grid is available. Devices that normalize
+# Paper Pro scenes to 1404x1872 continue to use the calibrated value.
+_DEVICE_POINTS_PER_UNIT = {
+    (1404, 1872): 0.3177,
+    (1620, 2160): 0.3144,
+}
+REMARKABLE_PDF_POINTS_PER_UNIT = 0.3177
 
 
-def _rm_units_per_point(paper_size: Optional[tuple] = None) -> float:
-    """rmscene coordinate units per PDF point, for placing annotations on a page.
+def _points_per_unit(paper_size: Optional[Tuple[float, float]]) -> float:
+    """Return PDF points per stroke unit for a SceneInfo paper grid."""
+    if paper_size:
+        key = (int(round(paper_size[0])), int(round(paper_size[1])))
+        if key in _DEVICE_POINTS_PER_UNIT:
+            return _DEVICE_POINTS_PER_UNIT[key]
+    return REMARKABLE_PDF_POINTS_PER_UNIT
 
-    Returns a constant (``REMARKABLE_COORD_DPI / 72``) that holds for every device
-    normalising onto the standard 1404x1872 grid -- verified on a reMarkable Paper
-    Pro across A4, US-Letter and Springer page sizes.
 
-    ``paper_size`` (from rmscene ``SceneInfo``) is accepted but unused for now, on
-    purpose: this function is the single seam for making the scale device-derived.
-    A device reporting a non-standard ``paper_size`` (the smaller reMarkable Move
-    reportedly normalises differently) may use a different grid; when a sample
-    from such a device is available, derive the scale here from ``paper_size``
-    instead of assuming the constant. Callers must go through this function rather
-    than hard-coding the ratio.
-    """
-    return REMARKABLE_COORD_DPI / 72.0
+def _annotation_page_viewbox(
+    pdf_w_pt: float,
+    pdf_h_pt: float,
+    points_per_unit: float,
+    *,
+    centered_x: bool = True,
+) -> Tuple[float, float, float, float]:
+    """Return the stroke-space rectangle occupied by a PDF page."""
+    view_w = pdf_w_pt / points_per_unit
+    view_h = pdf_h_pt / points_per_unit
+    view_x = -view_w / 2.0 if centered_x else 0.0
+    return view_x, 0.0, view_w, view_h
+
+
+def _rewrite_svg_root(
+    svg_content: str,
+    *,
+    viewbox: Tuple[float, float, float, float],
+    width: int,
+    height: int,
+) -> str:
+    """Rewrite only root SVG geometry, leaving path stroke widths untouched."""
+    import re
+
+    root_match = re.search(r"<svg\b[^>]*>", svg_content, re.IGNORECASE)
+    if root_match is None:
+        return svg_content
+
+    root = root_match.group(0)
+    values = {
+        "viewBox": " ".join(f"{value:.2f}" for value in viewbox),
+        "width": str(width),
+        "height": str(height),
+    }
+    for name, value in values.items():
+        pattern = rf'(?<![-\w]){name}="[^"]*"'
+        if re.search(pattern, root):
+            root = re.sub(pattern, f'{name}="{value}"', root, count=1)
+        else:
+            root = root[:-1] + f' {name}="{value}">'
+
+    return svg_content[: root_match.start()] + root + svg_content[root_match.end() :]
 
 
 # Standard reMarkable background color (light cream/gray)
@@ -629,6 +668,7 @@ def _v6_paths_from_blocks(blocks: list, anchor_pos: Optional[dict] = None) -> Tu
         if not hasattr(block, "item") or not hasattr(block.item, "value"):
             continue
         line = block.item.value
+        dx, dy = group_offsets.get(getattr(block, "parent_id", None), (0.0, 0.0))
 
         # Text highlights are GlyphRange items: they carry `rectangles`
         # (highlight boxes over selected text) rather than stroke `points`.
@@ -639,17 +679,16 @@ def _v6_paths_from_blocks(blocks: list, anchor_pos: Optional[dict] = None) -> Tu
             hl_fill = COLOR_MAP.get(hl_color, "#FFD700")
             for r in line.rectangles:
                 paths.append(
-                    f'<rect x="{r.x:.1f}" y="{r.y:.1f}" '
+                    f'<rect x="{r.x + dx:.1f}" y="{r.y + dy:.1f}" '
                     f'width="{r.w:.1f}" height="{r.h:.1f}" '
                     f'fill="{hl_fill}" opacity="0.35" stroke="none"/>'
                 )
-                all_coords.append((r.x, r.y))
-                all_coords.append((r.x + r.w, r.y + r.h))
+                all_coords.append((r.x + dx, r.y + dy))
+                all_coords.append((r.x + dx + r.w, r.y + dy + r.h))
             continue
 
         if not hasattr(line, "points") or not line.points:
             continue
-        dx, dy = group_offsets.get(getattr(block, "parent_id", None), (0.0, 0.0))
 
         tool = line.tool if hasattr(line, "tool") else None
         color = line.color if hasattr(line, "color") else 0
@@ -1370,22 +1409,18 @@ def render_page_full_page_from_document_zip(
         with zipfile.ZipFile(zip_path, "r") as zf:
             zf.extractall(tmpdir_path)
 
-        rm_glob = list(tmpdir_path.glob("**/*.rm"))
+        rm_files = _get_ordered_rm_files(tmpdir_path)
+        page_order = _get_page_order(tmpdir_path)
 
-        entries = _read_cpages_entries(tmpdir_path)
-        page_ids = [e.get("id") for e in entries if isinstance(e, dict) and e.get("id")]
-
-        if page_ids:
-            if page < 1 or page > len(page_ids):
+        if page_order:
+            if page < 1 or page > len(page_order):
                 return None
-            page_id = page_ids[page - 1]
-            rm_file = next((p for p in rm_glob if p.stem == page_id), None)
+            rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
         else:
-            # No cPages metadata: fall back to filesystem/page order of .rm files.
-            ordered = _get_ordered_rm_files(tmpdir_path)
-            if page < 1 or page > len(ordered):
+            # No page metadata: fall back to filesystem order of .rm files.
+            if page < 1 or page > len(rm_files):
                 return None
-            rm_file = ordered[page - 1]
+            rm_file = rm_files[page - 1]
 
         if rm_file is not None and rm_file.exists():
             return render_rm_file_full_page_png(rm_file, background_color=background_color)
@@ -1394,7 +1429,7 @@ def render_page_full_page_from_document_zip(
         # render a blank full page at the document's paper size so the viewer
         # still shows it. (The write tool will return no_page_layer until the
         # page has a drawable layer / has been added via remarkable_add_page.)
-        paper_w, paper_h = _document_paper_size(rm_glob)
+        paper_w, paper_h = _document_paper_size(rm_files)
         svg = _svg_full_page([], paper_w, paper_h)
         scale = FULL_PAGE_TARGET_LONG_EDGE / max(paper_w, paper_h)
         png = _svg_string_to_png(
@@ -1505,15 +1540,27 @@ def _resolve_pdf_page_index(tmpdir_path: Path, page: int) -> Optional[int]:
     """
     # formatVersion 2 (cPages) — authoritative when present
     entries = _read_cpages_entries(tmpdir_path)
-    if entries and page <= len(entries):
-        return _pdf_page_index_for_cpages_entry(entries[page - 1])
+    if entries:
+        if 1 <= page <= len(entries):
+            return _pdf_page_index_for_cpages_entry(entries[page - 1])
+        return None
 
     # formatVersion 1 (redirectionPageMap)
     rpm = _read_redirection_page_map(tmpdir_path)
-    if rpm and page <= len(rpm):
-        val = rpm[page - 1]
-        if isinstance(val, int) and val >= 0:
-            return val
+    if rpm:
+        if 1 <= page <= len(rpm):
+            val = rpm[page - 1]
+            if isinstance(val, int) and val >= 0:
+                return val
+        return None
+
+    # Some formatVersion 1 documents (including files uploaded by this server)
+    # contain a flat page-id list but omit redirectionPageMap. With no explicit
+    # user-added-page markers, the source PDF order is the only authoritative
+    # mapping and is therefore identity.
+    page_order = _get_page_order(tmpdir_path)
+    if page_order and 1 <= page <= len(page_order):
+        return page - 1
 
     return None
 
@@ -1604,6 +1651,42 @@ def render_tablet_pdf_page_to_png(
         doc.close()
 
 
+def render_mapped_pdf_page_from_document_zip(
+    zip_path: Path, page: int = 1, target_long_edge: int = 2048
+) -> Tuple[Optional[bytes], bool]:
+    """Render a source-PDF underlay using the document's authoritative page map.
+
+    Returns ``(png, has_source_pdf)``. A source PDF with ``png=None`` means the
+    requested page has no mapped underlay (for example, a user-added page), so
+    callers must not substitute the same ordinal from a native PDF export.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        try:
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                zf.extractall(tmpdir_path)
+        except Exception:
+            return None, False
+
+        pdf_files = list(tmpdir_path.glob("**/*.pdf"))
+        if not pdf_files:
+            return None, False
+
+        pdf_page_index = _resolve_pdf_page_index(tmpdir_path, page)
+        if pdf_page_index is None:
+            return None, True
+
+        content_stems = {path.stem for path in tmpdir_path.glob("*.content")}
+        matching = [path for path in pdf_files if path.stem in content_stems]
+        pdf_path = matching[0] if matching else sorted(pdf_files)[0]
+        png = render_tablet_pdf_page_to_png(
+            pdf_path.read_bytes(),
+            page=pdf_page_index + 1,
+            target_long_edge=target_long_edge,
+        )
+        return png, True
+
+
 def render_merged_page_from_document_zip(
     zip_path: Path,
     page: int = 1,
@@ -1631,7 +1714,6 @@ def render_merged_page_from_document_zip(
         or None. Returns (None, error_note) on failure.
     """
     import io
-    import re
 
     import fitz
     from PIL import Image as PILImage
@@ -1746,25 +1828,20 @@ def render_merged_page_from_document_zip(
                 # page and filled it black.)
                 svg_content = ann_svg_path.read_text()
 
-                rm_units_per_point = _rm_units_per_point()
-                vb_w = pdf_w_pt * rm_units_per_point
-                vb_h = pdf_h_pt * rm_units_per_point
-                svg_content = re.sub(
-                    r'viewBox="[^"]*"',
-                    f'viewBox="{-vb_w / 2:.2f} 0 {vb_w:.2f} {vb_h:.2f}"',
+                blocks = _v6_blocks(target_rm_file)
+                paper_size = _v6_paper_size(blocks) if blocks is not None else None
+                points_per_unit = _points_per_unit(paper_size)
+                viewbox = _annotation_page_viewbox(
+                    pdf_w_pt,
+                    pdf_h_pt,
+                    points_per_unit,
+                    centered_x=blocks is not None,
+                )
+                svg_content = _rewrite_svg_root(
                     svg_content,
-                )
-                # Also set explicit width/height to match output canvas. Only
-                # the root <svg> element's attributes (the first occurrence), and
-                # a negative lookbehind so we never rewrite `stroke-width="..."`
-                # (a plain `width="[^"]*"` also matches inside `stroke-width`,
-                # which blows every stroke up to `out_w` units wide and fills the
-                # page solid black).
-                svg_content = re.sub(
-                    r'(?<![-\w])width="[^"]*"', f'width="{out_w}"', svg_content, count=1
-                )
-                svg_content = re.sub(
-                    r'(?<![-\w])height="[^"]*"', f'height="{out_h}"', svg_content, count=1
+                    viewbox=viewbox,
+                    width=out_w,
+                    height=out_h,
                 )
 
                 # Render SVG to PNG with transparent background
@@ -2005,9 +2082,11 @@ def extract_text_from_document_zip(
                 if rm_file not in ordered_rm_files:
                     ordered_rm_files.append(rm_file)
             rm_files = ordered_rm_files
+            result["page_ids"] = page_order
+        else:
             result["page_ids"] = [f.stem for f in rm_files]
 
-        result["pages"] = len(rm_files)
+        result["pages"] = len(page_order) or len(rm_files)
 
         # Extract typed text from .rm files using rmscene
         for rm_file in rm_files:

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -67,6 +67,7 @@ def _rm_units_per_point(paper_size: Optional[tuple] = None) -> float:
     """
     return REMARKABLE_COORD_DPI / 72.0
 
+
 # Standard reMarkable background color (light cream/gray)
 # Can be overridden via REMARKABLE_BACKGROUND_COLOR environment variable
 _DEFAULT_BACKGROUND_COLOR = "#FBFBFB"
@@ -1247,9 +1248,7 @@ def _get_page_order(tmpdir_path: Path) -> List[str]:
     return []
 
 
-def _select_rm_file_for_page(
-    tmpdir_path: Path, rm_files: List[Path], page: int
-) -> Optional[Path]:
+def _select_rm_file_for_page(tmpdir_path: Path, rm_files: List[Path], page: int) -> Optional[Path]:
     """Return the .rm stroke file for a 1-based page, matched by page id.
 
     ``_get_ordered_rm_files`` is compacted (only pages that actually have

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1183,6 +1183,27 @@ def _get_ordered_rm_files(tmpdir_path: Path) -> List[Path]:
     return rm_files
 
 
+def _get_page_order(tmpdir_path: Path) -> List[str]:
+    """Return the ordered list of page ids from the .content file.
+
+    formatVersion 2 stores them under ``cPages.pages[].id``; formatVersion 1 as
+    a flat ``pages`` list of ids. Returns an empty list if unavailable. This is
+    the full page order (including pages that have no strokes), unlike
+    ``_get_ordered_rm_files`` which is compacted to pages that do.
+    """
+    for content_file in tmpdir_path.glob("*.content"):
+        try:
+            data = json.loads(content_file.read_text())
+            if "cPages" in data and "pages" in data["cPages"]:
+                return [p.get("id") for p in data["cPages"]["pages"] if p.get("id")]
+            if isinstance(data.get("pages"), list):
+                return [p for p in data["pages"] if isinstance(p, str)]
+        except Exception:
+            pass
+        break
+    return []
+
+
 def render_page_from_document_zip_svg(
     zip_path: Path, page: int = 1, background_color: Optional[str] = None
 ) -> Optional[str]:
@@ -1574,11 +1595,24 @@ def render_merged_page_from_document_zip(
         pdf_bytes = pdf_path.read_bytes()
 
         rm_files = _get_ordered_rm_files(tmpdir_path)
+        page_order = _get_page_order(tmpdir_path)
+        total_pages = len(page_order) or len(rm_files)
 
-        if page < 1 or page > len(rm_files):
-            return None, f"Page {page} out of range (document has {len(rm_files)} pages)."
+        if page < 1 or page > total_pages:
+            return None, f"Page {page} out of range (document has {total_pages} pages)."
 
-        target_rm_file = rm_files[page - 1]
+        # Select the .rm for this page BY PAGE ID. _get_ordered_rm_files returns
+        # only pages that actually have strokes (compacted), so indexing it by
+        # page number pairs the wrong strokes with the page whenever an earlier
+        # page is un-annotated (e.g. page 4 would get page 6's ink). Map through
+        # the full .content page order instead. A page with no strokes yields
+        # target_rm_file=None and composites to the bare PDF page.
+        target_rm_file: Optional[Path] = None
+        if page_order and page <= len(page_order):
+            page_id = page_order[page - 1]
+            target_rm_file = next((p for p in rm_files if p.stem == page_id), None)
+        elif page <= len(rm_files):
+            target_rm_file = rm_files[page - 1]
 
         # Determine which PDF page this reMarkable page maps to. Handles both the
         # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
@@ -1588,6 +1622,8 @@ def render_merged_page_from_document_zip(
 
         if pdf_page_index is None:
             # No redirect — this page may be a user-added blank page
+            if target_rm_file is None:
+                return None, "Page has no PDF underlay and no annotations."
             png = render_rm_file_to_png(target_rm_file, background_color=background_color)
             return png, "Page has no PDF underlay (user-added page); annotation-only render."
 
@@ -1626,7 +1662,7 @@ def render_merged_page_from_document_zip(
             with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
                 ann_svg_path = Path(tmp_svg.name)
 
-            if _rm_to_svg(target_rm_file, ann_svg_path):
+            if target_rm_file is not None and _rm_to_svg(target_rm_file, ann_svg_path):
                 # Read the SVG and adjust viewBox to match PDF page bounds.
                 #
                 # rmscene emits stroke coordinates in the reMarkable device

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -539,7 +539,25 @@ async def remarkable_read(
                 annotation_parts = []
                 if content.get("typed_text"):
                     annotation_parts.extend(content["typed_text"])
-                if content.get("highlights"):
+                # Per-page index of highlights / handwritten notes: surfaces only
+                # the annotated pages (and their highlighted text) so the reader
+                # need not page through the whole document to find them.
+                annotated_pages = content.get("annotated_pages") or []
+                if annotated_pages:
+                    annotation_parts.append("\n--- Annotated pages ---")
+                    for ap in annotated_pages:
+                        marks = []
+                        if ap.get("has_handwriting"):
+                            marks.append("handwritten notes")
+                        n_hl = len(ap.get("highlights") or [])
+                        if n_hl:
+                            marks.append(f"{n_hl} highlight" + ("s" if n_hl != 1 else ""))
+                        annotation_parts.append(
+                            f"Page {ap['page']}: " + (", ".join(marks) or "annotated")
+                        )
+                        for h in ap.get("highlights") or []:
+                            annotation_parts.append(f"  • {h}")
+                elif content.get("highlights"):
                     annotation_parts.append("\n--- Highlights ---")
                     annotation_parts.extend(content["highlights"])
                 if content.get("handwritten_text"):

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -543,6 +543,7 @@ async def remarkable_read(
                 # the annotated pages (and their highlighted text) so the reader
                 # need not page through the whole document to find them.
                 annotated_pages = content.get("annotated_pages") or []
+                shown_highlights = set()
                 if annotated_pages:
                     annotation_parts.append("\n--- Annotated pages ---")
                     for ap in annotated_pages:
@@ -557,9 +558,17 @@ async def remarkable_read(
                         )
                         for h in ap.get("highlights") or []:
                             annotation_parts.append(f"  • {h}")
-                elif content.get("highlights"):
+                            shown_highlights.add(h)
+                # Highlights not covered by the per-page index above — e.g. from
+                # the legacy .highlights JSON (older firmware), which has no page
+                # attribution. Without this, a doc whose pages carry pen strokes
+                # would suppress its legacy highlight text entirely.
+                other_highlights = [
+                    h for h in content.get("highlights") or [] if h not in shown_highlights
+                ]
+                if other_highlights:
                     annotation_parts.append("\n--- Highlights ---")
-                    annotation_parts.extend(content["highlights"])
+                    annotation_parts.extend(other_highlights)
                 if content.get("handwritten_text"):
                     annotation_parts.append("\n--- Handwritten (OCR) ---")
                     annotation_parts.extend(content["handwritten_text"])

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -43,6 +43,7 @@ from remarkable_mcp.extract import (
     get_cached_ocr_result,
     get_cached_page_ocr,
     get_document_page_count,
+    render_mapped_pdf_page_from_document_zip,
     render_merged_page_from_document_zip,
     render_page_from_document_zip,
     render_page_from_document_zip_svg,
@@ -1814,12 +1815,17 @@ async def remarkable_image(
                 # returns None and this safely no-ops. Credit: ljdutel (#95).
                 rendered_via_pdf = False
                 if png_data is None:
-                    pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
-                    if pdf_bytes:
-                        png_data = await run_blocking(
-                            render_tablet_pdf_page_to_png, pdf_bytes, page
-                        )
-                        rendered_via_pdf = png_data is not None
+                    png_data, has_source_pdf = await run_blocking(
+                        render_mapped_pdf_page_from_document_zip, tmp_path, page
+                    )
+                    rendered_via_pdf = png_data is not None
+                    if png_data is None and not has_source_pdf:
+                        pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
+                        if pdf_bytes:
+                            png_data = await run_blocking(
+                                render_tablet_pdf_page_to_png, pdf_bytes, page
+                            )
+                            rendered_via_pdf = png_data is not None
 
                 # Blank-page fallback: the stroke renderer returns None for a
                 # notebook page with no drawable strokes (e.g. a freshly-created

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -58,6 +58,30 @@ def test_formatversion2_cpages_redir_still_works():
         assert _resolve_pdf_page_index(tmp, 2) == 1
 
 
+def test_cpages_is_authoritative_over_stale_redirection_page_map():
+    """A v2 user-added page (cPages entry without redir) must resolve to None.
+
+    A v1->v2 migrated document can retain a stale redirectionPageMap whose
+    order-shifted indices would otherwise composite a wrong PDF underlay.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(
+            tmp,
+            {
+                "cPages": {
+                    "pages": [
+                        {"id": "a", "redir": {"value": 0}},
+                        {"id": "b"},  # user-added page, no underlay
+                    ]
+                },
+                "redirectionPageMap": [0, 1],  # stale: would wrongly map page 2
+            },
+        )
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 2) is None
+
+
 def test_no_mapping_returns_none():
     """Without cPages or redirectionPageMap the page has no resolvable underlay."""
     with tempfile.TemporaryDirectory() as td:

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -1,0 +1,61 @@
+"""Unit tests for render_merged PDF page-index resolution.
+
+Regression coverage for formatVersion 1 documents (flat ``pages`` list plus a
+``redirectionPageMap``), which were previously misread as user-added pages so
+``render_merged`` fell back to an annotation-only render for cloud-imported
+PDFs. See ``_resolve_pdf_page_index`` in ``remarkable_mcp/extract.py``.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from remarkable_mcp.extract import _resolve_pdf_page_index
+
+
+def _write_content(tmp: Path, content: dict) -> None:
+    (tmp / "doc.content").write_text(json.dumps(content))
+
+
+def test_formatversion1_redirection_page_map():
+    """formatVersion 1 imports map via redirectionPageMap (index -> PDF page)."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "redirectionPageMap": [0, 1, 2, 3]})
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 3) == 2
+
+
+def test_formatversion1_user_added_page_is_none():
+    """A -1 entry marks a user-added page with no PDF underlay."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "redirectionPageMap": [0, -1, 1]})
+        assert _resolve_pdf_page_index(tmp, 2) is None
+
+
+def test_formatversion2_cpages_redir_still_works():
+    """The existing cPages.redir path (formatVersion 2) is unchanged."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(
+            tmp,
+            {
+                "cPages": {
+                    "pages": [
+                        {"id": "a", "redir": {"value": 0}},
+                        {"id": "b", "redir": {"value": 1}},
+                    ]
+                }
+            },
+        )
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 2) == 1
+
+
+def test_no_mapping_returns_none():
+    """Without cPages or redirectionPageMap the page has no resolvable underlay."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "pages": ["a", "b"]})
+        assert _resolve_pdf_page_index(tmp, 1) is None

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 from remarkable_mcp.extract import (
+    _extract_page_annotations,
     _get_ordered_rm_files,
     _resolve_pdf_page_index,
     _select_rm_file_for_page,
@@ -97,3 +98,12 @@ def test_select_rm_file_positional_without_page_order():
         rm_files = _get_ordered_rm_files(tmp)
         assert _select_rm_file_for_page(tmp, rm_files, 1) is not None
         assert _select_rm_file_for_page(tmp, rm_files, 5) is None
+
+
+def test_extract_page_annotations_handles_unparseable_file():
+    """A missing or non-.rm file yields no highlights and no strokes, not an error."""
+    with tempfile.TemporaryDirectory() as td:
+        bad = Path(td) / "not_real.rm"
+        bad.write_bytes(b"this is not a valid rm file")
+        assert _extract_page_annotations(bad) == ([], False)
+        assert _extract_page_annotations(Path(td) / "missing.rm") == ([], False)

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -10,7 +10,11 @@ import json
 import tempfile
 from pathlib import Path
 
-from remarkable_mcp.extract import _resolve_pdf_page_index
+from remarkable_mcp.extract import (
+    _get_ordered_rm_files,
+    _resolve_pdf_page_index,
+    _select_rm_file_for_page,
+)
 
 
 def _write_content(tmp: Path, content: dict) -> None:
@@ -59,3 +63,37 @@ def test_no_mapping_returns_none():
         tmp = Path(td)
         _write_content(tmp, {"formatVersion": 1, "pages": ["a", "b"]})
         assert _resolve_pdf_page_index(tmp, 1) is None
+
+
+def test_select_rm_file_by_page_id_on_sparse_document():
+    """The .rm is chosen by page id, not positional index in the compacted list.
+
+    An 8-page doc annotated on pages 2,3,4,6,7,8 must render page 4's own strokes
+    (p4.rm), not the 4th entry of the compacted rm list (p6.rm).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        ids = [f"p{i}" for i in range(1, 9)]
+        _write_content(tmp, {"cPages": {"pages": [{"id": i} for i in ids]}})
+        for pid in ("p2", "p3", "p4", "p6", "p7", "p8"):
+            (tmp / f"{pid}.rm").write_bytes(b"")
+        rm_files = _get_ordered_rm_files(tmp)
+
+        assert _select_rm_file_for_page(tmp, rm_files, 4).stem == "p4"
+        assert _select_rm_file_for_page(tmp, rm_files, 8).stem == "p8"
+        # Un-annotated pages have no stroke layer.
+        assert _select_rm_file_for_page(tmp, rm_files, 1) is None
+        assert _select_rm_file_for_page(tmp, rm_files, 5) is None
+        # Out of range.
+        assert _select_rm_file_for_page(tmp, rm_files, 9) is None
+
+
+def test_select_rm_file_positional_without_page_order():
+    """With no .content page order, fall back to positional selection."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        (tmp / "a.rm").write_bytes(b"")
+        (tmp / "b.rm").write_bytes(b"")
+        rm_files = _get_ordered_rm_files(tmp)
+        assert _select_rm_file_for_page(tmp, rm_files, 1) is not None
+        assert _select_rm_file_for_page(tmp, rm_files, 5) is None

--- a/test_page_mapping.py
+++ b/test_page_mapping.py
@@ -8,13 +8,24 @@ PDFs. See ``_resolve_pdf_page_index`` in ``remarkable_mcp/extract.py``.
 
 import json
 import tempfile
+import zipfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
 
 from remarkable_mcp.extract import (
+    _annotation_page_viewbox,
     _extract_page_annotations,
     _get_ordered_rm_files,
+    _points_per_unit,
     _resolve_pdf_page_index,
+    _rewrite_svg_root,
     _select_rm_file_for_page,
+    _v6_paths_from_blocks,
+    extract_text_from_document_zip,
+    render_mapped_pdf_page_from_document_zip,
 )
 
 
@@ -82,12 +93,34 @@ def test_cpages_is_authoritative_over_stale_redirection_page_map():
         assert _resolve_pdf_page_index(tmp, 2) is None
 
 
-def test_no_mapping_returns_none():
-    """Without cPages or redirectionPageMap the page has no resolvable underlay."""
+@pytest.mark.parametrize("page", [0, -1, -100])
+def test_pdf_page_resolution_rejects_non_positive_pages(page):
+    """Invalid pages never wrap around to the final redirect entry."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(
+            tmp,
+            {
+                "cPages": {
+                    "pages": [
+                        {"id": "a", "redir": {"value": 0}},
+                        {"id": "b", "redir": {"value": 7}},
+                    ]
+                },
+                "redirectionPageMap": [0, 7],
+            },
+        )
+        assert _resolve_pdf_page_index(tmp, page) is None
+
+
+def test_flat_pages_without_redirect_map_use_identity_mapping():
+    """Server-uploaded v1 PDFs omit redirects, so their flat page order is identity."""
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         _write_content(tmp, {"formatVersion": 1, "pages": ["a", "b"]})
-        assert _resolve_pdf_page_index(tmp, 1) is None
+        assert _resolve_pdf_page_index(tmp, 1) == 0
+        assert _resolve_pdf_page_index(tmp, 2) == 1
+        assert _resolve_pdf_page_index(tmp, 3) is None
 
 
 def test_select_rm_file_by_page_id_on_sparse_document():
@@ -124,6 +157,90 @@ def test_select_rm_file_positional_without_page_order():
         assert _select_rm_file_for_page(tmp, rm_files, 5) is None
 
 
+def test_select_rm_file_by_page_id_for_formatversion1_sparse_document():
+    """The legacy flat page list is authoritative even when .rm files are sparse."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        _write_content(tmp, {"formatVersion": 1, "pages": ["p1", "p2", "p3"]})
+        (tmp / "p1.rm").write_bytes(b"")
+        (tmp / "p3.rm").write_bytes(b"")
+        rm_files = _get_ordered_rm_files(tmp)
+
+        assert _select_rm_file_for_page(tmp, rm_files, 1).stem == "p1"
+        assert _select_rm_file_for_page(tmp, rm_files, 2) is None
+        assert _select_rm_file_for_page(tmp, rm_files, 3).stem == "p3"
+
+
+def test_device_scale_selection_and_annotation_viewbox():
+    """SceneInfo paper grids select their calibrated per-device coordinate scale."""
+    rm2_ppu = _points_per_unit((1404, 1872))
+    paper_pro_ppu = _points_per_unit((1620, 2160))
+
+    assert rm2_ppu == pytest.approx(0.3177)
+    assert paper_pro_ppu == pytest.approx(0.3144)
+    assert _points_per_unit((999, 999)) == pytest.approx(rm2_ppu)
+    assert _points_per_unit(None) == pytest.approx(rm2_ppu)
+
+    rm2_viewbox = _annotation_page_viewbox(612, 792, rm2_ppu)
+    paper_pro_viewbox = _annotation_page_viewbox(612, 792, paper_pro_ppu)
+    assert rm2_viewbox[0] == pytest.approx(-rm2_viewbox[2] / 2)
+    assert paper_pro_viewbox[2] > rm2_viewbox[2]
+    assert _annotation_page_viewbox(612, 792, rm2_ppu, centered_x=False)[0] == 0
+
+
+def test_svg_root_rewrite_preserves_stroke_width():
+    """Only root width/height change; path stroke-width remains untouched."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="1 2 3 4" '
+        'width="3" height="4"><path stroke-width="3.5" width="9"/></svg>'
+    )
+
+    rewritten = _rewrite_svg_root(
+        svg,
+        viewbox=(-100.0, 0.0, 200.0, 300.0),
+        width=1200,
+        height=1800,
+    )
+
+    assert 'viewBox="-100.00 0.00 200.00 300.00"' in rewritten
+    assert '<svg xmlns="http://www.w3.org/2000/svg"' in rewritten
+    assert 'width="1200" height="1800"' in rewritten
+    assert 'stroke-width="3.5"' in rewritten
+    assert '<path stroke-width="3.5" width="9"' in rewritten
+
+
+def test_glyph_range_rectangles_render_as_translucent_highlights():
+    """GlyphRange rectangle geometry is emitted alongside pen paths."""
+    rectangle = SimpleNamespace(x=10.0, y=20.0, w=30.0, h=8.0)
+    glyph_range = SimpleNamespace(rectangles=[rectangle], color=3)
+    block = SimpleNamespace(item=SimpleNamespace(value=glyph_range))
+
+    paths, coords = _v6_paths_from_blocks([block])
+
+    assert paths == [
+        '<rect x="10.0" y="20.0" width="30.0" height="8.0" '
+        'fill="#FFD700" opacity="0.35" stroke="none"/>'
+    ]
+    assert coords == [(10.0, 20.0), (40.0, 28.0)]
+
+
+def test_glyph_range_rectangles_apply_text_anchor_offsets():
+    """Highlights nested under anchored groups move with the corresponding text."""
+    parent_id = object()
+    rectangle = SimpleNamespace(x=10.0, y=20.0, w=30.0, h=8.0)
+    glyph_range = SimpleNamespace(rectangles=[rectangle], color=3)
+    block = SimpleNamespace(parent_id=parent_id, item=SimpleNamespace(value=glyph_range))
+
+    with patch(
+        "remarkable_mcp.extract._v6_group_offsets",
+        return_value={parent_id: (4.0, 6.0)},
+    ):
+        paths, coords = _v6_paths_from_blocks([block], anchor_pos={"anchor": 1})
+
+    assert 'x="14.0" y="26.0"' in paths[0]
+    assert coords == [(14.0, 26.0), (44.0, 34.0)]
+
+
 def test_extract_page_annotations_handles_unparseable_file():
     """A missing or non-.rm file yields no highlights and no strokes, not an error."""
     with tempfile.TemporaryDirectory() as td:
@@ -131,3 +248,103 @@ def test_extract_page_annotations_handles_unparseable_file():
         bad.write_bytes(b"this is not a valid rm file")
         assert _extract_page_annotations(bad) == ([], False)
         assert _extract_page_annotations(Path(td) / "missing.rm") == ([], False)
+
+
+def test_extract_page_annotations_orders_highlights_and_detects_ink():
+    """Stored highlight text is ordered by rectangle location and ink is indexed."""
+
+    class GlyphRange:
+        def __init__(self, text, x, y):
+            self.text = text
+            self.rectangles = [SimpleNamespace(x=x, y=y)]
+
+    class Line:
+        pass
+
+    tree = SimpleNamespace(
+        walk=lambda: [
+            GlyphRange("second", 5, 50),
+            Line(),
+            GlyphRange("first", 20, 10),
+        ]
+    )
+    with tempfile.TemporaryDirectory() as td:
+        rm_file = Path(td) / "page.rm"
+        rm_file.write_bytes(b"placeholder")
+        with patch("rmscene.read_tree", return_value=tree):
+            assert _extract_page_annotations(rm_file) == (["first", "second"], True)
+
+
+def test_extraction_uses_authoritative_page_count_and_ids_with_blank_pages():
+    """Annotated extraction reports all metadata pages, not only existing .rm files."""
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        zip_path = Path(tmp.name)
+    try:
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr(
+                "doc.content",
+                json.dumps({"cPages": {"pages": [{"id": "p1"}, {"id": "p2"}]}}),
+            )
+            zf.writestr("p1.rm", b"not-a-valid-rm")
+
+        result = extract_text_from_document_zip(zip_path)
+        assert result["pages"] == 2
+        assert result["page_ids"] == ["p1", "p2"]
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+
+def test_mapped_pdf_fallback_uses_redirected_source_page():
+    """Source-PDF fallback rasterizes the mapped PDF page, not the page ordinal."""
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        zip_path = Path(tmp.name)
+    try:
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr(
+                "doc.content",
+                json.dumps({"formatVersion": 1, "redirectionPageMap": [2, 0]}),
+            )
+            zf.writestr("doc.pdf", b"synthetic-pdf")
+
+        with patch(
+            "remarkable_mcp.extract.render_tablet_pdf_page_to_png",
+            return_value=b"png",
+        ) as render_pdf:
+            assert render_mapped_pdf_page_from_document_zip(zip_path, page=1) == (
+                b"png",
+                True,
+            )
+        render_pdf.assert_called_once_with(
+            b"synthetic-pdf",
+            page=3,
+            target_long_edge=2048,
+        )
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+
+def test_mapped_pdf_fallback_does_not_invent_underlay_for_user_added_page():
+    """A cPages entry without redir blocks stale/ordinal PDF fallback."""
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        zip_path = Path(tmp.name)
+    try:
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr(
+                "doc.content",
+                json.dumps(
+                    {
+                        "cPages": {"pages": [{"id": "added-page"}]},
+                        "redirectionPageMap": [0],
+                    }
+                ),
+            )
+            zf.writestr("doc.pdf", b"synthetic-pdf")
+
+        with patch("remarkable_mcp.extract.render_tablet_pdf_page_to_png") as render_pdf:
+            assert render_mapped_pdf_page_from_document_zip(zip_path, page=1) == (
+                None,
+                True,
+            )
+        render_pdf.assert_not_called()
+    finally:
+        zip_path.unlink(missing_ok=True)

--- a/test_server.py
+++ b/test_server.py
@@ -734,6 +734,55 @@ class TestRemarkableRead:
             or ("coroutine" not in data["_error"].get("message", ""))
         ), f"Got coroutine error: {data}"
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.extract_text_from_document_zip")
+    @patch("remarkable_mcp.tools.get_file_type")
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_read_legacy_highlights_shown_alongside_annotated_pages(
+        self, mock_get_rmapi, mock_get_file_type, mock_extract
+    ):
+        """Legacy-JSON highlights must still be listed when annotated_pages exists.
+
+        Regression test: highlights without page attribution (older-firmware
+        .highlights JSON) were suppressed whenever the per-page annotated_pages
+        index was non-empty (e.g. a page with pen strokes but no GlyphRange).
+        """
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+
+        doc = Mock()
+        doc.VissibleName = "Annotated PDF"
+        doc.ID = "pdf-123"
+        doc.Parent = ""
+        doc.ModifiedClient = "2024-01-15T10:30:00Z"
+        doc.is_folder = False
+        doc.tags = []
+        mock_client.get_meta_items.return_value = [doc]
+        mock_client.download.return_value = b"zip-bytes-unused-by-mocked-extraction"
+
+        mock_get_file_type.return_value = "pdf"
+        mock_extract.return_value = {
+            "typed_text": [],
+            "highlights": ["A legacy highlighted sentence."],
+            "handwritten_text": None,
+            "pages": 3,
+            "page_ids": [],
+            "annotated_pages": [
+                {"page": 2, "page_id": "p2", "has_handwriting": True, "highlights": []}
+            ],
+            "ocr_backend": None,
+            "tags": [],
+        }
+
+        result = await mcp.call_tool(
+            "remarkable_read", {"document": "Annotated PDF", "content_type": "annotations"}
+        )
+        data = json.loads(result[0][0].text)
+
+        assert "_error" not in data, f"Unexpected error: {data}"
+        assert "Page 2: handwritten notes" in data["content"]
+        assert "A legacy highlighted sentence." in data["content"]
+
 
 # =============================================================================
 # Test remarkable_image Tool

--- a/test_server.py
+++ b/test_server.py
@@ -783,6 +783,55 @@ class TestRemarkableRead:
         assert "Page 2: handwritten notes" in data["content"]
         assert "A legacy highlighted sentence." in data["content"]
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.extract_text_from_document_zip")
+    @patch("remarkable_mcp.tools.get_file_type")
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_read_annotations_lists_page_highlights(
+        self, mock_get_rmapi, mock_get_file_type, mock_extract
+    ):
+        """Annotation-only reads expose highlighted text under its real page."""
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+
+        doc = Mock()
+        doc.VissibleName = "Annotated PDF"
+        doc.ID = "pdf-123"
+        doc.Parent = ""
+        doc.ModifiedClient = "2024-01-15T10:30:00Z"
+        doc.is_folder = False
+        doc.tags = []
+        mock_client.get_meta_items.return_value = [doc]
+        mock_client.download.return_value = b"zip-bytes-unused-by-mocked-extraction"
+
+        mock_get_file_type.return_value = "pdf"
+        mock_extract.return_value = {
+            "typed_text": [],
+            "highlights": ["Selected passage"],
+            "handwritten_text": None,
+            "pages": 4,
+            "page_ids": ["p1", "p2", "p3", "p4"],
+            "annotated_pages": [
+                {
+                    "page": 3,
+                    "page_id": "p3",
+                    "has_handwriting": True,
+                    "highlights": ["Selected passage"],
+                }
+            ],
+            "ocr_backend": None,
+            "tags": [],
+        }
+
+        result = await mcp.call_tool(
+            "remarkable_read", {"document": "Annotated PDF", "content_type": "annotations"}
+        )
+        data = json.loads(result[0][0].text)
+
+        assert "_error" not in data
+        assert "Page 3: handwritten notes, 1 highlight" in data["content"]
+        assert "Selected passage" in data["content"]
+
 
 # =============================================================================
 # Test remarkable_image Tool


### PR DESCRIPTION
## Summary

Synthesizes the complementary fixes from #133 by @dbosk and #134 by @steiner385 into a maintainer-owned change based on current `main`. This PR supersedes both competing branches rather than merging either implementation wholesale.

This intentionally remains separate from issue #135 / PR #136.

## Problem reports

- `formatVersion: 1` imported PDFs store page redirects in `redirectionPageMap`, which the merged renderer ignored.
- Sparse documents compact their `.rm` files to annotated pages, so positional indexing could apply another page's ink or reject a valid blank page.
- Annotation SVG coordinates are device-grid units, not PDF points; the old viewBox mis-scaled and displaced ink.
- A broad `width="..."` replacement also matched `stroke-width`, expanding strokes until the page appeared black.
- Current-firmware text highlights are `GlyphRange` scene items, so they were neither rendered nor included in extracted annotations.
- Source-PDF fallbacks could use the reMarkable page ordinal instead of the mapped PDF page, while server-uploaded v1 PDFs without an explicit redirect map require identity mapping.

## Implementation choices

- Treat v2 `cPages` entries as authoritative, use v1 `redirectionPageMap` when present, and use identity mapping only for flat v1 page lists without explicit redirects.
- Select `.rm` layers by page ID in merged, PNG, SVG, notebook, full-page, and fallback paths. Strokeless mapped pages render the bare PDF; explicit user-added pages do not receive an invented underlay.
- Derive annotation calibration per page from `SceneInfo.paper_size`: calibrated `1404x1872` pages use `0.3177` PDF points per unit; `1620x2160` uses the Paper Pro panel-DPI estimate `0.3144`; unknown grids safely fall back to the calibrated value.
- Rewrite only the root SVG `viewBox`/`width`/`height`, preserving every path's `stroke-width`.
- Render `GlyphRange` rectangles with color, opacity, and anchored-group offsets while retaining the anchored-ink behavior already on current `main`.
- Return authoritative `pages`, `page_ids`, and `annotated_pages` extraction data; `remarkable_read(content_type="annotations")` lists page-local handwriting/highlight summaries while retaining legacy JSON highlights.
- Preserve annotation-only, bare-PDF, native-export, blank-page, and malformed-input fallbacks without dereferencing absent `.rm` files.

## Validation

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (27 files)
- `uv run pytest test_server.py -v` — 228 passed
- `uv run pytest test_page_mapping.py -v` — 20 passed
- `REMARKABLE_SSH_HOST=10.11.99.1 uv run pytest test_integration.py --run-integration -v` — 10 passed on the connected Paper Pro
- Remote CI passed lint, Python 3.10/3.11/3.12 tests, conformance, and CodeQL.
- Final read-only review against current `main` found no significant issues and confirmed the newer anchored-ink/typed-text behavior remains intact.

### Cloud library comparison

The configured cloud library contained 401 documents. The comparison inspected 10 PDFs and successfully rendered real annotated imports in both metadata formats:

- format v1, page 2, `SceneInfo.paper_size=(1404, 1872)`: merged output produced an annotation delta over the mapped source page with no fallback note.
- format v2, page 1, `SceneInfo.paper_size=(1404, 1872)`: merged output produced an annotation delta over the mapped source page with no fallback note.
- a sparse format v1 page with no `.rm` layer matched a direct raster of its mapped bare PDF underlay exactly.

### Paper Pro native-export comparison

A priority-5260 main-table rule bypassed an overlapping accepted Tailscale `10.8.0.0/13` route and kept `10.11.99.1` on the directly connected USB interface. Two bounded representative annotated PDFs then completed native/local comparisons:

- **format v1**, page 1, 151 KB source, `SceneInfo.paper_size=(1404,1872)`: native bbox `[290,1336,929,1604]`, MCP bbox `[289,1338,930,1607]`, centroid delta 2.19 px. Delta-mask mutual coverage was ~91% within 1 px, >99.4% within 2 px, and 100% in both directions within 3 px.
- **format v2**, page 1, 190 KB source, `SceneInfo.paper_size=(1404,1872)`: native/local bboxes differed by at most 2 px per edge; the best integer registration was `(0,-2)` px with 0.730 annotation-mask IoU and 0.344 direct RGB MAE.

The full live SSH integration suite also passed. This validates the `1404x1872` calibration and page mapping against the Paper Pro's native export. The device reports the normalized `1404x1872` scene grid, so the separate `1620x2160` panel-DPI estimate remains fallback coverage rather than a hardware-observed Paper Pro path.

## USB export robustness

During diagnosis, xochitl intermittently returned exact 10-second HTTP 408s despite healthy process/load. The focused follow-up #160 adds bounded retries only for safe GET 408 responses and has fully green CI plus live first-attempt-success validation. Subsequent bounded replay returned HTTP 200 for `/documents/`, rmdoc, PDF, and thumbnail requests. On this firmware, `HEAD /download/{guid}/...` returns the full response body, so HEAD must not be treated as a cheap export preflight.