### PR TITLE
fix: remove Cairo dependency from remarkable_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Your reMarkable tablet is a powerful tool for thinking, note-taking, and researc
 - **Typed text extraction** — Native support for Type Folio and typed annotations
 - **Handwriting OCR** — Convert handwritten notes to searchable text
 - **PDF & EPUB support** — Extract text plus an index of annotated pages, highlights, and notes
-- **Robust page rendering** — Renders pages locally and automatically falls back to a source PDF when the local stroke renderer can't (USB/SSH use the tablet's own PDF export; cloud uses the original source PDF), so images work across firmware versions and even without system graphics libraries installed
+- **Portable page rendering** — Renders notebook SVG and PDF pages with bundled Python dependencies only, then automatically falls back to a source PDF when local stroke parsing can't handle a page (USB/SSH use the tablet's own PDF export; cloud uses the original source PDF)
 - **Smart search** — Find content across your entire library
 - **Second brain integration** — Use with Obsidian, note-taking apps, or any AI workflow
 
@@ -25,6 +25,8 @@ Whether you're researching, writing, or developing ideas, remarkable-mcp lets yo
 ### Prerequisite: install `uv`
 
 The commands below use `uvx`, which is included with [`uv`](https://docs.astral.sh/uv/getting-started/installation/).
+Page images are rasterized with PyMuPDF; no system Cairo, browser, or graphics
+runtime needs to be installed on macOS, Linux, or Windows.
 
 #### macOS and Linux
 
@@ -421,12 +423,11 @@ remarkable_image("Logo Sketch", background="#00000000")
 remarkable_image("Diagram", compatibility=True)
 ```
 
-> **Note:** PNG rendering automatically falls back to a source PDF when the
-> local stroke renderer can't produce an image (empty pages, newer `.rm`
-> formats, or a machine without `libcairo`). USB and SSH modes use the tablet's
-> native PDF export; cloud mode uses the document's original source PDF. This
-> keeps `remarkable_image` working across firmware versions and platforms.
-> Cloud mode has no native export, so it relies on the local renderer.
+> **Note:** PNG rendering uses PyMuPDF for both notebook SVGs and PDF pages, so
+> `remarkable_image` does not require Cairo, Inkscape, Chromium, or another
+> system graphics runtime. If local stroke parsing cannot handle a page, USB
+> and SSH modes fall back to the tablet's native PDF export and cloud mode falls
+> back to an original source PDF when one exists.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -166,7 +166,7 @@ The workflow automatically:
 | `requests` | HTTP client for reMarkable Cloud API |
 | `paramiko` | SSH client for direct tablet access |
 | `rmscene` | Native .rm file parser for text extraction |
-| `pymupdf` | PDF text extraction |
+| `pymupdf` | PDF text extraction and Cairo-free SVG/PDF rasterization |
 | `ebooklib` | EPUB text extraction |
 | `pytesseract` | OCR fallback |
 | `google-cloud-vision` | OCR (recommended) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "pytesseract>=0.3.10",
     "Pillow>=10.0.0",
     "requests>=2.28.0",
-    "cairosvg>=2.9.0",
     "pymupdf>=1.26.7",
     "ebooklib>=0.18",
     "beautifulsoup4>=4.12.0",

--- a/remarkable_mcp/concurrency.py
+++ b/remarkable_mcp/concurrency.py
@@ -3,8 +3,8 @@
 FastMCP awaits ``async def`` tool handlers directly on the asyncio event loop
 without dispatching them to a thread pool, and it also calls plain ``def``
 handlers inline. Any blocking I/O performed inside a tool handler — SSH
-subprocess calls, ``requests`` HTTP requests, ``pymupdf``/``cairosvg``
-rendering, ``pytesseract`` OCR, ``zipfile`` extraction — therefore blocks the
+subprocess calls, ``requests`` HTTP requests, ``pymupdf`` rendering,
+``pytesseract`` OCR, ``zipfile`` extraction — therefore blocks the
 entire event loop. While that handler is running, no other ``call_tool``
 request can make progress, which serializes concurrent requests and can make
 the server appear to hang under parallel tool calls.

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -937,7 +937,7 @@ def render_rm_file_to_png(
     """
     Render a .rm file to PNG image bytes.
 
-    Uses the rmscene renderers to convert .rm to SVG, then cairosvg to convert to PNG.
+    Uses the rmscene renderers to convert .rm to SVG, then PyMuPDF to convert to PNG.
     The output is sized based on the SVG content bounds with a margin.
 
     Args:
@@ -949,19 +949,11 @@ def render_rm_file_to_png(
     Returns:
         PNG image bytes, or None if rendering failed
     """
-    import subprocess
-    import tempfile
-
     tmp_svg_path = None
-    tmp_png_path = None
-    tmp_raw_path = None
 
     try:
-        # Create temp files
         with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
             tmp_svg_path = Path(tmp_svg.name)
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
-            tmp_png_path = Path(tmp_png.name)
 
         # Convert .rm to SVG via the rmscene renderers
         if not _rm_to_svg(rm_file_path, tmp_svg_path):
@@ -979,73 +971,17 @@ def render_rm_file_to_png(
             output_width = REMARKABLE_WIDTH
             output_height = REMARKABLE_HEIGHT
 
-        # Convert SVG to PNG
-        try:
-            import cairosvg
-            from PIL import Image as PILImage
-
-            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_raw:
-                tmp_raw_path = Path(tmp_raw.name)
-
-            # Use cairosvg with background_color if specified
-            cairosvg.svg2png(
-                url=str(tmp_svg_path),
-                write_to=str(tmp_raw_path),
-                output_width=output_width,
-                output_height=output_height,
-                background_color=background_color,
-            )
-
-            # If no background color specified (transparent), return as-is
-            if background_color is None:
-                with open(tmp_raw_path, "rb") as f:
-                    return f.read()
-
-            # If background color specified, ensure it's applied properly
-            img = PILImage.open(tmp_raw_path)
-            if img.mode == "RGBA" and background_color:
-                # Parse hex color (supports #RRGGBB and #RRGGBBAA formats)
-                r, g, b, a = _parse_hex_color(background_color)
-                # Create background and composite foreground on top
-                if a == 255:
-                    # Fully opaque background - convert to RGB
-                    bg = PILImage.new("RGB", img.size, (r, g, b))
-                    bg.paste(img, mask=img.split()[3])
-                    img = bg
-                elif a > 0:
-                    # Semi-transparent or transparent background
-                    bg = PILImage.new("RGBA", img.size, (r, g, b, a))
-                    img = PILImage.alpha_composite(bg, img)
-                # If a == 0 (fully transparent), return as-is
-            img.save(tmp_png_path)
-
-            with open(tmp_png_path, "rb") as f:
-                return f.read()
-
-        except ImportError:
-            # Fall back to inkscape
-            result = subprocess.run(
-                ["inkscape", str(tmp_svg_path), "--export-filename", str(tmp_png_path)],
-                capture_output=True,
-                timeout=30,
-            )
-            if result.returncode != 0:
-                return None
-
-            with open(tmp_png_path, "rb") as f:
-                return f.read()
-
-    except subprocess.TimeoutExpired:
-        return None
+        return _svg_string_to_png(
+            tmp_svg_path.read_text(),
+            output_width,
+            output_height,
+            background_color,
+        )
     except Exception:
         return None
     finally:
         if tmp_svg_path:
             tmp_svg_path.unlink(missing_ok=True)
-        if tmp_png_path:
-            tmp_png_path.unlink(missing_ok=True)
-        if tmp_raw_path:
-            tmp_raw_path.unlink(missing_ok=True)
 
 
 def _svg_full_page(paths: list, paper_w: float, paper_h: float) -> str:
@@ -1070,20 +1006,70 @@ def _svg_full_page(paths: list, paper_w: float, paper_h: float) -> str:
 def _svg_string_to_png(
     svg: str, output_width: int, output_height: int, background_color: Optional[str]
 ) -> Optional[bytes]:
-    """Rasterize an in-memory SVG string to PNG bytes via cairosvg."""
+    """Rasterize an SVG string to exact-size PNG bytes without system Cairo."""
+    import io
+
     try:
-        import cairosvg
+        import fitz
     except ImportError:
-        return None
-    try:
-        return cairosvg.svg2png(
-            bytestring=svg.encode("utf-8"),
-            output_width=output_width,
-            output_height=output_height,
-            background_color=background_color,
+        logger.error(
+            "SVG rasterization requires PyMuPDF. Reinstall remarkable-mcp so its "
+            "runtime dependencies are available."
         )
-    except Exception:
         return None
+
+    if output_width < 1 or output_height < 1:
+        logger.error(
+            "SVG rasterization requires positive output dimensions, got %sx%s.",
+            output_width,
+            output_height,
+        )
+        return None
+
+    doc = None
+    try:
+        doc = fitz.open(stream=svg.encode("utf-8"), filetype="svg")
+        if len(doc) != 1:
+            raise ValueError(f"expected one SVG page, found {len(doc)}")
+
+        page = doc[0]
+        if page.rect.width <= 0 or page.rect.height <= 0:
+            raise ValueError(f"SVG has invalid dimensions: {page.rect}")
+
+        matrix = fitz.Matrix(
+            output_width / page.rect.width,
+            output_height / page.rect.height,
+        )
+        pixmap = page.get_pixmap(matrix=matrix, colorspace=fitz.csRGB, alpha=True)
+        png = pixmap.tobytes("png")
+
+        from PIL import Image as PILImage
+
+        image = PILImage.open(io.BytesIO(png)).convert("RGBA")
+        if image.size != (output_width, output_height):
+            image = image.resize((output_width, output_height), PILImage.Resampling.LANCZOS)
+
+        if background_color is not None:
+            red, green, blue, alpha = _parse_hex_color(background_color)
+            background = PILImage.new("RGBA", image.size, (red, green, blue, alpha))
+            image = PILImage.alpha_composite(background, image)
+            if alpha == 255:
+                image = image.convert("RGB")
+
+        output = io.BytesIO()
+        image.save(output, format="PNG")
+        return output.getvalue()
+    except Exception as exc:
+        logger.error(
+            "PyMuPDF could not rasterize SVG to PNG (%sx%s): %s",
+            output_width,
+            output_height,
+            exc,
+        )
+        return None
+    finally:
+        if doc is not None:
+            doc.close()
 
 
 def render_rm_file_full_page_png(
@@ -1607,8 +1593,8 @@ def render_tablet_pdf_page_to_png(
     produce an image. The reMarkable's own firmware renders every notebook (and
     annotated PDF/EPUB) to a PDF served at ``/download/<uuid>/pdf``, so this path
     works regardless of the .rm block format, handles empty pages, and—crucially
-    for portability—does not depend on a working ``cairo``/``libcairo`` for
-    ``cairosvg`` (PyMuPDF bundles its own renderer). Credit: ljdutel (#95).
+    for portability—does not depend on a system graphics library (PyMuPDF
+    bundles its own renderer). Credit: ljdutel (#95).
 
     Args:
         pdf_bytes: Raw bytes of the tablet-exported PDF.
@@ -1844,15 +1830,15 @@ def render_merged_page_from_document_zip(
                     height=out_h,
                 )
 
-                # Render SVG to PNG with transparent background
-                import cairosvg
-
-                ann_png_data = cairosvg.svg2png(
-                    bytestring=svg_content.encode("utf-8"),
-                    output_width=out_w,
-                    output_height=out_h,
+                # Render SVG to PNG with a transparent background.
+                ann_png_bytes = _svg_string_to_png(
+                    svg_content,
+                    out_w,
+                    out_h,
+                    None,
                 )
-                ann_png_bytes = ann_png_data
+                if ann_png_bytes is None:
+                    raise RuntimeError("PyMuPDF could not rasterize the annotation SVG")
         except Exception as exc:
             # Annotation rendering failed; we'll just return the PDF, but
             # record the failure so callers can surface it as a note.
@@ -2181,7 +2167,7 @@ def extract_handwriting_ocr(rm_files: List[Path]) -> tuple[Optional[List[str]], 
     Supports multiple backends (set REMARKABLE_OCR_BACKEND env var):
     - "sampling": Uses client's LLM via MCP sampling (requires async context, tools only)
     - "google": Google Cloud Vision - best for handwriting
-    - "tesseract": pytesseract - basic OCR, requires cairosvg (or inkscape)
+    - "tesseract": pytesseract - basic OCR, rasterized locally with PyMuPDF
     - "auto" (default): Google if API key provided, else Tesseract
 
     Note: "sampling" backend requires async context and is only available via tools,
@@ -2242,7 +2228,6 @@ def _ocr_google_vision_rest(rm_files: List[Path], api_key: str) -> Optional[List
     OCR using Google Cloud Vision REST API with API key.
     """
     import base64
-    import subprocess
     import tempfile
 
     import requests
@@ -2251,54 +2236,25 @@ def _ocr_google_vision_rest(rm_files: List[Path], api_key: str) -> Optional[List
 
     for rm_file in rm_files:
         tmp_svg_path = None
-        tmp_png_path = None
-        tmp_raw_path = None
         try:
-            # Create temp files
             with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
                 tmp_svg_path = Path(tmp_svg.name)
-            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
-                tmp_png_path = Path(tmp_png.name)
 
             # Convert .rm to SVG via the rmscene renderers
             if not _rm_to_svg(rm_file, tmp_svg_path):
                 continue
-            # Convert SVG to PNG
-            try:
-                import cairosvg
-                from PIL import Image as PILImage
 
-                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_raw:
-                    tmp_raw_path = Path(tmp_raw.name)
-
-                cairosvg.svg2png(
-                    url=str(tmp_svg_path),
-                    write_to=str(tmp_raw_path),
-                    output_width=REMARKABLE_WIDTH,
-                    output_height=REMARKABLE_HEIGHT,
-                )
-
-                # Add white background
-                img = PILImage.open(tmp_raw_path)
-                if img.mode == "RGBA":
-                    bg = PILImage.new("RGB", img.size, (255, 255, 255))
-                    bg.paste(img, mask=img.split()[3])
-                    img = bg
-                img.save(tmp_png_path)
-                tmp_raw_path.unlink(missing_ok=True)
-                tmp_raw_path = None
-            except ImportError:
-                result = subprocess.run(
-                    ["inkscape", str(tmp_svg_path), "--export-filename", str(tmp_png_path)],
-                    capture_output=True,
-                    timeout=30,
-                )
-                if result.returncode != 0:
-                    continue
+            png = _svg_string_to_png(
+                tmp_svg_path.read_text(),
+                REMARKABLE_WIDTH,
+                REMARKABLE_HEIGHT,
+                "#FFFFFF",
+            )
+            if png is None:
+                continue
 
             # Read and encode image
-            with open(tmp_png_path, "rb") as f:
-                image_content = base64.b64encode(f.read()).decode("utf-8")
+            image_content = base64.b64encode(png).decode("utf-8")
 
             # Call Google Vision REST API
             url = f"https://vision.googleapis.com/v1/images:annotate?key={api_key}"
@@ -2324,19 +2280,12 @@ def _ocr_google_vision_rest(rm_files: List[Path], api_key: str) -> Optional[List
                 # API key invalid or API not enabled - fall back to Tesseract
                 return _ocr_tesseract(rm_files)
 
-        except subprocess.TimeoutExpired:
-            # Page rendering timed out - skip this page and continue
-            pass
         except Exception:
             # API call or rendering failed - skip this page and continue
             pass
         finally:
             if tmp_svg_path:
                 tmp_svg_path.unlink(missing_ok=True)
-            if tmp_png_path:
-                tmp_png_path.unlink(missing_ok=True)
-            if tmp_raw_path:
-                tmp_raw_path.unlink(missing_ok=True)
 
     return ocr_results if ocr_results else None
 
@@ -2346,7 +2295,6 @@ def _ocr_google_vision_sdk(rm_files: List[Path]) -> Optional[List[str]]:
     OCR using Google Cloud Vision SDK with service account credentials.
     """
     try:
-        import subprocess
         import tempfile
 
         from google.cloud import vision
@@ -2356,57 +2304,25 @@ def _ocr_google_vision_sdk(rm_files: List[Path]) -> Optional[List[str]]:
 
         for rm_file in rm_files:
             tmp_svg_path = None
-            tmp_png_path = None
-            tmp_raw_path = None
             try:
-                # Create temp files
                 with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
                     tmp_svg_path = Path(tmp_svg.name)
-                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
-                    tmp_png_path = Path(tmp_png.name)
 
                 # Convert .rm to SVG via the rmscene renderers
                 if not _rm_to_svg(rm_file, tmp_svg_path):
                     continue
-                try:
-                    import cairosvg
-                    from PIL import Image as PILImage
 
-                    # Convert to PNG (comes out with transparent background)
-                    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_raw:
-                        tmp_raw_path = Path(tmp_raw.name)
-
-                    cairosvg.svg2png(
-                        url=str(tmp_svg_path),
-                        write_to=str(tmp_raw_path),
-                        output_width=REMARKABLE_WIDTH,
-                        output_height=REMARKABLE_HEIGHT,
-                    )
-
-                    # Add white background (SVG renders as black-on-transparent)
-                    img = PILImage.open(tmp_raw_path)
-                    if img.mode == "RGBA":
-                        bg = PILImage.new("RGB", img.size, (255, 255, 255))
-                        bg.paste(img, mask=img.split()[3])
-                        img = bg
-                    img.save(tmp_png_path)
-                    tmp_raw_path.unlink(missing_ok=True)
-                    tmp_raw_path = None
-                except ImportError:
-                    # Fall back to inkscape
-                    result = subprocess.run(
-                        ["inkscape", str(tmp_svg_path), "--export-filename", str(tmp_png_path)],
-                        capture_output=True,
-                        timeout=30,
-                    )
-                    if result.returncode != 0:
-                        continue
+                png = _svg_string_to_png(
+                    tmp_svg_path.read_text(),
+                    REMARKABLE_WIDTH,
+                    REMARKABLE_HEIGHT,
+                    "#FFFFFF",
+                )
+                if png is None:
+                    continue
 
                 # Send to Google Vision API
-                with open(tmp_png_path, "rb") as f:
-                    content = f.read()
-
-                image = vision.Image(content=content)
+                image = vision.Image(content=png)
 
                 # Use DOCUMENT_TEXT_DETECTION for best handwriting results
                 response = client.document_text_detection(image=image)
@@ -2417,19 +2333,12 @@ def _ocr_google_vision_sdk(rm_files: List[Path]) -> Optional[List[str]]:
                 if response.full_text_annotation.text:
                     ocr_results.append(response.full_text_annotation.text.strip())
 
-            except subprocess.TimeoutExpired:
-                # Page rendering timed out - skip this page and continue
-                pass
             except Exception:
                 # Rendering or API error - skip this page and continue
                 pass
             finally:
                 if tmp_svg_path:
                     tmp_svg_path.unlink(missing_ok=True)
-                if tmp_png_path:
-                    tmp_png_path.unlink(missing_ok=True)
-                if tmp_raw_path:
-                    tmp_raw_path.unlink(missing_ok=True)
 
         return ocr_results if ocr_results else None
 
@@ -2446,10 +2355,10 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
     OCR using Tesseract.
     Basic quality - designed for printed text, not handwriting.
 
-    Requires: pytesseract, cairosvg (or inkscape)
+    Requires: pytesseract and PyMuPDF.
     """
     try:
-        import subprocess
+        import io
         import tempfile
 
         import pytesseract
@@ -2459,55 +2368,26 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
 
         for rm_file in rm_files:
             tmp_svg_path = None
-            tmp_png_path = None
-            tmp_raw_path = None
             try:
-                # Create temp files
                 with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
                     tmp_svg_path = Path(tmp_svg.name)
-                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
-                    tmp_png_path = Path(tmp_png.name)
 
                 # Convert .rm to SVG via the rmscene renderers
                 if not _rm_to_svg(rm_file, tmp_svg_path):
                     continue
 
                 # Convert SVG to PNG with higher resolution for better OCR
-                try:
-                    import cairosvg
-
-                    # Convert to PNG (comes out with transparent background)
-                    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_raw:
-                        tmp_raw_path = Path(tmp_raw.name)
-
-                    # Use 1.5x resolution for better OCR (2x is too slow)
-                    cairosvg.svg2png(
-                        url=str(tmp_svg_path),
-                        write_to=str(tmp_raw_path),
-                        output_width=2106,  # 1.5x reMarkable width
-                        output_height=2808,  # 1.5x reMarkable height
-                    )
-
-                    # Add white background (SVG renders as black-on-transparent)
-                    img = Image.open(tmp_raw_path)
-                    if img.mode == "RGBA":
-                        bg = Image.new("RGB", img.size, (255, 255, 255))
-                        bg.paste(img, mask=img.split()[3])
-                        img = bg
-                    img.save(tmp_png_path)
-                    tmp_raw_path.unlink(missing_ok=True)
-                    tmp_raw_path = None
-                except ImportError:
-                    result = subprocess.run(
-                        ["inkscape", str(tmp_svg_path), "--export-filename", str(tmp_png_path)],
-                        capture_output=True,
-                        timeout=30,
-                    )
-                    if result.returncode != 0:
-                        continue
+                png = _svg_string_to_png(
+                    tmp_svg_path.read_text(),
+                    2106,
+                    2808,
+                    "#FFFFFF",
+                )
+                if png is None:
+                    continue
 
                 # Preprocess image for better OCR
-                img = Image.open(tmp_png_path)
+                img = Image.open(io.BytesIO(png))
 
                 # Convert to grayscale
                 img = img.convert("L")
@@ -2527,19 +2407,12 @@ def _ocr_tesseract(rm_files: List[Path]) -> Optional[List[str]]:
                 if text.strip():
                     ocr_results.append(text.strip())
 
-            except subprocess.TimeoutExpired:
-                # Page rendering timed out - skip this page and continue
-                pass
             except Exception:
                 # Rendering or OCR error - skip this page and continue
                 pass
             finally:
                 if tmp_svg_path:
                     tmp_svg_path.unlink(missing_ok=True)
-                if tmp_png_path:
-                    tmp_png_path.unlink(missing_ok=True)
-                if tmp_raw_path:
-                    tmp_raw_path.unlink(missing_ok=True)
 
         return ocr_results if ocr_results else None
 

--- a/remarkable_mcp/resources.py
+++ b/remarkable_mcp/resources.py
@@ -198,7 +198,7 @@ def _make_image_resource(client, document):
             if png_data is None:
                 raise RuntimeError(
                     f"Failed to render page {page_num}. "
-                    "Make sure 'rmc' and 'cairosvg' are installed."
+                    "Reinstall remarkable-mcp to restore rmscene and PyMuPDF."
                 )
             return png_data
         finally:

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1805,14 +1805,14 @@ async def remarkable_image(
                     )
 
                 # Portable fallback: the local stroke renderer can fail to
-                # produce an image for empty pages, newer .rm block formats, or
-                # when the client machine lacks a working cairo/libcairo for
-                # cairosvg. In that case we rasterize the requested page from the
-                # document's source PDF with PyMuPDF (which needs no system
-                # cairo). USB/SSH expose the tablet's natively-rendered (merged)
+                # produce an image for empty pages or newer .rm block formats.
+                # In that case we rasterize the requested page from the document's
+                # source PDF. USB/SSH expose the tablet's natively-rendered (merged)
                 # PDF; cloud exposes the original source PDF — either covers the
-                # failure cases above. Notebooks have no PDF, so download_raw_file
-                # returns None and this safely no-ops. Credit: ljdutel (#95).
+                # failure cases above. Both SVG and PDF rasterization use PyMuPDF,
+                # which needs no system Cairo. Notebooks have no PDF, so
+                # download_raw_file returns None and this safely no-ops.
+                # Credit: ljdutel (#95).
                 rendered_via_pdf = False
                 if png_data is None:
                     png_data, has_source_pdf = await run_blocking(
@@ -1848,10 +1848,10 @@ async def remarkable_image(
                         error_type="render_failed",
                         message="Failed to render page to image.",
                         suggestion=(
-                            "The page may be empty, or local rendering "
-                            "dependencies (cairo/libcairo for cairosvg) may be "
-                            "missing. For PDF-backed documents the source PDF is "
-                            "used automatically as a fallback. You can also try "
+                            "Local stroke parsing and PyMuPDF SVG rasterization both "
+                            "failed. Reinstall remarkable-mcp to restore its Python "
+                            "dependencies. For PDF-backed documents the source PDF is "
+                            "used automatically as a fallback; otherwise try "
                             "remarkable_read() to extract text instead."
                         ),
                     )

--- a/test_server.py
+++ b/test_server.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import zipfile
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -896,6 +897,36 @@ class TestRemarkableImage:
         assert compat_schema.get("type") == "boolean"
         assert compat_schema.get("default") is False
 
+    @pytest.mark.asyncio
+    @patch("remarkable_mcp.tools.get_rmapi")
+    async def test_image_response_formats_work_without_cairo(self, mock_get_rmapi, mock_document):
+        """Cairo-free rendering preserves embedded and compatibility responses."""
+        from mcp.types import EmbeddedResource
+
+        from remarkable_mcp import notebooks
+
+        document_zip = _make_notebook_zip(notebooks.page_rm_bytes("Portable rendering"))
+        mock_client = Mock()
+        mock_get_rmapi.return_value = mock_client
+        mock_document.is_folder = False
+        mock_client.get_meta_items.return_value = [mock_document]
+        mock_client.download.return_value = document_zip
+
+        with _cairo_unavailable():
+            embedded = await mcp.call_tool(
+                "remarkable_image",
+                {"document": "Test Document"},
+            )
+            compatible = await mcp.call_tool(
+                "remarkable_image",
+                {"document": "Test Document", "compatibility": True},
+            )
+
+        assert any(isinstance(content, EmbeddedResource) for content in embedded)
+        compatible_data = json.loads(compatible[0].text)
+        assert compatible_data["mime_type"] == "image/png"
+        assert compatible_data["image_base64"]
+
 
 # =============================================================================
 # Test Merged Rendering
@@ -1061,6 +1092,140 @@ def _make_synthetic_pdf(pages: int = 2) -> bytes:
     return data
 
 
+def _make_notebook_zip(rm_bytes: bytes, pdf_bytes: bytes | None = None) -> bytes:
+    """Build a one-page native notebook archive, optionally with a PDF underlay."""
+    import io
+
+    output = io.BytesIO()
+    page_entry = {"id": "page-1"}
+    if pdf_bytes is not None:
+        page_entry["redir"] = {"value": 0}
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr("doc.content", json.dumps({"cPages": {"pages": [page_entry]}}))
+        archive.writestr("page-1.rm", rm_bytes)
+        if pdf_bytes is not None:
+            archive.writestr("doc.pdf", pdf_bytes)
+    return output.getvalue()
+
+
+@contextmanager
+def _cairo_unavailable():
+    """Fail any accidental Cairo import while allowing all other imports."""
+    import builtins
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name.split(".", 1)[0].lower() in {"cairo", "cairocffi", "cairosvg"}:
+            raise ImportError(f"{name} intentionally unavailable")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=guarded_import):
+        yield
+
+
+class TestCairoFreeRasterization:
+    """SVG-to-PNG paths must work with no Cairo installation."""
+
+    def test_svg_stream_preserves_dimensions_background_and_alpha(self):
+        import io
+
+        from PIL import Image
+
+        from remarkable_mcp.extract import _svg_string_to_png
+
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" '
+            'viewBox="0 0 120 80"><rect x="30" y="20" width="60" height="40" '
+            'fill="#D02030"/></svg>'
+        )
+        with _cairo_unavailable():
+            opaque = _svg_string_to_png(svg, 360, 240, "#FBFBFB")
+            transparent = _svg_string_to_png(svg, 180, 120, None)
+
+        assert opaque is not None and opaque.startswith(b"\x89PNG\r\n\x1a\n")
+        opaque_image = Image.open(io.BytesIO(opaque))
+        assert opaque_image.size == (360, 240)
+        assert opaque_image.mode == "RGB"
+        assert opaque_image.getpixel((0, 0)) == (251, 251, 251)
+        red, green, blue = opaque_image.getpixel((180, 120))
+        assert red > 150 and green < 100 and blue < 100
+
+        assert transparent is not None and transparent.startswith(b"\x89PNG\r\n\x1a\n")
+        transparent_image = Image.open(io.BytesIO(transparent))
+        assert transparent_image.size == (180, 120)
+        assert transparent_image.mode == "RGBA"
+        assert transparent_image.getpixel((0, 0))[3] == 0
+
+    def test_native_notebook_page_rasterizes_without_cairo(self, tmp_path):
+        import io
+
+        from PIL import Image
+
+        from remarkable_mcp import notebooks
+        from remarkable_mcp.extract import (
+            CONTENT_MARGIN,
+            render_page_from_document_zip,
+            render_page_from_document_zip_svg,
+        )
+
+        archive_path = tmp_path / "notebook.zip"
+        archive_path.write_bytes(_make_notebook_zip(notebooks.page_rm_bytes("Notebook page")))
+
+        with _cairo_unavailable():
+            svg = render_page_from_document_zip_svg(archive_path, page=1)
+            png = render_page_from_document_zip(
+                archive_path,
+                page=1,
+                background_color="#FFFFFF",
+            )
+
+        assert svg is not None
+        assert png is not None and png.startswith(b"\x89PNG\r\n\x1a\n")
+        image = Image.open(io.BytesIO(png))
+        viewbox = svg.split('viewBox="', 1)[1].split('"', 1)[0].split()
+        expected_size = (
+            int(float(viewbox[2])) + 2 * CONTENT_MARGIN,
+            int(float(viewbox[3])) + 2 * CONTENT_MARGIN,
+        )
+        assert image.size == expected_size
+        assert image.mode == "RGB"
+        assert sum(image.convert("L").histogram()[:128]) > 0
+
+    def test_annotated_pdf_overlay_rasterizes_without_cairo(self, tmp_path):
+        import io
+
+        from PIL import Image, ImageChops
+
+        from remarkable_mcp import notebooks
+        from remarkable_mcp.extract import (
+            _render_pdf_page_to_png,
+            render_merged_page_from_document_zip,
+        )
+
+        pdf = _make_synthetic_pdf(1)
+        archive_path = tmp_path / "annotated.zip"
+        archive_path.write_bytes(
+            _make_notebook_zip(
+                notebooks.page_rm_bytes("Overlay"),
+                pdf_bytes=pdf,
+            )
+        )
+
+        with _cairo_unavailable():
+            png, note = render_merged_page_from_document_zip(archive_path, page=1)
+            bare_pdf_png = _render_pdf_page_to_png(pdf, 0, 890, 1188)
+
+        assert note is None
+        assert png is not None and png.startswith(b"\x89PNG\r\n\x1a\n")
+        image = Image.open(io.BytesIO(png))
+        assert image.size == (890, 1188)
+        assert image.mode == "RGB"
+        assert bare_pdf_png is not None
+        bare_pdf_image = Image.open(io.BytesIO(bare_pdf_png)).convert("RGB")
+        assert ImageChops.difference(image, bare_pdf_image).getbbox() is not None
+
+
 class TestRenderTabletPdfFallback:
     """Tests for the portable tablet-PDF render fallback (issue #95/#102/#94)."""
 
@@ -1107,7 +1272,7 @@ class TestRenderTabletPdfFallback:
         mock_client.get_meta_items.return_value = [mock_document]
         mock_client.download.return_value = b"fake zip"
         mock_page_count.return_value = 2
-        # Local stroke renderer fails (e.g. empty page or missing libcairo)
+        # Local stroke renderer fails (for example, an empty page).
         mock_render.return_value = None
         # Tablet exposes a natively-rendered PDF
         mock_download_raw.return_value = _make_synthetic_pdf(2)
@@ -1174,7 +1339,7 @@ class TestRenderTabletPdfFallback:
         # The misleading "v5 / rmc" message is gone; guidance is actionable
         suggestion = data["_error"]["suggestion"].lower()
         assert "v5" not in suggestion
-        assert "cairo" in suggestion or "native pdf" in suggestion
+        assert "pymupdf" in suggestion
 
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.render_page_full_page_from_document_zip")
@@ -3968,14 +4133,14 @@ class TestFullPageRender:
             rm_tmp.write(data)
             rm_path = Path(rm_tmp.name)
         try:
-            result = render_rm_file_full_page_png(rm_path, background_color="#FFFFFF")
+            with _cairo_unavailable():
+                result = render_rm_file_full_page_png(rm_path, background_color="#FFFFFF")
             assert result is not None
             png, (w, h) = result
             # The fixture has no SceneInfo -> fall back to the standard page extent.
             assert (round(w), round(h)) == (1404, 1872)
             im = Image.open(_io.BytesIO(png))
-            # PNG aspect must match the page aspect so [0,1] maps linearly.
-            assert abs(im.size[0] / im.size[1] - w / h) < 0.01
+            assert im.size == (1404, 1872)
         finally:
             rm_path.unlink(missing_ok=True)
 
@@ -4003,18 +4168,21 @@ class TestFullPageRender:
                 zf.writestr("p1.rm", rm_bytes)  # p2.rm intentionally absent
 
             # Page 1 has a drawable layer -> rendered from its .rm.
-            r1 = render_page_full_page_from_document_zip(zpath, 1, background_color="#FFFFFF")
+            with _cairo_unavailable():
+                r1 = render_page_full_page_from_document_zip(zpath, 1, background_color="#FFFFFF")
             assert r1 is not None
             png1, size1 = r1
-            assert Image.open(_io.BytesIO(png1)).size[0] > 0
+            assert Image.open(_io.BytesIO(png1)).size == (1404, 1872)
 
             # Page 2 exists in cPages but has no .rm -> a BLANK full page is
             # rendered (not None). If pages were addressed by filesystem .rm
             # order this would be out of range (only one .rm file exists).
-            r2 = render_page_full_page_from_document_zip(zpath, 2, background_color="#FFFFFF")
+            with _cairo_unavailable():
+                r2 = render_page_full_page_from_document_zip(zpath, 2, background_color="#FFFFFF")
             assert r2 is not None
-            _png2, size2 = r2
+            png2, size2 = r2
             assert size2 == size1  # blank page sized to the document's paper size
+            assert Image.open(_io.BytesIO(png2)).size == (1404, 1872)
 
             # Page 3 is not in cPages -> out of range.
             assert render_page_full_page_from_document_zip(zpath, 3) is None
@@ -4064,7 +4232,8 @@ class TestFullPageRender:
             rm_tmp.write(nb.page_rm_bytes("Hello world"))
             rm_path = Path(rm_tmp.name)
         try:
-            result = render_rm_file_full_page_png(rm_path, background_color="#FFFFFF")
+            with _cairo_unavailable():
+                result = render_rm_file_full_page_png(rm_path, background_color="#FFFFFF")
             assert result is not None
             png, _ = result
             im = Image.open(_io.BytesIO(png)).convert("L")

--- a/uv.lock
+++ b/uv.lock
@@ -117,34 +117,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cairocffi"
-version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
-]
-
-[[package]]
-name = "cairosvg"
-version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cairocffi" },
-    { name = "cssselect2" },
-    { name = "defusedxml" },
-    { name = "pillow" },
-    { name = "tinycss2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/07/e8412a13019b3f737972dea23a2c61ca42becafc16c9338f4ca7a0caa993/cairosvg-2.9.0.tar.gz", hash = "sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5", size = 40877, upload-time = "2026-03-13T15:42:00.564Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl", hash = "sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68", size = 45962, upload-time = "2026-03-14T13:56:33.512Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -403,28 +375,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cssselect2"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tinycss2" },
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/86/fd7f58fc498b3166f3a7e8e0cddb6e620fe1da35b02248b1bd59e95dbaaa/cssselect2-0.8.0.tar.gz", hash = "sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a", size = 35716, upload-time = "2025-03-05T14:46:07.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/e7/aa315e6a749d9b96c2504a1ba0ba031ba2d0517e972ce22682e3fccecb09/cssselect2-0.8.0-py3-none-any.whl", hash = "sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e", size = 15454, upload-time = "2025-03-05T14:46:06.463Z" },
-]
-
-[[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
 name = "ebooklib"
 version = "0.20"
 source = { registry = "https://pypi.org/simple" }
@@ -442,7 +392,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1351,7 +1301,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "cairosvg" },
     { name = "ebooklib" },
     { name = "mcp" },
     { name = "pillow" },
@@ -1382,7 +1331,6 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "cairosvg", specifier = ">=2.9.0" },
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "google-cloud-vision", marker = "extra == 'ocr'", specifier = ">=3.0.0" },
     { name = "mcp", specifier = ">=1.27.0,<2.0.0" },
@@ -1643,18 +1591,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tinycss2"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1745,13 +1681,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
-]
-
-[[package]]
-name = "webencodings"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]


### PR DESCRIPTION
## Summary
- rasterize every SVG-to-PNG path with the existing PyMuPDF dependency
- preserve exact dimensions, transparent/opaque backgrounds, merged PDF annotations, and embedded/compatibility responses
- remove CairoSVG and its native Cairo dependency from runtime metadata and document the portable installation

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest test_server.py test_page_mapping.py -v` (254 passed)
- stripped-environment notebook smoke test with Cairo imports blocked

Closes #137