### PR TITLE
fix(ssh): serialize tablet operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ Write tools let you upload, organize, and manage documents on your reMarkable. *
 | Mkdir | ❌ | ✅ | ✅ | ❌ |
 | Move | ❌ | ✅ | ✅ | ❌ |
 | Rename | ❌ | ✅ | ✅ | ❌ |
-| Delete | ❌ | ✅ (→ trash) | ✅ | ❌ |
+| Delete | ❌ | ✅ (→ trash) | ✅ (→ trash; optional permanent) | ❌ |
 
 ### Disabling Write Tools (read-only mode)
 
@@ -606,7 +606,7 @@ Or set the environment variable:
 | `remarkable_mkdir(folder_name, parent, defer_restart)` | Create a new folder (cloud and SSH) |
 | `remarkable_move(document, dest_folder, defer_restart)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name, defer_restart)` | Rename a document or folder (cloud and SSH) |
-| `remarkable_delete(document, defer_restart)` | Delete a document or folder — destructive (cloud and SSH) |
+| `remarkable_delete(document, defer_restart, permanent)` | Move a document/folder to Trash; SSH can permanently remove it with `permanent=True` |
 | `remarkable_refresh()` | Restart `xochitl` once to apply writes made with `defer_restart=True` — **SSH only** |
 | `remarkable_author(method, ...)` | Author native ink and notebooks — `draw` (append strokes), `add_page` (append a blank notebook page), `create_document` (new notebook) — **SSH only** |
 
@@ -614,7 +614,7 @@ Or set the environment variable:
 
 - **Upload registers in cloud, SSH, and USB web mode** — local-directory mode never exposes write tools.
 - **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
-- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
+- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. Cloud and SSH move items to Trash by default. SSH also supports `permanent=True` for an explicitly requested permanent removal; cloud permanent deletion remains a Trash-management operation in the app/tablet. Set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
 - After each write operation in SSH mode, the tablet UI (`xochitl`) restarts automatically to reflect changes; the call waits for it to come back before returning so the next write doesn't race a restarting daemon. For bulk operations, pass `defer_restart=True` to each write — or set `REMARKABLE_DEFER_RESTART=1` — and call `remarkable_refresh()` once at the end, so the batch triggers a single restart instead of one per write (each restart forces a full document-store rescan).
 
 ### Examples
@@ -634,6 +634,9 @@ remarkable_rename("Untitled", "Q4 Planning Notes")
 
 # Delete (destructive — confirms via elicitation when supported)
 remarkable_delete("Old Draft")
+
+# Permanently delete in SSH mode only
+remarkable_delete("Disposable Test", permanent=True)
 
 # Bulk import (SSH): defer the restart on each write, then refresh once.
 # One xochitl restart for the whole batch instead of one per upload.

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -192,6 +192,14 @@ Note: WiFi is slower than USB but works from anywhere on your network.
 | `REMARKABLE_RESTART_SETTLE` | `3` | Extra settle delay (seconds) after `xochitl` is active, before the next operation runs |
 | `REMARKABLE_DEFER_RESTART` | *(unset)* | When set (`1`/`true`/`yes`), write tools skip their per-write `xochitl` restart; call `remarkable_refresh` once to apply a whole batch with a single restart |
 
+Direct SSH writes bypass the live library control plane used by cloud sync and
+the USB web upload service. Stock firmware exposes no external library reload
+API, and xochitl does not automatically ingest raw metadata/filesystem changes.
+That is why a refresh restart is still required after an SSH write batch.
+`remarkable_refresh` performs one restart for all writes deferred with
+`defer_restart=True`; it is preferable to restarting after every item in a
+large batch.
+
 ## Troubleshooting
 
 ### "Connection refused"

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import time
 import zipfile
 from difflib import SequenceMatcher
@@ -141,6 +142,9 @@ _extraction_cache: Dict[str, Dict[str, Any]] = {}
 # Key: (doc_id, page_number, backend)
 # Value: {"text": str, "timestamp": float}
 _page_ocr_cache: Dict[tuple, Dict[str, Any]] = {}
+_cache_lock = threading.RLock()
+_cache_generation: Dict[str, int] = {}
+_global_cache_generation = 0
 
 
 def _is_cache_valid(cached: Dict[str, Any]) -> bool:
@@ -158,15 +162,46 @@ def clear_extraction_cache(doc_id: Optional[str] = None) -> None:
         doc_id: If provided, only clear cache for this document.
                 If None, clear the entire cache.
     """
-    if doc_id:
-        _extraction_cache.pop(doc_id, None)
-        # Also clear per-page cache entries for this document
-        keys_to_remove = [k for k in _page_ocr_cache if k[0] == doc_id]
-        for key in keys_to_remove:
-            _page_ocr_cache.pop(key, None)
-    else:
-        _extraction_cache.clear()
-        _page_ocr_cache.clear()
+    global _global_cache_generation
+
+    with _cache_lock:
+        if doc_id:
+            _cache_generation[doc_id] = _cache_generation.get(doc_id, 0) + 1
+            _extraction_cache.pop(doc_id, None)
+            keys_to_remove = [k for k in _page_ocr_cache if k[0] == doc_id]
+            for key in keys_to_remove:
+                _page_ocr_cache.pop(key, None)
+        else:
+            _global_cache_generation += 1
+            _extraction_cache.clear()
+            _page_ocr_cache.clear()
+            _cache_generation.clear()
+
+
+def _cache_token(doc_id: str) -> tuple[int, int]:
+    with _cache_lock:
+        return _global_cache_generation, _cache_generation.get(doc_id, 0)
+
+
+def _cache_extraction_result_if_current(
+    doc_id: str,
+    result: Dict[str, Any],
+    include_ocr: bool,
+    token: tuple[int, int],
+) -> bool:
+    """Cache only if no mutation invalidated this document during extraction."""
+    with _cache_lock:
+        if token != (
+            _global_cache_generation,
+            _cache_generation.get(doc_id, 0),
+        ):
+            return False
+        _extraction_cache[doc_id] = {
+            "result": result,
+            "include_ocr": include_ocr,
+            "timestamp": time.time(),
+        }
+        return True
 
 
 def get_cached_page_ocr(
@@ -186,12 +221,12 @@ def get_cached_page_ocr(
         Cached OCR text or None if not cached/expired
     """
     cache_key = (doc_id, page, backend)
-    if cache_key in _page_ocr_cache:
-        cached = _page_ocr_cache[cache_key]
-        if _is_cache_valid(cached):
-            return cached["text"]
-        # Expired, remove it
-        _page_ocr_cache.pop(cache_key, None)
+    with _cache_lock:
+        if cache_key in _page_ocr_cache:
+            cached = _page_ocr_cache[cache_key]
+            if _is_cache_valid(cached):
+                return cached["text"]
+            _page_ocr_cache.pop(cache_key, None)
     return None
 
 
