### PR TITLE
fix(usb): retry transient xochitl GET timeouts

### DIFF
--- a/remarkable_mcp/usb_web.py
+++ b/remarkable_mcp/usb_web.py
@@ -22,6 +22,7 @@ Benefits:
 """
 
 import logging
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -32,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 # Default USB web interface settings
 DEFAULT_USB_HOST = "http://10.11.99.1"
+GET_408_MAX_ATTEMPTS = 3
+GET_408_BACKOFF_SECONDS = 0.25
 
 # API endpoints
 DOCUMENTS_URL = "/documents/"
@@ -120,10 +123,35 @@ class USBWebClient:
     ) -> requests.Response:
         """Make an HTTP request to the USB web interface."""
         url = f"{self.host}{endpoint}"
+        request_timeout = self.timeout if timeout is None else timeout
+        normalized_method = method.upper()
+
         try:
-            response = requests.request(method, url, timeout=timeout or self.timeout)
-            response.raise_for_status()
-            return response
+            for attempt in range(GET_408_MAX_ATTEMPTS):
+                response = requests.request(normalized_method, url, timeout=request_timeout)
+                if response.status_code != 408 or normalized_method != "GET":
+                    response.raise_for_status()
+                    return response
+
+                if attempt == GET_408_MAX_ATTEMPTS - 1:
+                    response.close()
+                    raise RuntimeError(
+                        f"USB web interface returned HTTP 408 after "
+                        f"{GET_408_MAX_ATTEMPTS} GET attempts for {endpoint}. "
+                        "The tablet's xochitl HTTP handler did not complete the request in time. "
+                        "The tablet may be temporarily busy; wait a moment and try again."
+                    )
+
+                response.close()
+                delay = GET_408_BACKOFF_SECONDS * (2**attempt)
+                logger.warning(
+                    "USB web interface returned HTTP 408 for %s (attempt %d/%d); retrying in %.2fs",
+                    endpoint,
+                    attempt + 1,
+                    GET_408_MAX_ATTEMPTS,
+                    delay,
+                )
+                time.sleep(delay)
         except requests.Timeout:
             raise RuntimeError(
                 "USB web interface request timed out. "

--- a/test_server.py
+++ b/test_server.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 import requests
@@ -2256,6 +2256,80 @@ class TestUSBWebInterface:
 
         content = client.download(doc)
         assert content == b"fake zip content"
+
+    @patch("remarkable_mcp.usb_web.time.sleep")
+    @patch("requests.request")
+    def test_usb_web_get_retries_408_until_success(self, mock_request, mock_sleep):
+        """A transient xochitl 408 is retried for a safe GET request."""
+        from remarkable_mcp.usb_web import USBWebClient
+
+        timed_out = Mock(status_code=408)
+        succeeded = Mock(status_code=200)
+        mock_request.side_effect = [timed_out, succeeded]
+
+        result = USBWebClient(timeout=37)._request("/documents/")
+
+        assert result is succeeded
+        assert mock_request.call_count == 2
+        assert all(call.kwargs["timeout"] == 37 for call in mock_request.call_args_list)
+        timed_out.close.assert_called_once_with()
+        mock_sleep.assert_called_once_with(0.25)
+
+    @patch("remarkable_mcp.usb_web.time.sleep")
+    @patch("requests.request")
+    def test_usb_web_get_408_exhaustion_is_educational(self, mock_request, mock_sleep):
+        """Exhausted GET retries explain that xochitl may be temporarily busy."""
+        from remarkable_mcp.usb_web import USBWebClient
+
+        responses = [Mock(status_code=408) for _ in range(3)]
+        mock_request.side_effect = responses
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"HTTP 408 after 3 GET attempts.*temporarily busy.*try again",
+        ):
+            USBWebClient()._request("/download/doc1/pdf", timeout=120)
+
+        assert mock_request.call_count == 3
+        assert all(call.kwargs["timeout"] == 120 for call in mock_request.call_args_list)
+        assert mock_sleep.call_args_list == [call(0.25), call(0.5)]
+        responses[0].close.assert_called_once_with()
+        responses[1].close.assert_called_once_with()
+        responses[2].close.assert_called_once_with()
+
+    @patch("remarkable_mcp.usb_web.time.sleep")
+    @patch("requests.request")
+    def test_usb_web_does_not_retry_408_for_non_get(self, mock_request, mock_sleep):
+        """Potentially mutating requests retain their single-attempt behavior."""
+        from remarkable_mcp.usb_web import USBWebClient
+
+        response = Mock(status_code=408)
+        response.raise_for_status.side_effect = requests.HTTPError(
+            "408 Client Error: Request Timeout"
+        )
+        mock_request.return_value = response
+
+        with pytest.raises(RuntimeError, match="USB web interface request failed: 408"):
+            USBWebClient()._request("/upload", method="POST")
+
+        mock_request.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("remarkable_mcp.usb_web.time.sleep")
+    @patch("requests.request")
+    def test_usb_web_does_not_retry_non_transient_http_error(self, mock_request, mock_sleep):
+        """Non-transient HTTP errors keep the existing error behavior."""
+        from remarkable_mcp.usb_web import USBWebClient
+
+        response = Mock(status_code=404)
+        response.raise_for_status.side_effect = requests.HTTPError("404 Client Error: Not Found")
+        mock_request.return_value = response
+
+        with pytest.raises(RuntimeError, match="USB web interface request failed: 404"):
+            USBWebClient()._request("/documents/missing")
+
+        mock_request.assert_called_once()
+        mock_sleep.assert_not_called()
 
     @patch("remarkable_mcp.usb_web.create_usb_web_client")
     def test_get_rmapi_usb_web_mode(self, mock_create_client):


### PR DESCRIPTION
## Summary

- retry HTTP 408 responses from the USB web interface only for safe GET requests
- bound retries to three attempts with 250 ms / 500 ms backoff while preserving the caller timeout on every attempt
- keep writes and non-transient HTTP failures single-attempt, and raise an actionable error when 408 retries are exhausted

This is limited to USB transport resilience and does not change PDF rendering or annotation mapping. `Connection: close` is intentionally not forced because the client already creates an isolated Requests session per call and there is no evidence that changing the header improves xochitl behavior.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest test_server.py -v` (247 passed)