@@ -211,10 +246,11 @@ def cache_page_ocr(
         text: OCR text result
     """
     cache_key = (doc_id, page, backend)
-    _page_ocr_cache[cache_key] = {
-        "text": text,
-        "timestamp": time.time(),
-    }
+    with _cache_lock:
+        _page_ocr_cache[cache_key] = {
+            "text": text,
+            "timestamp": time.time(),
+        }
 
 
 def get_cached_ocr_result(
@@ -234,15 +270,15 @@ def get_cached_ocr_result(
     Returns:
         Cached result dict or None if not cached/expired/wrong backend
     """
-    if doc_id in _extraction_cache:
-        cached = _extraction_cache[doc_id]
-        if (cached["include_ocr"] or not include_ocr) and _is_cache_valid(cached):
-            # Check backend match if specified
-            if ocr_backend is not None:
-                cached_backend = cached["result"].get("ocr_backend")
-                if cached_backend != ocr_backend:
-                    return None
-            return cached["result"]
+    with _cache_lock:
+        if doc_id in _extraction_cache:
+            cached = _extraction_cache[doc_id]
+            if (cached["include_ocr"] or not include_ocr) and _is_cache_valid(cached):
+                if ocr_backend is not None:
+                    cached_backend = cached["result"].get("ocr_backend")
+                    if cached_backend != ocr_backend:
+                        return None
+                return cached["result"]
     return None
 
 
@@ -260,11 +296,12 @@ def cache_ocr_result(
                 handwritten_text, pages, page_ids, ocr_backend
         include_ocr: Whether this result includes OCR content
     """
-    _extraction_cache[doc_id] = {
-        "result": result,
-        "include_ocr": include_ocr,
-        "timestamp": time.time(),
-    }
+    with _cache_lock:
+        _extraction_cache[doc_id] = {
+            "result": result,
+            "include_ocr": include_ocr,
+            "timestamp": time.time(),
+        }
 
 
 def find_similar_documents(query: str, documents: List, limit: int = 5) -> List[str]:
@@ -2021,13 +2058,16 @@ def extract_text_from_document_zip(
             "ocr_backend": str,        # Which OCR backend was used (if any)
         }
     """
-    # Check cache if doc_id provided
-    if doc_id and doc_id in _extraction_cache:
-        cached = _extraction_cache[doc_id]
-        # Return cached result if OCR requirement is satisfied and cache is valid
-        # (cached with OCR can satisfy no-OCR request, but not vice versa)
-        if (cached["include_ocr"] or not include_ocr) and _is_cache_valid(cached):
-            return cached["result"]
+    cache_token = None
+    if doc_id:
+        with _cache_lock:
+            cache_token = (
+                _global_cache_generation,
+                _cache_generation.get(doc_id, 0),
+            )
+            cached = _extraction_cache.get(doc_id)
+            if cached and (cached["include_ocr"] or not include_ocr) and _is_cache_valid(cached):
+                return cached["result"]
 
     result: Dict[str, Any] = {
         "typed_text": [],
@@ -2163,13 +2203,8 @@ def extract_text_from_document_zip(
             result["handwritten_text"] = ocr_result
             result["ocr_backend"] = ocr_backend
 
-    # Cache result if doc_id provided
-    if doc_id:
-        _extraction_cache[doc_id] = {
-            "result": result,
-            "include_ocr": include_ocr,
-            "timestamp": time.time(),
-        }
+    if doc_id and cache_token is not None:
+        _cache_extraction_result_if_current(doc_id, result, include_ocr, cache_token)
 
     return result
 

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -616,6 +616,7 @@ class SSHClient:
 
             except Exception as e:
                 logger.warning(f"Failed to batch-load file types: {e}")
+                return {}
 
             self._file_type_cache = cache
             return cache

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -18,6 +18,8 @@ import json
 import logging
 import os
 import subprocess
+import threading
+import time
 import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -119,6 +121,65 @@ class SSHClient:
         self.key_path = os.path.expanduser(key_path) if key_path else None
         self._documents: List[Document] = []
         self._documents_by_id: Dict[str, Document] = {}
+        self._metadata_lock = threading.RLock()
+        self._file_type_lock = threading.RLock()
+        self._io_lock = threading.RLock()
+        self._file_type_cache: Optional[dict[str, Optional[str]]] = None
+        self._trace_lock = threading.Lock()
+        self._trace_sequence = 0
+        self._trace_active = 0
+
+    def _trace_start(self, operation: str) -> tuple[int, float]:
+        if os.environ.get("REMARKABLE_SSH_TRACE", "").lower() not in ("1", "true", "yes"):
+            return 0, 0.0
+        with self._trace_lock:
+            self._trace_sequence += 1
+            self._trace_active += 1
+            sequence = self._trace_sequence
+            active = self._trace_active
+        logger.warning("SSH trace start id=%d operation=%s active=%d", sequence, operation, active)
+        return sequence, time.monotonic()
+
+    def _trace_finish(
+        self,
+        trace: tuple[int, float],
+        operation: str,
+        returncode: Optional[int],
+        output_bytes: int,
+    ) -> None:
+        sequence, started = trace
+        if not sequence:
+            return
+        with self._trace_lock:
+            self._trace_active -= 1
+            active = self._trace_active
+        logger.warning(
+            "SSH trace finish id=%d operation=%s active=%d duration=%.3fs returncode=%s bytes=%d",
+            sequence,
+            operation,
+            active,
+            time.monotonic() - started,
+            returncode,
+            output_bytes,
+        )
+
+    @staticmethod
+    def _command_operation(command: str) -> str:
+        if "*.metadata" in command:
+            return "metadata-preload"
+        if "*.content" in command:
+            return "file-type-preload"
+        if command.startswith("find "):
+            return "document-file-list"
+        if command.startswith("test -f "):
+            return "file-exists"
+        if "systemctl restart xochitl" in command:
+            return "xochitl-restart"
+        if "systemctl is-active xochitl" in command:
+            return "xochitl-readiness"
+        if command == "echo ok":
+            return "connection-check"
+        return "command"
 
     def _auth_ssh_options(self) -> List[str]:
         """SSH options for key-based auth.
@@ -141,6 +202,14 @@ class SSHClient:
 
     def _ssh_command(self, command: str, timeout: int = 30) -> str:
         """Execute a command on the tablet via SSH."""
+        with self._io_lock:
+            return self._ssh_command_unlocked(command, timeout)
+
+    def _ssh_command_unlocked(self, command: str, timeout: int) -> str:
+        operation = self._command_operation(command)
+        trace = self._trace_start(operation)
+        returncode = None
+        output_bytes = 0
         ssh_args = [
             "ssh",
             *self._auth_ssh_options(),
@@ -165,6 +234,8 @@ class SSHClient:
                 text=True,
                 timeout=timeout,
             )
+            returncode = result.returncode
+            output_bytes = len(result.stdout.encode()) + len(result.stderr.encode())
             if result.returncode != 0:
                 raise RuntimeError(f"SSH command failed: {result.stderr}")
             return result.stdout
@@ -184,9 +255,19 @@ class SSHClient:
                 "built in on Windows 10+), macOS (preinstalled), "
                 "Linux (apt install openssh-client / equivalent)."
             )
+        finally:
+            self._trace_finish(trace, operation, returncode, output_bytes)
 
     def _scp_download(self, remote_path: str, timeout: int = 60) -> bytes:
         """Download a file from the tablet via SSH cat (more reliable than SCP)."""
+        with self._io_lock:
+            return self._scp_download_unlocked(remote_path, timeout)
+
+    def _scp_download_unlocked(self, remote_path: str, timeout: int) -> bytes:
+        operation = f"download-{remote_path.rsplit('.', 1)[-1]}"
+        trace = self._trace_start(operation)
+        returncode = None
+        output_bytes = 0
         # Use SSH + cat instead of SCP for binary file transfer
         # This avoids issues with /dev/stdout on various platforms
         ssh_args = [
@@ -212,11 +293,63 @@ class SSHClient:
                 capture_output=True,
                 timeout=timeout,
             )
+            returncode = result.returncode
+            output_bytes = len(result.stdout) + len(result.stderr)
             if result.returncode != 0:
                 raise RuntimeError(f"SSH cat failed: {result.stderr.decode()}")
             return result.stdout
         except subprocess.TimeoutExpired:
             raise RuntimeError(f"SSH cat timed out after {timeout}s")
+        finally:
+            self._trace_finish(trace, operation, returncode, output_bytes)
+
+    def _upload_file(self, local_path: str, remote_path: str, timeout: int = 120) -> None:
+        """Upload one file while participating in the per-client SSH I/O queue."""
+        with self._io_lock:
+            operation = f"upload-{remote_path.rsplit('.', 1)[-1]}"
+            trace = self._trace_start(operation)
+            returncode = None
+            output_bytes = 0
+            ssh_args = [
+                "ssh",
+                *self._auth_ssh_options(),
+                "-o",
+                "ConnectTimeout=5",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-p",
+                str(self.port),
+                f"{self.user}@{self.host}",
+                f"cat > '{remote_path}'",
+            ]
+            if self.password:
+                ssh_args = ["sshpass", "-p", self.password] + ssh_args
+
+            try:
+                with open(local_path, "rb") as source:
+                    result = subprocess.run(
+                        ssh_args,
+                        stdin=source,
+                        capture_output=True,
+                        timeout=timeout,
+                    )
+                returncode = result.returncode
+                output_bytes = len(result.stdout) + len(result.stderr)
+                if result.returncode != 0:
+                    raise RuntimeError(f"Upload failed: {result.stderr.decode()}")
+            except FileNotFoundError as e:
+                if self.password and "sshpass" in str(e):
+                    raise RuntimeError(
+                        "sshpass not found. Install it with: "
+                        "apt install sshpass (Debian/Ubuntu), "
+                        "brew install hudochenkov/sshpass/sshpass (macOS), "
+                        "or set up SSH key authentication instead."
+                    )
+                raise RuntimeError("SSH client not found. Install openssh-client.")
+            except subprocess.TimeoutExpired:
+                raise RuntimeError(f"SSH upload timed out after {timeout}s")
+            finally:
+                self._trace_finish(trace, operation, returncode, output_bytes)
 
     def check_connection(self) -> bool:
         """Check if SSH connection to tablet is available."""
@@ -236,61 +369,53 @@ class SSHClient:
 
         Returns a list of Document objects.
         """
-        # Return cached documents if available and no limit specified
-        if self._documents and limit is None:
-            return self._documents
+        with self._metadata_lock:
+            # Re-check inside the lock: startup resource loading and the first
+            # status/tool request can arrive together on separate worker threads.
+            # Exactly one of them should scan the tablet; the other reuses its cache.
+            if self._documents and limit is None:
+                return self._documents
+            if self._documents and limit is not None and len(self._documents) >= limit:
+                return self._documents[:limit]
 
-        # If we have cached docs and limit is within cache, return slice
-        if self._documents and limit is not None and len(self._documents) >= limit:
-            return self._documents[:limit]
+            try:
+                output = self._ssh_command(
+                    f"for f in {XOCHITL_PATH}/*.metadata; do "
+                    f'echo "===FILE===$(basename $f .metadata)"; cat "$f" 2>/dev/null; '
+                    f"done",
+                    timeout=60,
+                )
+            except Exception as e:
+                raise RuntimeError(f"Failed to read metadata: {e}")
 
-        # Read all metadata files in a single SSH command for efficiency
-        # Output format: filename<TAB>content (JSON)
-        try:
-            # Use a single command to read all metadata files at once
-            # This is MUCH faster than individual cat commands
-            output = self._ssh_command(
-                f"for f in {XOCHITL_PATH}/*.metadata; do "
-                f'echo "===FILE===$(basename $f .metadata)"; cat "$f" 2>/dev/null; '
-                f"done",
-                timeout=60,
-            )
-        except Exception as e:
-            raise RuntimeError(f"Failed to read metadata: {e}")
+            documents = []
+            current_id = None
+            current_content = []
 
-        documents = []
+            for line in output.split("\n"):
+                if line.startswith("===FILE==="):
+                    if current_id and current_content:
+                        self._parse_and_add_document(
+                            current_id, "\n".join(current_content), documents, limit
+                        )
+                        if limit is not None and len(documents) >= limit:
+                            break
+                    current_id = line.replace("===FILE===", "").strip()
+                    current_content = []
+                else:
+                    current_content.append(line)
 
-        # Parse the output - split by our delimiter
-        current_id = None
-        current_content = []
-
-        for line in output.split("\n"):
-            if line.startswith("===FILE==="):
-                # Save previous document if we have one
-                if current_id and current_content:
+            if current_id and current_content:
+                if limit is None or len(documents) < limit:
                     self._parse_and_add_document(
                         current_id, "\n".join(current_content), documents, limit
                     )
-                    if limit is not None and len(documents) >= limit:
-                        break
-                # Start new document
-                current_id = line.replace("===FILE===", "").strip()
-                current_content = []
-            else:
-                current_content.append(line)
 
-        # Don't forget the last document
-        if current_id and current_content:
-            if limit is None or len(documents) < limit:
-                self._parse_and_add_document(
-                    current_id, "\n".join(current_content), documents, limit
-                )
+            self._documents = documents
+            self._documents_by_id = {d.id: d for d in documents}
 
-        self._documents = documents
-        self._documents_by_id = {d.id: d for d in documents}
-
-        logger.info(f"Loaded {len(documents)} documents via SSH")
-        return documents
+            logger.info(f"Loaded {len(documents)} documents via SSH")
+            return documents
 
     def _parse_and_add_document(
         self,
@@ -429,18 +554,19 @@ class SSHClient:
 
         Returns the extension without dot, or None if not a file-based document.
         """
-        # Check cache first
-        if hasattr(self, "_file_type_cache") and doc.id in self._file_type_cache:
-            return self._file_type_cache[doc.id]
+        with self._file_type_lock:
+            # If the background all-file preload owns this lock, wait for it to
+            # finish instead of starting another SSH connection in parallel.
+            if self._file_type_cache is not None and doc.id in self._file_type_cache:
+                return self._file_type_cache[doc.id]
 
-        content_file = f"{XOCHITL_PATH}/{doc.id}.content"
-
-        try:
-            content = self._scp_download(content_file, timeout=10)
-            data = json.loads(content.decode("utf-8"))
-            return data.get("fileType")
-        except Exception:
-            return None
+            content_file = f"{XOCHITL_PATH}/{doc.id}.content"
+            try:
+                content = self._scp_download(content_file, timeout=10)
+                data = json.loads(content.decode("utf-8"))
+                return data.get("fileType")
+            except Exception:
+                return None
 
     def get_all_file_types(self) -> dict[str, Optional[str]]:
         """
@@ -449,50 +575,48 @@ class SSHClient:
         Returns a dict mapping document ID to file type (pdf, epub, or None).
         Much more efficient than calling get_file_type() for each document.
         """
-        if hasattr(self, "_file_type_cache"):
-            return self._file_type_cache
+        with self._file_type_lock:
+            if self._file_type_cache is not None:
+                return self._file_type_cache
 
-        self._file_type_cache: dict[str, Optional[str]] = {}
+            cache: dict[str, Optional[str]] = {}
+            try:
+                output = self._ssh_command(
+                    f"for f in {XOCHITL_PATH}/*.content; do "
+                    f'echo "===FILE===$(basename $f .content)"; cat "$f" 2>/dev/null; '
+                    f"done",
+                    timeout=60,
+                )
 
-        try:
-            # Read all .content files in a single command
-            output = self._ssh_command(
-                f"for f in {XOCHITL_PATH}/*.content; do "
-                f'echo "===FILE===$(basename $f .content)"; cat "$f" 2>/dev/null; '
-                f"done",
-                timeout=60,
-            )
+                current_id = None
+                current_content = []
 
-            current_id = None
-            current_content = []
+                for line in output.split("\n"):
+                    if line.startswith("===FILE==="):
+                        if current_id and current_content:
+                            try:
+                                data = json.loads("\n".join(current_content))
+                                cache[current_id] = data.get("fileType")
+                            except json.JSONDecodeError:
+                                cache[current_id] = None
 
-            for line in output.split("\n"):
-                if line.startswith("===FILE==="):
-                    # Parse previous content
-                    if current_id and current_content:
-                        try:
-                            data = json.loads("\n".join(current_content))
-                            self._file_type_cache[current_id] = data.get("fileType")
-                        except json.JSONDecodeError:
-                            self._file_type_cache[current_id] = None
+                        current_id = line.replace("===FILE===", "").strip()
+                        current_content = []
+                    else:
+                        current_content.append(line)
 
-                    current_id = line.replace("===FILE===", "").strip()
-                    current_content = []
-                else:
-                    current_content.append(line)
+                if current_id and current_content:
+                    try:
+                        data = json.loads("\n".join(current_content))
+                        cache[current_id] = data.get("fileType")
+                    except json.JSONDecodeError:
+                        cache[current_id] = None
 
-            # Don't forget the last one
-            if current_id and current_content:
-                try:
-                    data = json.loads("\n".join(current_content))
-                    self._file_type_cache[current_id] = data.get("fileType")
-                except json.JSONDecodeError:
-                    self._file_type_cache[current_id] = None
+            except Exception as e:
+                logger.warning(f"Failed to batch-load file types: {e}")
 
-        except Exception as e:
-            logger.warning(f"Failed to batch-load file types: {e}")
-
-        return self._file_type_cache
+            self._file_type_cache = cache
+            return cache
 
 
 def check_ssh_available(

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -27,6 +27,8 @@ import logging
 import os
 import time
 import uuid
+from contextlib import nullcontext
+from datetime import datetime
 from typing import Optional
 
 from mcp.server.fastmcp import Context
@@ -40,7 +42,7 @@ from remarkable_mcp.api import (
 )
 from remarkable_mcp.capabilities import client_supports_elicitation
 from remarkable_mcp.responses import make_error, make_response
-from remarkable_mcp.ssh import XOCHITL_PATH, SSHClient
+from remarkable_mcp.ssh import XOCHITL_PATH, Document, SSHClient
 
 logger = logging.getLogger(__name__)
 
@@ -167,45 +169,7 @@ def _write_content_file(ssh_client: SSHClient, doc_uuid: str, content_data: dict
 
 def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str) -> None:
     """Upload a local file to the tablet via SSH stdin pipe."""
-    import subprocess
-
-    ssh_args = [
-        "ssh",
-        *ssh_client._auth_ssh_options(),
-        "-o",
-        "ConnectTimeout=5",
-        "-o",
-        "StrictHostKeyChecking=accept-new",
-        "-p",
-        str(ssh_client.port),
-        f"{ssh_client.user}@{ssh_client.host}",
-        f"cat > '{remote_path}'",
-    ]
-
-    if ssh_client.password:
-        ssh_args = ["sshpass", "-p", ssh_client.password] + ssh_args
-
-    with open(local_path, "rb") as f:
-        try:
-            result = subprocess.run(
-                ssh_args,
-                stdin=f,
-                capture_output=True,
-                timeout=120,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(f"Upload failed: {result.stderr.decode()}")
-        except FileNotFoundError as e:
-            if ssh_client.password and "sshpass" in str(e):
-                raise RuntimeError(
-                    "sshpass not found. Install it with: "
-                    "apt install sshpass (Debian/Ubuntu), "
-                    "brew install hudochenkov/sshpass/sshpass (macOS), "
-                    "or set up SSH key authentication instead."
-                )
-            raise RuntimeError("SSH client not found. Install openssh-client.")
-        except subprocess.TimeoutExpired:
-            raise RuntimeError("SSH upload timed out after 120s")
+    ssh_client._upload_file(local_path, remote_path)
 
 
 # Tunables for the post-restart readiness wait (see _restart_xochitl). All are
@@ -433,8 +397,67 @@ def _resolve_document(
 
 def _invalidate_client_cache(client) -> None:
     """Drop the in-memory document cache so the next read reflects the write."""
-    client._documents = []
-    client._documents_by_id = {}
+    metadata_lock = getattr(client, "_metadata_lock", None)
+    context = metadata_lock if metadata_lock is not None else nullcontext()
+    with context:
+        client._documents = []
+        client._documents_by_id = {}
+
+    file_type_lock = getattr(client, "_file_type_lock", None)
+    context = file_type_lock if file_type_lock is not None else nullcontext()
+    with context:
+        if isinstance(client, SSHClient):
+            client._file_type_cache = None
+        elif hasattr(client, "_file_type_cache"):
+            client._file_type_cache = {}
+
+
+def _clear_document_extraction_cache(doc_id: str) -> None:
+    from remarkable_mcp.extract import clear_extraction_cache
+
+    clear_extraction_cache(doc_id)
+
+
+def _update_deferred_ssh_cache(
+    client: SSHClient,
+    restarted: bool,
+    *,
+    document: Optional[Document] = None,
+    remove_id: Optional[str] = None,
+    file_type: Optional[str] = None,
+) -> None:
+    """Keep a deferred batch resolvable without rescanning the whole library."""
+    if restarted:
+        _invalidate_client_cache(client)
+        return
+
+    documents = getattr(client, "_documents", None)
+    if not isinstance(documents, list):
+        return
+
+    lock = getattr(client, "_metadata_lock", None)
+    context = lock if lock is not None else nullcontext()
+    with context:
+        if remove_id is not None:
+            client._documents = [item for item in documents if item.ID != remove_id]
+            client._documents_by_id.pop(remove_id, None)
+        elif document is not None:
+            existing = client._documents_by_id.get(document.ID)
+            if existing is None:
+                client._documents.append(document)
+            elif existing is not document:
+                client._documents = [
+                    document if item.ID == document.ID else item for item in client._documents
+                ]
+            client._documents_by_id[document.ID] = document
+
+    file_type_lock = getattr(client, "_file_type_lock", None)
+    context = file_type_lock if file_type_lock is not None else nullcontext()
+    with context:
+        if remove_id is not None and client._file_type_cache is not None:
+            client._file_type_cache.pop(remove_id, None)
+        elif document is not None and file_type is not None and client._file_type_cache is not None:
+            client._file_type_cache[document.ID] = file_type
 
 
 def _cloud_mkdir(folder_name: str, parent: str) -> str:
@@ -747,7 +770,9 @@ def _author_draw(document: str, page: int, strokes: list, ui_submitted: bool) ->
         if not _remote_file_exists(ssh_client, bak_path):
             _write_remote_bytes(ssh_client, bak_path, original)
     _write_remote_bytes(ssh_client, rm_path, new_bytes)
-    _maybe_restart_xochitl(ssh_client)
+    restarted = _maybe_restart_xochitl(ssh_client)
+    _update_deferred_ssh_cache(ssh_client, restarted)
+    _clear_document_extraction_cache(doc_uuid)
 
     result = {
         "written": True,
@@ -840,8 +865,9 @@ def _author_add_page(document: str) -> str:
 
     _write_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}/{new_page_id}.rm", page_bytes)
     _write_content_file(ssh_client, doc_uuid, updated["content"])
-    _maybe_restart_xochitl(ssh_client)
-    _invalidate_client_cache(ssh_client)
+    restarted = _maybe_restart_xochitl(ssh_client)
+    _update_deferred_ssh_cache(ssh_client, restarted)
+    _clear_document_extraction_cache(doc_uuid)
 
     result = {
         "added": True,
@@ -894,8 +920,18 @@ def _author_create_document(name: str, text: Optional[str], folder: Optional[str
     _write_remote_bytes(ssh_client, f"{XOCHITL_PATH}/{doc_uuid}/{page_id}.rm", page_bytes)
     _write_content_file(ssh_client, doc_uuid, content_data)
     _write_metadata(ssh_client, doc_uuid, metadata)
-    _maybe_restart_xochitl(ssh_client)
-    _invalidate_client_cache(ssh_client)
+    restarted = _maybe_restart_xochitl(ssh_client)
+    cached_doc = Document(
+        id=doc_uuid,
+        hash=doc_uuid,
+        name=name,
+        doc_type="DocumentType",
+        parent=parent_id,
+        synced=False,
+        last_modified=datetime.now(),
+        local_path=f"{XOCHITL_PATH}/{doc_uuid}",
+    )
+    _update_deferred_ssh_cache(ssh_client, restarted, document=cached_doc, file_type="notebook")
 
     result = {
         "created": True,
@@ -1201,9 +1237,19 @@ def register_write_tools():
                 # Restart xochitl to pick up changes (unless deferred for a batch)
                 restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
-                # Clear cached documents so next read picks up the new doc
-                ssh_client._documents = []
-                ssh_client._documents_by_id = {}
+                cached_doc = Document(
+                    id=doc_uuid,
+                    hash=doc_uuid,
+                    name=name,
+                    doc_type="DocumentType",
+                    parent=parent_id,
+                    synced=False,
+                    last_modified=datetime.now(),
+                    local_path=f"{XOCHITL_PATH}/{doc_uuid}",
+                )
+                _update_deferred_ssh_cache(
+                    ssh_client, restarted, document=cached_doc, file_type=ext
+                )
 
                 return make_response(
                     {
@@ -1308,9 +1354,17 @@ def register_write_tools():
                     # Restart xochitl (unless deferred for a batch)
                     restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
-                    # Clear cache
-                    ssh_client._documents = []
-                    ssh_client._documents_by_id = {}
+                    cached_folder = Document(
+                        id=doc_uuid,
+                        hash=doc_uuid,
+                        name=folder_name,
+                        doc_type="CollectionType",
+                        parent=parent_id,
+                        synced=False,
+                        last_modified=datetime.now(),
+                        local_path=f"{XOCHITL_PATH}/{doc_uuid}",
+                    )
+                    _update_deferred_ssh_cache(ssh_client, restarted, document=cached_folder)
 
                     return make_response(
                         {
@@ -1433,9 +1487,9 @@ def register_write_tools():
                     # Restart xochitl (unless deferred for a batch)
                     restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
-                    # Clear cache
-                    ssh_client._documents = []
-                    ssh_client._documents_by_id = {}
+                    target.parent = dest_id
+                    target.last_modified = datetime.now()
+                    _update_deferred_ssh_cache(ssh_client, restarted, document=target)
 
                     return make_response(
                         {
@@ -1526,9 +1580,9 @@ def register_write_tools():
                     # Restart xochitl (unless deferred for a batch)
                     restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
-                    # Clear cache
-                    ssh_client._documents = []
-                    ssh_client._documents_by_id = {}
+                    target.name = new_name
+                    target.last_modified = datetime.now()
+                    _update_deferred_ssh_cache(ssh_client, restarted, document=target)
 
                     return make_response(
                         {
@@ -1626,9 +1680,8 @@ def register_write_tools():
                     # Restart xochitl (unless deferred for a batch)
                     restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
 
-                    # Clear cache
-                    ssh_client._documents = []
-                    ssh_client._documents_by_id = {}
+                    _update_deferred_ssh_cache(ssh_client, restarted, remove_id=target.ID)
+                    _clear_document_extraction_cache(target.ID)
 
                     return make_response(
                         {
@@ -1682,19 +1735,24 @@ def register_write_tools():
             if error:
                 return error
 
+            ssh_client = None
             try:
                 ssh_client = _get_ssh_client()
                 _restart_xochitl(ssh_client)
                 # Drop any cache populated while restarts were deferred so the
                 # next read reflects the just-applied changes.
-                ssh_client._documents = []
-                ssh_client._documents_by_id = {}
+                _invalidate_client_cache(ssh_client)
                 return make_response(
                     {"refreshed": True, "transport": "ssh"},
                     "xochitl restarted; any deferred changes are now visible. "
                     "Use remarkable_browse() to verify.",
                 )
             except Exception as e:
+                # A failed refresh leaves the relationship between on-disk state,
+                # xochitl, and our deferred cache uncertain. Force the next read
+                # to rebuild rather than presenting the cache as authoritative.
+                if ssh_client is not None:
+                    _invalidate_client_cache(ssh_client)
                 return make_error(
                     error_type="refresh_failed",
                     message=f"Failed to refresh tablet UI: {e}",

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import logging
 import os
+import shlex
 import time
 import uuid
 from contextlib import nullcontext
@@ -165,6 +166,13 @@ def _write_content_file(ssh_client: SSHClient, doc_uuid: str, content_data: dict
     content = json.dumps(content_data, indent=2)
     remote_path = f"{XOCHITL_PATH}/{doc_uuid}.content"
     ssh_client._ssh_command(f"cat > '{remote_path}' << 'REMARKABLE_EOF'\n{content}\nREMARKABLE_EOF")
+
+
+def _permanently_delete_ssh_entry(ssh_client: SSHClient, doc_uuid: str) -> None:
+    """Remove one resolved UUID and all of its sidecar files from the tablet."""
+    entry = shlex.quote(f"{XOCHITL_PATH}/{doc_uuid}")
+    sidecar_prefix = shlex.quote(f"{XOCHITL_PATH}/{doc_uuid}.")
+    ssh_client._ssh_command(f"rm -rf {entry} {sidecar_prefix}*")
 
 
 def _upload_file_bytes(ssh_client: SSHClient, local_path: str, remote_path: str) -> None:
@@ -1607,14 +1615,16 @@ def register_write_tools():
         async def remarkable_delete(
             document: str,
             defer_restart: bool = False,
+            permanent: bool = False,
             ctx: Optional[Context] = None,
         ) -> str:
             """
             <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
             <instructions>
-            DESTRUCTIVE operation. In cloud mode the item is moved to the trash
-            (recoverable from the device's Trash). In SSH mode it is marked deleted
-            in its metadata and disappears from the tablet UI after restart.
+            DESTRUCTIVE operation. By default the item is moved to the tablet's
+            Trash and remains recoverable. In SSH mode only, permanent=True removes
+            the resolved UUID and all sidecar files instead; use that only when the
+            user explicitly asked for permanent deletion.
 
             Works in cloud and SSH modes (default; --read-only disables). Not available over the
             USB web interface.
@@ -1629,6 +1639,8 @@ def register_write_tools():
             - defer_restart: SSH only. Skip the xochitl restart so a batch of
               deletes can refresh once via remarkable_refresh() instead of once
               per delete. Sets "refresh_pending": true. Ignored in cloud mode.
+            - permanent: SSH only. Permanently remove the resolved document/folder
+              files instead of moving the item to Trash (default: False).
             </parameters>
             <examples>
             - remarkable_delete("Old Notes")
@@ -1644,6 +1656,15 @@ def register_write_tools():
                 return abort
 
             if _is_cloud_mode():
+                if permanent:
+                    return make_error(
+                        error_type="permanent_delete_unsupported",
+                        message="Permanent deletion is not supported in cloud mode.",
+                        suggestion=(
+                            "Delete normally to move the item to Trash, then empty "
+                            "Trash from a reMarkable app or tablet."
+                        ),
+                    )
                 return await asyncio.to_thread(_cloud_delete, document)
 
             def _impl() -> str:
@@ -1667,15 +1688,22 @@ def register_write_tools():
 
                     doc_path = get_item_path(target, items_by_id)
 
-                    # Read existing metadata
-                    meta_content = ssh_client._scp_download(f"{XOCHITL_PATH}/{target.ID}.metadata")
-                    metadata = json.loads(meta_content.decode("utf-8"))
-
-                    # Mark as deleted
-                    metadata["deleted"] = True
-                    metadata["lastModified"] = str(int(time.time() * 1000))
-                    metadata["metadatamodified"] = True
-                    _write_metadata(ssh_client, target.ID, metadata)
+                    if permanent:
+                        _permanently_delete_ssh_entry(ssh_client, target.ID)
+                    else:
+                        meta_content = ssh_client._scp_download(
+                            f"{XOCHITL_PATH}/{target.ID}.metadata"
+                        )
+                        metadata = json.loads(meta_content.decode("utf-8"))
+                        metadata["parent"] = "trash"
+                        metadata["deleted"] = False
+                        metadata["lastModified"] = str(int(time.time() * 1000))
+                        metadata["metadatamodified"] = True
+                        try:
+                            metadata["version"] = int(metadata.get("version", 0)) + 1
+                        except (TypeError, ValueError):
+                            metadata["version"] = 1
+                        _write_metadata(ssh_client, target.ID, metadata)
 
                     # Restart xochitl (unless deferred for a batch)
                     restarted = _maybe_restart_xochitl(ssh_client, defer_restart)
@@ -1689,12 +1717,17 @@ def register_write_tools():
                             "name": target.VissibleName,
                             "path": doc_path,
                             "type": "folder" if target.is_folder else "document",
+                            "permanent": permanent,
                             "refresh_pending": not restarted,
                         },
                         _write_result_message(
                             restarted,
-                            "Document deleted.",
-                            "It will no longer appear on the tablet.",
+                            (
+                                "Document permanently deleted."
+                                if permanent
+                                else "Document moved to Trash."
+                            ),
+                            "It will no longer appear in the active library.",
                         ),
                     )
 

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -466,13 +466,12 @@ def _update_deferred_ssh_cache(
         _invalidate_client_cache(client)
         return
 
-    documents = getattr(client, "_documents", None)
-    if not isinstance(documents, list):
-        return
-
     lock = getattr(client, "_metadata_lock", None)
     context = lock if lock is not None else nullcontext()
     with context:
+        documents = getattr(client, "_documents", None)
+        if not isinstance(documents, list):
+            return
         if remove_id is not None:
             client._documents = [item for item in documents if item.ID != remove_id]
             client._documents_by_id.pop(remove_id, None)

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -439,7 +439,9 @@ def _invalidate_client_cache(client) -> None:
     file_type_lock = getattr(client, "_file_type_lock", None)
     context = file_type_lock if file_type_lock is not None else nullcontext()
     with context:
-        if isinstance(client, SSHClient):
+        from remarkable_mcp.local_dir import LocalDirClient
+
+        if isinstance(client, (SSHClient, LocalDirClient)):
             client._file_type_cache = None
         elif hasattr(client, "_file_type_cache"):
             client._file_type_cache = {}
@@ -1784,6 +1786,21 @@ def register_write_tools():
                     doc_path = get_item_path(target, items_by_id)
 
                     if permanent:
+                        if target.is_folder and any(
+                            item.Parent == target.ID for item in collection
+                        ):
+                            return make_error(
+                                error_type="folder_not_empty",
+                                message=(
+                                    f"Cannot permanently delete non-empty folder "
+                                    f"'{target.VissibleName}'."
+                                ),
+                                suggestion=(
+                                    "Permanently delete its child documents and "
+                                    "folders first, or omit permanent=True to move "
+                                    "the whole folder to Trash."
+                                ),
+                            )
                         _permanently_delete_ssh_entry(ssh_client, target.ID)
                     else:
                         meta_content = ssh_client._scp_download(

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -785,8 +785,16 @@ async def run_write_phase(session, mode, rec, registered):
 
             delete_states = []
             for _kind, path in created:
+                delete_args = {"document": path}
+                if is_ssh:
+                    # Smoke artifacts are disposable test data; do not fill the
+                    # tablet's Trash or let sync restore them after validation.
+                    delete_args["permanent"] = True
                 payload, is_err, exc = await call_tool(
-                    session, "remarkable_delete", {"document": path}, TIMEOUTS["remarkable_delete"]
+                    session,
+                    "remarkable_delete",
+                    delete_args,
+                    TIMEOUTS["remarkable_delete"],
                 )
                 st, _ = classify_ok(payload, is_err, exc)
                 delete_states.append((path, st))

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -47,15 +47,18 @@ import asyncio
 import json
 import os
 import pathlib
+import re
 import shutil
 import socket
+import subprocess
 import sys
 import tempfile
 import time
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from typing import Any
 
 from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
 
 HERE = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent
@@ -92,6 +95,7 @@ ALL_TOOLS = [
     "remarkable_rename",
     "remarkable_move",
     "remarkable_author",
+    "remarkable_refresh",
     "remarkable_delete",
 ]
 
@@ -109,6 +113,7 @@ WRITE_TOOLS = {
     "remarkable_rename",
     "remarkable_move",
     "remarkable_author",
+    "remarkable_refresh",
     "remarkable_delete",
 }
 
@@ -148,6 +153,10 @@ MODES = {
         "env": {
             "REMARKABLE_USE_SSH": "1",
             "REMARKABLE_DISABLE_CLOUD_FALLBACK": "1",
+            # A smoke run is a write batch. Restart xochitl once after cleanup
+            # rather than after every operation, which would force repeated
+            # full-library rescans and obscure sequencing failures.
+            "REMARKABLE_DEFER_RESTART": "1",
         },
         "probe_port": 22,
     },
@@ -159,6 +168,7 @@ TIMEOUTS = {
     "remarkable_image": 120,
     "remarkable_canvas": 120,
     "remarkable_author": 120,
+    "remarkable_refresh": 120,
     "remarkable_upload": 120,
     "remarkable_delete": 90,
     "_default": 60,
@@ -167,6 +177,220 @@ TIMEOUTS = {
 
 def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _read_text(path: pathlib.Path) -> str | None:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def _process_tree(root_pid: int) -> set[int]:
+    """Return the live Linux process tree rooted at ``root_pid``."""
+    found = {root_pid}
+    pending = [root_pid]
+    while pending:
+        pid = pending.pop()
+        children = _read_text(pathlib.Path(f"/proc/{pid}/task/{pid}/children"))
+        if not children:
+            continue
+        for value in children.split():
+            child = int(value)
+            if child not in found:
+                found.add(child)
+                pending.append(child)
+    return found
+
+
+def _process_sample(root_pid: int) -> dict[str, Any]:
+    total_rss_kb = 0
+    processes = []
+    for pid in sorted(_process_tree(root_pid)):
+        status = _read_text(pathlib.Path(f"/proc/{pid}/status"))
+        if not status:
+            continue
+        name_match = re.search(r"^Name:\s+(.+)$", status, re.MULTILINE)
+        rss_match = re.search(r"^VmRSS:\s+(\d+)\s+kB$", status, re.MULTILINE)
+        rss_kb = int(rss_match.group(1)) if rss_match else 0
+        total_rss_kb += rss_kb
+        processes.append(
+            {
+                "pid": pid,
+                "name": name_match.group(1) if name_match else "unknown",
+                "rss_kb": rss_kb,
+            }
+        )
+    return {"total_rss_kb": total_rss_kb, "processes": processes}
+
+
+class ProcessDiagnostics:
+    """Capture the stdio server process lifetime without changing the MCP SDK."""
+
+    def __init__(self):
+        self.process = None
+        self._sampler = None
+        self._stop = asyncio.Event()
+        self.max_tree_rss_kb = 0
+        self.max_tree_processes = []
+        self.stderr = ""
+
+    def attach(self, process) -> None:
+        self.process = process
+        self._sampler = asyncio.create_task(self._sample_loop())
+
+    async def _sample_loop(self) -> None:
+        while not self._stop.is_set():
+            if self.process is not None:
+                sample = _process_sample(self.process.pid)
+                if sample["total_rss_kb"] > self.max_tree_rss_kb:
+                    self.max_tree_rss_kb = sample["total_rss_kb"]
+                    self.max_tree_processes = sample["processes"]
+            try:
+                await asyncio.wait_for(self._stop.wait(), 0.25)
+            except asyncio.TimeoutError:
+                pass
+
+    async def finish(self, errlog) -> None:
+        self._stop.set()
+        if self._sampler is not None:
+            await self._sampler
+        errlog.flush()
+        errlog.seek(0)
+        self.stderr = errlog.read()
+
+    def snapshot(self) -> dict[str, Any]:
+        returncode = self.process.returncode if self.process is not None else None
+        signal = -returncode if isinstance(returncode, int) and returncode < 0 else None
+        stderr_lines = self.stderr.splitlines()
+        return {
+            "pid": self.process.pid if self.process is not None else None,
+            "returncode": returncode,
+            "signal": signal,
+            "max_process_tree_rss_kb": self.max_tree_rss_kb,
+            "max_process_tree": self.max_tree_processes,
+            "stderr_tail": stderr_lines[-500:],
+            "python_traceback": any(
+                "Traceback (most recent call last)" in line for line in stderr_lines
+            ),
+        }
+
+
+@asynccontextmanager
+async def diagnostic_stdio_client(params):
+    """Wrap MCP's stdio client while retaining its otherwise-hidden child process."""
+    import mcp.client.stdio as stdio_module
+
+    diagnostics = ProcessDiagnostics()
+    original_create = stdio_module._create_platform_compatible_process
+
+    async def _capture_process(**kwargs):
+        process = await original_create(**kwargs)
+        diagnostics.attach(process)
+        return process
+
+    stdio_module._create_platform_compatible_process = _capture_process
+    try:
+        with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as errlog:
+            try:
+                async with stdio_module.stdio_client(params, errlog=errlog) as streams:
+                    yield (*streams, diagnostics)
+            finally:
+                await diagnostics.finish(errlog)
+    finally:
+        stdio_module._create_platform_compatible_process = original_create
+
+
+def _run_diagnostic_command(args: list[str], timeout: int = 10) -> dict[str, Any]:
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _host_diagnostics() -> dict[str, Any]:
+    meminfo = _read_text(pathlib.Path("/proc/meminfo")) or ""
+    selected_mem = {}
+    for key in ("MemTotal", "MemAvailable", "SwapTotal", "SwapFree"):
+        match = re.search(rf"^{key}:\s+(.+)$", meminfo, re.MULTILINE)
+        if match:
+            selected_mem[key] = match.group(1)
+
+    cgroup = {}
+    for path in (
+        pathlib.Path("/sys/fs/cgroup/memory.events"),
+        pathlib.Path("/sys/fs/cgroup/memory.max"),
+        pathlib.Path("/sys/fs/cgroup/memory.current"),
+        pathlib.Path("/sys/fs/cgroup/memory/memory.oom_control"),
+        pathlib.Path("/sys/fs/cgroup/memory/memory.limit_in_bytes"),
+        pathlib.Path("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
+    ):
+        value = _read_text(path)
+        if value is not None:
+            cgroup[str(path)] = value.strip()
+
+    kernel = _run_diagnostic_command(
+        [
+            "journalctl",
+            "-k",
+            "--since",
+            "10 minutes ago",
+            "--no-pager",
+            "--grep",
+            "oom-kill|out of memory|killed process",
+        ]
+    )
+    return {"memory": selected_mem, "cgroup": cgroup, "kernel_oom": kernel}
+
+
+def _tablet_diagnostics() -> dict[str, Any]:
+    """Collect read-only load/memory/SSH state in one additional connection."""
+    command = (
+        "printf 'uptime='; uptime; "
+        "printf 'loadavg='; cat /proc/loadavg; "
+        "printf 'memory_kb\\n'; sed -n "
+        "'/MemTotal:/p;/MemAvailable:/p;/SwapTotal:/p;/SwapFree:/p' /proc/meminfo; "
+        "printf 'processes\\n'; "
+        "ps -eo pid,comm,rss,stat --sort=-rss 2>/dev/null | head -n 12; "
+        "printf 'sshd='; systemctl is-active sshd 2>/dev/null || "
+        "systemctl is-active dropbear 2>/dev/null || true; "
+        "printf 'xochitl='; systemctl is-active xochitl 2>/dev/null || true; "
+        "printf 'kernel_oom\\n'; "
+        "journalctl -k --since '-10 min' --no-pager 2>/dev/null | "
+        "grep -Ei 'oom-kill|out of memory|killed process' | tail -20 || true"
+    )
+    args = [
+        "ssh",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+    ]
+    key_path = os.environ.get("REMARKABLE_SSH_KEY")
+    if key_path:
+        args.extend(["-i", os.path.expanduser(key_path), "-o", "IdentitiesOnly=yes"])
+    args.extend(
+        [
+            "-p",
+            os.environ.get("REMARKABLE_SSH_PORT", "22"),
+            (
+                f"{os.environ.get('REMARKABLE_SSH_USER', 'root')}@"
+                f"{os.environ.get('REMARKABLE_SSH_HOST', USB_HOST)}"
+            ),
+            command,
+        ]
+    )
+    password = os.environ.get("REMARKABLE_SSH_PASSWORD")
+    if password:
+        args = ["sshpass", "-p", password, *args]
+    else:
+        args[1:1] = ["-o", "BatchMode=yes"]
+    return _run_diagnostic_command(args, timeout=15)
 
 
 def _cloud_token_present() -> bool:
@@ -236,12 +460,15 @@ class Recorder:
         self.modes: dict[str, dict] = {}
 
     def mode_unavailable(self, mode: str, reason: str):
-        self.modes[mode] = {"available": False, "reason": reason, "tools": {}}
+        prior = self.modes.get(mode, {})
+        self.modes[mode] = {**prior, "available": False, "reason": reason, "tools": {}}
         for tool in ALL_TOOLS:
             self.modes[mode]["tools"][tool] = {"state": SKIP, "note": "mode unavailable"}
 
     def ensure_mode(self, mode: str, transport: str, doc_count, reason: str):
+        prior = self.modes.get(mode, {})
         self.modes[mode] = {
+            **prior,
             "available": True,
             "transport": transport,
             "document_count": doc_count,
@@ -573,6 +800,18 @@ async def run_write_phase(session, mode, rec, registered):
                     rec.record(
                         mode, "remarkable_delete", PASS, f"deleted {len(delete_states)} item(s)"
                     )
+
+        # SSH writes above are intentionally deferred. Refresh exactly once,
+        # after cleanup metadata is on disk, then the mode-level tablet probe
+        # confirms a fresh SSH session still succeeds after the xochitl restart.
+        if is_ssh and "remarkable_refresh" in registered:
+            payload, is_err, exc = await call_tool(
+                session, "remarkable_refresh", {}, TIMEOUTS["remarkable_refresh"]
+            )
+            state, note = classify_ok(payload, is_err, exc)
+            rec.record(
+                mode, "remarkable_refresh", state, note, _detail_for("remarkable_refresh", payload)
+            )
     finally:
         tmp_pdf.unlink(missing_ok=True)
 
@@ -593,16 +832,32 @@ async def run_mode(mode: str, rec: Recorder, read_only: bool):
         return
 
     spec = MODES[mode]
-    env = {**os.environ, "REMARKABLE_SKIP_CONFIRM": "1", **spec["env"]}
+    env = {
+        **os.environ,
+        "PYTHONFAULTHANDLER": "1",
+        "REMARKABLE_SKIP_CONFIRM": "1",
+        "REMARKABLE_SSH_TRACE": "1",
+        **spec["env"],
+    }
+    server_args = ["server.py", *spec["args"]]
+    if read_only:
+        server_args.append("--read-only")
     params = StdioServerParameters(
-        command="uv",
-        args=["run", "python", "server.py", *spec["args"]],
+        # The smoke harness itself runs under ``uv run``, so sys.executable is
+        # already the project interpreter. Launch it directly rather than through
+        # another uv wrapper: the process handle then exposes the Python server's
+        # real return code/signal instead of uv's success-shaped wrapper status.
+        command=sys.executable,
+        args=server_args,
         env=env,
         cwd=str(REPO_ROOT),
     )
 
+    diagnostics = None
+    if mode == "ssh":
+        rec.modes.setdefault(mode, {})["tablet_before"] = _tablet_diagnostics()
     try:
-        async with stdio_client(params) as (read, write):
+        async with diagnostic_stdio_client(params) as (read, write, diagnostics):
             async with ClientSession(read, write) as session:
                 await asyncio.wait_for(session.initialize(), 60)
 
@@ -644,7 +899,17 @@ async def run_mode(mode: str, rec: Recorder, read_only: bool):
                 else:
                     await run_write_phase(session, mode, rec, registered)
     except Exception as exc:  # noqa: BLE001
-        rec.mode_unavailable(mode, f"server launch/session error: {type(exc).__name__}: {exc}")
+        if mode not in rec.modes or not rec.modes[mode].get("available"):
+            rec.mode_unavailable(mode, f"server launch/session error: {type(exc).__name__}: {exc}")
+        else:
+            rec.modes[mode]["session_error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        data = rec.modes.setdefault(mode, {})
+        if diagnostics is not None:
+            data["server_process"] = diagnostics.snapshot()
+        data["host_after"] = _host_diagnostics()
+        if mode == "ssh":
+            data["tablet_after"] = _tablet_diagnostics()
 
 
 def print_report(rec: Recorder, modes: list[str], started: str) -> bool:
@@ -656,6 +921,24 @@ def print_report(rec: Recorder, modes: list[str], started: str) -> bool:
     for mode in modes:
         data = rec.modes.get(mode, {})
         print(f"\n### MODE: {mode}")
+        process = data.get("server_process", {})
+        returncode = process.get("returncode")
+        process_failed = returncode not in (None, 0)
+        if process_failed:
+            any_fail = True
+            signal = process.get("signal")
+            suffix = f" (signal {signal})" if signal is not None else ""
+            print(f"    SERVER PROCESS EXIT: returncode={returncode}{suffix}")
+
+        tablet_after = data.get("tablet_after")
+        tablet_probe_failed = isinstance(tablet_after, dict) and (
+            tablet_after.get("error") is not None or tablet_after.get("returncode") not in (None, 0)
+        )
+        if tablet_probe_failed:
+            any_fail = True
+            detail = tablet_after.get("error") or tablet_after.get("stderr") or "unknown error"
+            print(f"    POST-RUN TABLET PROBE FAILED: {detail}")
+
         if not data.get("available"):
             print(f"  UNAVAILABLE -- {data.get('reason', 'unknown')}  (all tools SKIPped)")
             continue
@@ -670,6 +953,10 @@ def print_report(rec: Recorder, modes: list[str], started: str) -> bool:
                 any_fail = True
             note = entry.get("note", "")
             print(f"    {GLYPH.get(st, st):10} {tool:22} {note}")
+        session_error = data.get("session_error")
+        if session_error:
+            any_fail = True
+            print(f"    SERVER SESSION ERROR: {session_error}")
 
     # Matrix summary
     print(f"\n{line}\nSUMMARY MATRIX (rows=tools, cols=modes)\n{line}")

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -282,14 +282,15 @@ async def diagnostic_stdio_client(params):
     import mcp.client.stdio as stdio_module
 
     diagnostics = ProcessDiagnostics()
-    original_create = stdio_module._create_platform_compatible_process
+    original_create = getattr(stdio_module, "_create_platform_compatible_process", None)
 
     async def _capture_process(**kwargs):
         process = await original_create(**kwargs)
         diagnostics.attach(process)
         return process
 
-    stdio_module._create_platform_compatible_process = _capture_process
+    if original_create is not None:
+        stdio_module._create_platform_compatible_process = _capture_process
     try:
         with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as errlog:
             try:
@@ -298,7 +299,8 @@ async def diagnostic_stdio_client(params):
             finally:
                 await diagnostics.finish(errlog)
     finally:
-        stdio_module._create_platform_compatible_process = original_create
+        if original_create is not None:
+            stdio_module._create_platform_compatible_process = original_create
 
 
 def _run_diagnostic_command(args: list[str], timeout: int = 10) -> dict[str, Any]:

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -291,7 +291,7 @@ async def diagnostic_stdio_client(params):
 
     stdio_module._create_platform_compatible_process = _capture_process
     try:
-        with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as errlog:
+        with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as errlog:
             try:
                 async with stdio_module.stdio_client(params, errlog=errlog) as streams:
                     yield (*streams, diagnostics)
@@ -303,7 +303,13 @@ async def diagnostic_stdio_client(params):
 
 def _run_diagnostic_command(args: list[str], timeout: int = 10) -> dict[str, Any]:
     try:
-        result = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=timeout,
+        )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return {"error": f"{type(exc).__name__}: {exc}"}
     return {

--- a/test_server.py
+++ b/test_server.py
@@ -4222,13 +4222,15 @@ class TestSSHCacheConcurrency:
     class AttemptLock:
         def __init__(self):
             self._lock = threading.RLock()
+            self._counter_lock = threading.Lock()
             self.acquisitions = 0
             self.second_attempted = threading.Event()
 
         def __enter__(self):
-            self.acquisitions += 1
-            if self.acquisitions == 2:
-                self.second_attempted.set()
+            with self._counter_lock:
+                self.acquisitions += 1
+                if self.acquisitions == 2:
+                    self.second_attempted.set()
             self._lock.acquire()
             return self
 

--- a/test_server.py
+++ b/test_server.py
@@ -3182,6 +3182,63 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
+    async def test_permanent_delete_rejects_non_empty_folder(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+
+        try:
+            folder = Mock()
+            folder.VissibleName = "Smoke Folder"
+            folder.ID = "folder-123"
+            folder.Parent = ""
+            folder.is_folder = True
+            child = Mock()
+            child.VissibleName = "Child"
+            child.ID = "child-123"
+            child.Parent = folder.ID
+            child.is_folder = False
+
+            mock_client = Mock(
+                spec=[
+                    "get_meta_items",
+                    "_documents",
+                    "_documents_by_id",
+                    "host",
+                    "user",
+                    "port",
+                    "password",
+                ]
+            )
+            mock_client.get_meta_items.return_value = [folder, child]
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi", return_value=mock_client),
+                patch("remarkable_mcp.write_tools._permanently_delete_ssh_entry") as mock_purge,
+                patch.dict(
+                    os.environ,
+                    {"REMARKABLE_USE_SSH": "1", "REMARKABLE_SKIP_CONFIRM": "1"},
+                ),
+            ):
+                result = await mcp.call_tool(
+                    "remarkable_delete",
+                    {"document": "Smoke Folder", "permanent": True},
+                )
+                data = json.loads(result[0][0].text)
+
+            assert data["_error"]["type"] == "folder_not_empty"
+            mock_purge.assert_not_called()
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
     async def test_managed_write_tools_registered_in_cloud_mode(self):
         """Cloud mode now has full write parity: mkdir/move/rename/delete register."""
         from remarkable_mcp.write_tools import register_write_tools
@@ -6122,6 +6179,17 @@ class TestDeferRestart:
 
         assert client._documents == []
         assert client._documents_by_id == {}
+        assert client._file_type_cache is None
+
+    def test_local_dir_invalidation_preserves_reload_sentinel(self, tmp_path):
+        from remarkable_mcp.local_dir import LocalDirClient
+        from remarkable_mcp.write_tools import _invalidate_client_cache
+
+        client = LocalDirClient(tmp_path)
+        client._file_type_cache = {"doc-1": "pdf"}
+
+        _invalidate_client_cache(client)
+
         assert client._file_type_cache is None
 
     @pytest.mark.asyncio

--- a/test_server.py
+++ b/test_server.py
@@ -4324,6 +4324,26 @@ class TestSSHCacheConcurrency:
 
         assert individual_downloads == 0
 
+    def test_failed_file_type_preload_remains_retryable(self):
+        from remarkable_mcp.ssh import SSHClient
+
+        client = SSHClient()
+        attempts = 0
+
+        def fake_command(command, timeout=30):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("transient SSH failure")
+            return '===FILE===doc-1\n{"fileType":"pdf"}\n'
+
+        client._ssh_command = fake_command
+
+        assert client.get_all_file_types() == {}
+        assert client._file_type_cache is None
+        assert client.get_all_file_types() == {"doc-1": "pdf"}
+        assert attempts == 2
+
     def test_file_type_preload_serializes_other_ssh_io(self):
         from remarkable_mcp.ssh import Document, SSHClient
 
@@ -6178,6 +6198,41 @@ class TestDeferRestart:
         assert client.get_doc("doc-2") is None
         assert "doc-2" not in client._file_type_cache
         assert client.get_doc("doc-1") is original
+
+    def test_deferred_cache_reads_documents_after_acquiring_lock(self):
+        from remarkable_mcp.ssh import Document, SSHClient
+        from remarkable_mcp.write_tools import _update_deferred_ssh_cache
+
+        client = SSHClient()
+        stale = Document(
+            id="stale",
+            hash="stale",
+            name="Stale",
+            doc_type="DocumentType",
+        )
+        current = Document(
+            id="current",
+            hash="current",
+            name="Current",
+            doc_type="DocumentType",
+        )
+        client._documents = [stale]
+        client._documents_by_id = {stale.ID: stale}
+
+        class SwapOnEnter:
+            def __enter__(self):
+                client._documents = [current]
+                client._documents_by_id = {current.ID: current}
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        client._metadata_lock = SwapOnEnter()
+
+        _update_deferred_ssh_cache(client, False, remove_id=current.ID)
+
+        assert client._documents == []
+        assert client._documents_by_id == {}
 
     def test_restart_invalidates_deferred_cache(self):
         from remarkable_mcp.ssh import Document, SSHClient

--- a/test_server.py
+++ b/test_server.py
@@ -2804,8 +2804,8 @@ class TestWriteTools:
                 mcp._tool_manager._tools.pop(name, None)
 
     @pytest.mark.asyncio
-    async def test_delete_marks_document_deleted(self):
-        """Test that delete marks the document's metadata as deleted."""
+    async def test_delete_moves_document_to_trash(self):
+        """SSH delete mirrors current-firmware Trash metadata semantics."""
         from remarkable_mcp.write_tools import register_write_tools
 
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
@@ -2863,14 +2863,72 @@ class TestWriteTools:
                     data = json.loads(result[0][0].text)
                     assert data["deleted"] is True
                     assert data["name"] == "Test Doc"
-                    # Verify metadata was written with deleted=True
+                    # Current firmware represents Trash via parent="trash".
                     mock_write_meta.assert_called_once()
                     written_metadata = mock_write_meta.call_args[0][2]
-                    assert written_metadata["deleted"] is True
+                    assert written_metadata["parent"] == "trash"
+                    assert written_metadata["deleted"] is False
+                    assert written_metadata["version"] == 1
                 finally:
                     if "REMARKABLE_USE_SSH" in os.environ:
                         del os.environ["REMARKABLE_USE_SSH"]
                     importlib.reload(remarkable_mcp.api)
+        finally:
+            for name in [
+                "remarkable_upload",
+                "remarkable_mkdir",
+                "remarkable_move",
+                "remarkable_rename",
+                "remarkable_delete",
+            ]:
+                mcp._tool_manager._tools.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_permanent_delete_removes_resolved_ssh_entry(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+
+        try:
+            mock_doc = Mock()
+            mock_doc.VissibleName = "Disposable Test"
+            mock_doc.ID = "doc-123"
+            mock_doc.Parent = ""
+            mock_doc.is_folder = False
+
+            mock_client = Mock(
+                spec=[
+                    "get_meta_items",
+                    "_documents",
+                    "_documents_by_id",
+                    "host",
+                    "user",
+                    "port",
+                    "password",
+                ]
+            )
+            mock_client.get_meta_items.return_value = [mock_doc]
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi", return_value=mock_client),
+                patch("remarkable_mcp.write_tools._permanently_delete_ssh_entry") as mock_purge,
+                patch("remarkable_mcp.write_tools._write_metadata") as mock_write_meta,
+                patch("remarkable_mcp.write_tools._restart_xochitl"),
+                patch.dict(
+                    os.environ,
+                    {"REMARKABLE_USE_SSH": "1", "REMARKABLE_SKIP_CONFIRM": "1"},
+                ),
+            ):
+                result = await mcp.call_tool(
+                    "remarkable_delete",
+                    {"document": "Disposable Test", "permanent": True},
+                )
+                data = json.loads(result[0][0].text)
+
+            assert data["deleted"] is True
+            assert data["permanent"] is True
+            mock_purge.assert_called_once_with(mock_client, "doc-123")
+            mock_write_meta.assert_not_called()
         finally:
             for name in [
                 "remarkable_upload",

--- a/test_server.py
+++ b/test_server.py
@@ -12,7 +12,7 @@ import tempfile
 import threading
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, call, patch
 
@@ -4459,6 +4459,23 @@ class TestExtractionCacheGeneration:
 
 
 class TestSmokeDiagnostics:
+    @pytest.mark.asyncio
+    async def test_stdio_diagnostics_fall_back_without_private_sdk_hook(self, monkeypatch):
+        import mcp.client.stdio as stdio_module
+
+        from smoke.run_smoke import diagnostic_stdio_client
+
+        @asynccontextmanager
+        async def fake_stdio_client(params, errlog):
+            yield "read", "write"
+
+        monkeypatch.delattr(stdio_module, "_create_platform_compatible_process", raising=False)
+        monkeypatch.setattr(stdio_module, "stdio_client", fake_stdio_client)
+
+        async with diagnostic_stdio_client("params") as (read, write, diagnostics):
+            assert (read, write) == ("read", "write")
+            assert diagnostics.process is None
+
     def test_abnormal_server_exit_fails_smoke_verdict(self, capsys):
         from smoke.run_smoke import PASS, Recorder, print_report
 

--- a/test_server.py
+++ b/test_server.py
@@ -9,7 +9,9 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -3683,6 +3685,252 @@ class TestCloudStartupFallback:
             api.reset_client_cache()
 
 
+class TestSSHCacheConcurrency:
+    """Startup resource loading must not duplicate or overlap SSH scans."""
+
+    class AttemptLock:
+        def __init__(self):
+            self._lock = threading.RLock()
+            self.acquisitions = 0
+            self.second_attempted = threading.Event()
+
+        def __enter__(self):
+            self.acquisitions += 1
+            if self.acquisitions == 2:
+                self.second_attempted.set()
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self._lock.release()
+
+    def test_metadata_load_is_single_flight(self):
+        from remarkable_mcp.ssh import SSHClient
+
+        client = SSHClient()
+        lock = self.AttemptLock()
+        client._metadata_lock = lock
+        first_started = threading.Event()
+        release_first = threading.Event()
+        call_count = 0
+        count_lock = threading.Lock()
+
+        def fake_command(command, timeout=30):
+            nonlocal call_count
+            assert "*.metadata" in command
+            with count_lock:
+                call_count += 1
+            first_started.set()
+            assert release_first.wait(2)
+            return '===FILE===doc-1\n{"visibleName":"One","type":"DocumentType","parent":""}\n'
+
+        client._ssh_command = fake_command
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(client.get_meta_items)
+            assert first_started.wait(1)
+            second = executor.submit(client.get_meta_items)
+            assert lock.second_attempted.wait(1)
+            release_first.set()
+            assert [doc.id for doc in first.result(timeout=2)] == ["doc-1"]
+            assert [doc.id for doc in second.result(timeout=2)] == ["doc-1"]
+
+        assert call_count == 1
+
+    def test_file_type_reader_waits_for_batch_preload(self):
+        from remarkable_mcp.ssh import Document, SSHClient
+
+        client = SSHClient()
+        lock = self.AttemptLock()
+        client._file_type_lock = lock
+        preload_started = threading.Event()
+        release_preload = threading.Event()
+        individual_downloads = 0
+
+        def fake_command(command, timeout=30):
+            assert "*.content" in command
+            preload_started.set()
+            assert release_preload.wait(2)
+            return '===FILE===doc-1\n{"fileType":"pdf"}\n'
+
+        def fake_download(remote_path, timeout=60):
+            nonlocal individual_downloads
+            individual_downloads += 1
+            return b'{"fileType":"pdf"}'
+
+        client._ssh_command = fake_command
+        client._scp_download = fake_download
+        doc = Document(id="doc-1", hash="doc-1", name="One", doc_type="DocumentType")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            preload = executor.submit(client.get_all_file_types)
+            assert preload_started.wait(1)
+            reader = executor.submit(client.get_file_type, doc)
+            assert lock.second_attempted.wait(1)
+            assert not reader.done()
+            release_preload.set()
+            assert preload.result(timeout=2) == {"doc-1": "pdf"}
+            assert reader.result(timeout=2) == "pdf"
+
+        assert individual_downloads == 0
+
+    def test_file_type_preload_serializes_other_ssh_io(self):
+        from remarkable_mcp.ssh import Document, SSHClient
+
+        client = SSHClient()
+        lock = self.AttemptLock()
+        client._io_lock = lock
+        preload_started = threading.Event()
+        release_preload = threading.Event()
+
+        def fake_command(command, timeout):
+            if "*.content" in command:
+                preload_started.set()
+                assert release_preload.wait(2)
+                return '===FILE===doc-1\n{"fileType":"pdf"}\n'
+            return ""
+
+        client._ssh_command_unlocked = fake_command
+        client._scp_download_unlocked = lambda remote_path, timeout: b"%PDF"
+        doc = Document(id="doc-1", hash="doc-1", name="One", doc_type="DocumentType")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            preload = executor.submit(client.get_all_file_types)
+            assert preload_started.wait(1)
+            download = executor.submit(client.download_raw_file, doc, "pdf")
+            assert lock.second_attempted.wait(1)
+            assert not download.done()
+            release_preload.set()
+            assert preload.result(timeout=2) == {"doc-1": "pdf"}
+            assert download.result(timeout=2) == b"%PDF"
+
+    def test_upload_serializes_with_file_type_preload(self, monkeypatch, tmp_path):
+        import remarkable_mcp.ssh as ssh_mod
+        from remarkable_mcp.ssh import SSHClient
+
+        client = SSHClient()
+        lock = self.AttemptLock()
+        client._io_lock = lock
+        preload_started = threading.Event()
+        release_preload = threading.Event()
+
+        def fake_command(command, timeout):
+            preload_started.set()
+            assert release_preload.wait(2)
+            return '===FILE===doc-1\n{"fileType":"pdf"}\n'
+
+        monkeypatch.setattr(
+            ssh_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(returncode=0, stdout=b"", stderr=b""),
+        )
+        client._ssh_command_unlocked = fake_command
+        local = tmp_path / "upload.pdf"
+        local.write_bytes(b"%PDF")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            preload = executor.submit(client.get_all_file_types)
+            assert preload_started.wait(1)
+            upload = executor.submit(
+                client._upload_file,
+                str(local),
+                "/home/root/upload.pdf",
+            )
+            assert lock.second_attempted.wait(1)
+            assert not upload.done()
+            release_preload.set()
+            assert preload.result(timeout=2) == {"doc-1": "pdf"}
+            assert upload.result(timeout=2) is None
+
+
+class TestExtractionCacheGeneration:
+    def test_inflight_result_cannot_repopulate_after_mutation(self):
+        from remarkable_mcp.extract import (
+            _cache_extraction_result_if_current,
+            _cache_token,
+            clear_extraction_cache,
+            get_cached_ocr_result,
+        )
+
+        doc_id = "mutated-doc"
+        clear_extraction_cache(doc_id)
+        token = _cache_token(doc_id)
+
+        clear_extraction_cache(doc_id)
+        cached = _cache_extraction_result_if_current(
+            doc_id,
+            {"typed_text": ["stale"], "ocr_backend": None},
+            False,
+            token,
+        )
+
+        assert cached is False
+        assert get_cached_ocr_result(doc_id, include_ocr=False) is None
+
+    def test_current_generation_can_cache_result(self):
+        from remarkable_mcp.extract import (
+            _cache_extraction_result_if_current,
+            _cache_token,
+            clear_extraction_cache,
+            get_cached_ocr_result,
+        )
+
+        doc_id = "current-doc"
+        clear_extraction_cache(doc_id)
+        token = _cache_token(doc_id)
+        result = {"typed_text": ["current"], "ocr_backend": None}
+
+        assert _cache_extraction_result_if_current(doc_id, result, False, token)
+        assert get_cached_ocr_result(doc_id, include_ocr=False) == result
+
+
+class TestSmokeDiagnostics:
+    def test_abnormal_server_exit_fails_smoke_verdict(self, capsys):
+        from smoke.run_smoke import PASS, Recorder, print_report
+
+        rec = Recorder()
+        rec.ensure_mode("ssh", "ssh", 1, "connected")
+        rec.record("ssh", "remarkable_status", PASS)
+        rec.modes["ssh"]["server_process"] = {"returncode": -9, "signal": 9}
+
+        assert print_report(rec, ["ssh"], "now") is True
+        assert "SERVER PROCESS EXIT: returncode=-9 (signal 9)" in capsys.readouterr().out
+
+    def test_session_error_fails_smoke_verdict(self, capsys):
+        from smoke.run_smoke import Recorder, print_report
+
+        rec = Recorder()
+        rec.ensure_mode("ssh", "ssh", 1, "connected")
+        rec.modes["ssh"]["session_error"] = "ClosedResourceError"
+        rec.modes["ssh"]["server_process"] = {"returncode": 0, "signal": None}
+
+        assert print_report(rec, ["ssh"], "now") is True
+        assert "SERVER SESSION ERROR: ClosedResourceError" in capsys.readouterr().out
+
+    def test_pre_status_server_exit_fails_smoke_verdict(self, capsys):
+        from smoke.run_smoke import Recorder, print_report
+
+        rec = Recorder()
+        rec.mode_unavailable("ssh", "status failed")
+        rec.modes["ssh"]["server_process"] = {"returncode": -11, "signal": 11}
+
+        assert print_report(rec, ["ssh"], "now") is True
+        assert "SERVER PROCESS EXIT: returncode=-11 (signal 11)" in capsys.readouterr().out
+
+    def test_post_run_tablet_probe_fails_smoke_verdict(self, capsys):
+        from smoke.run_smoke import Recorder, print_report
+
+        rec = Recorder()
+        rec.ensure_mode("ssh", "ssh", 1, "connected")
+        rec.modes["ssh"]["server_process"] = {"returncode": 0, "signal": None}
+        rec.modes["ssh"]["tablet_after"] = {
+            "returncode": 255,
+            "stderr": "banner exchange timed out",
+        }
+
+        assert print_report(rec, ["ssh"], "now") is True
+        assert "POST-RUN TABLET PROBE FAILED" in capsys.readouterr().out
+
+
 class TestSSHKeyAuth:
     """SSH command construction for key-based / password / agent-free auth."""
 
@@ -5145,6 +5393,65 @@ class TestDeferRestart:
             assert write_tools._maybe_restart_xochitl(client, defer_restart=False) is False
             mock_restart.assert_not_called()
 
+    def test_deferred_cache_tracks_add_update_and_delete(self):
+        from remarkable_mcp.ssh import Document, SSHClient
+        from remarkable_mcp.write_tools import _update_deferred_ssh_cache
+
+        client = SSHClient()
+        original = Document(
+            id="doc-1",
+            hash="doc-1",
+            name="Original",
+            doc_type="DocumentType",
+            parent="",
+        )
+        client._documents = [original]
+        client._documents_by_id = {original.ID: original}
+        client._file_type_cache = {original.ID: "pdf"}
+
+        created = Document(
+            id="doc-2",
+            hash="doc-2",
+            name="Created",
+            doc_type="DocumentType",
+            parent="folder-1",
+        )
+        _update_deferred_ssh_cache(client, False, document=created, file_type="notebook")
+        assert client.get_doc("doc-2") is created
+        assert client.get_file_type(created) == "notebook"
+
+        created.name = "Renamed"
+        created.parent = ""
+        _update_deferred_ssh_cache(client, False, document=created)
+        assert client.get_doc("doc-2").VissibleName == "Renamed"
+        assert client.get_doc("doc-2").Parent == ""
+
+        _update_deferred_ssh_cache(client, False, remove_id="doc-2")
+        assert client.get_doc("doc-2") is None
+        assert "doc-2" not in client._file_type_cache
+        assert client.get_doc("doc-1") is original
+
+    def test_restart_invalidates_deferred_cache(self):
+        from remarkable_mcp.ssh import Document, SSHClient
+        from remarkable_mcp.write_tools import _update_deferred_ssh_cache
+
+        client = SSHClient()
+        doc = Document(
+            id="doc-1",
+            hash="doc-1",
+            name="One",
+            doc_type="DocumentType",
+        )
+        client._documents = [doc]
+        client._documents_by_id = {doc.ID: doc}
+        client._file_type_cache = {doc.ID: "pdf"}
+
+        _update_deferred_ssh_cache(client, True, document=doc)
+
+        assert client._documents == []
+        assert client._documents_by_id == {}
+        assert client._file_type_cache is None
+
     @pytest.mark.asyncio
     async def test_upload_defer_skips_restart_and_flags_pending(self, tmp_path):
         from remarkable_mcp.write_tools import register_write_tools
@@ -5226,6 +5533,64 @@ class TestDeferRestart:
                 data = json.loads(result[0][0].text)
                 assert data["refreshed"] is True
                 mock_restart.assert_called_once_with(client)
+        finally:
+            self._cleanup_tools()
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_invalidates_deferred_cache(self):
+        from remarkable_mcp.ssh import Document, SSHClient
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+        try:
+            client = SSHClient()
+            doc = Document(
+                id="doc-1",
+                hash="doc-1",
+                name="One",
+                doc_type="DocumentType",
+            )
+            client._documents = [doc]
+            client._documents_by_id = {doc.ID: doc}
+            client._file_type_cache = {doc.ID: "pdf"}
+            with (
+                patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                patch(
+                    "remarkable_mcp.write_tools._restart_xochitl",
+                    side_effect=RuntimeError("SSH lost"),
+                ),
+                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            ):
+                result = await mcp.call_tool("remarkable_refresh", {})
+                data = json.loads(result[0][0].text)
+
+            assert data["_error"]["type"] == "refresh_failed"
+            assert client._documents == []
+            assert client._documents_by_id == {}
+            assert client._file_type_cache is None
+        finally:
+            self._cleanup_tools()
+
+    @pytest.mark.asyncio
+    async def test_refresh_client_failure_is_structured(self):
+        from remarkable_mcp.write_tools import register_write_tools
+
+        with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
+            register_write_tools()
+        try:
+            with (
+                patch(
+                    "remarkable_mcp.write_tools.get_rmapi",
+                    side_effect=RuntimeError("client unavailable"),
+                ),
+                patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
+            ):
+                result = await mcp.call_tool("remarkable_refresh", {})
+                data = json.loads(result[0][0].text)
+
+            assert data["_error"]["type"] == "refresh_failed"
+            assert "client unavailable" in data["_error"]["message"]
         finally:
             self._cleanup_tools()
 


### PR DESCRIPTION
Closes #157

## Root cause

The apparent MCP stdio child death was a downstream symptom of excessive SSH subprocess churn against the tablet, not host OOM or a Python exception:

- SSH startup ran duplicate full metadata scans concurrently.
- The 14 MB file-type preload overlapped live read/image downloads.
- Deferred write tools invalidated the whole metadata cache after each mutation, forcing another full-library scan before every following write.
- Repeated read-only reproduction progressed from image timeouts/closed sessions to a host-kernel-observed USB CDC gadget disconnect.

Direct-Python instrumentation found no traceback/OOM and captured orderly server exits; the previous nested `uv` launch had hidden the real Python child status.

## Changes

- Serialize every per-client SSH command, download, and upload behind one re-entrant I/O lock.
- Make metadata and file-type cache fills single-flight.
- Keep deferred batches coherent with precise in-memory add/update/move/rename/delete cache mutations, then invalidate authoritatively after one refresh.
- Prevent in-flight extraction work from repopulating stale cached content after a mutation.
- Invalidate caches and return a structured error if refresh fails.
- Run the SSH smoke write phase with one final deferred `remarkable_refresh`.
- Capture Python return code/signal, stderr/traceback tail, process-tree RSS, host/tablet memory and OOM evidence, tablet load, and pre/post-run SSH probes.
- Fail smoke on session death, abnormal process exit, or failed post-run tablet probe.
- Document why stock-firmware direct SSH writes still require one batched xochitl restart. Cloud sync and USB HTTP update xochitl through their live control planes; controlled no-restart and SIGUSR1 tests did not load a direct write into xochitl's search index.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest test_server.py -v` — 244 passed
- Paper Pro direct USB route, current firmware, ~400 entries:
  - 2/2 read-only SSH smoke runs passed
  - 2/2 deferred-write SSH smoke runs passed, including upload/mkdir/rename/move/author/delete/refresh
  - Python child return code 0, no signal/traceback
  - fresh post-run SSH probe passed every run
  - maximum concurrent SSH I/O: 1
  - exactly one metadata preload per session
  - USB CDC interface remained connected after all four final runs
  - all known prior and current smoke artifacts cleaned up