### PR TITLE
Migrate to stable MCP Python SDK 2.x

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is an MCP (Model Context Protocol) server that provides access to reMarkable tablet data. It's a Python project using FastMCP.
+This is an MCP (Model Context Protocol) server that provides access to reMarkable tablet data. It's a Python project using MCP Python SDK 2.x `MCPServer`.
 
 ## Git Workflow
 
@@ -47,7 +47,7 @@ uv add --dev <package>
 **Always run tests with:**
 
 ```bash
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 For specific test patterns:
@@ -56,10 +56,10 @@ For specific test patterns:
 uv run pytest test_server.py -v -k "TestClassName"
 
 # Run with coverage
-uv run pytest test_server.py -v --cov=server
+uv run pytest -v --cov=remarkable_mcp
 
 # Skip slow tests if any
-uv run pytest test_server.py -v -m "not slow"
+uv run pytest -v -m "not slow"
 ```
 
 **Important:** Tests use `pytest-asyncio` for async testing. All async tests should use the `@pytest.mark.asyncio` decorator.
@@ -89,7 +89,7 @@ uv run ruff check .
 uv run ruff format --check .
 
 # 3. Run tests (REQUIRED - CI will fail without this)
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 **Fix issues automatically:**
@@ -110,7 +110,7 @@ remarkable-mcp/
 ├── server.py              # Entry point (backwards compatible)
 ├── remarkable_mcp/        # Main package
 │   ├── __init__.py
-│   ├── server.py          # FastMCP server initialization
+│   ├── server.py          # MCPServer initialization
 │   ├── api.py             # reMarkable Cloud API helpers
 │   ├── extract.py         # Text extraction utilities
 │   ├── responses.py       # Response formatting
@@ -208,7 +208,7 @@ async def test_with_mock(mock_get_rmapi):
 2. Add tests in `test_server.py`
 3. Update README.md tools table
 4. Update README.md examples if relevant
-5. Run tests: `uv run pytest test_server.py -v`
+5. Run tests: `uv run pytest -v`
 
 ### Updating Dependencies
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,19 +47,19 @@ uv add --dev <package>
 **Always run tests with:**
 
 ```bash
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 For specific test patterns:
 ```bash
 # Run specific test class
-uv run pytest test_server.py -v -k "TestClassName"
+uv run pytest -v -k "TestClassName"
 
 # Run with coverage
-uv run pytest test_server.py -v --cov=server
+uv run pytest -v --cov=remarkable_mcp
 
 # Skip slow tests if any
-uv run pytest test_server.py -v -m "not slow"
+uv run pytest -v -m "not slow"
 ```
 
 **Important:** Tests use `pytest-asyncio` for async testing. All async tests should use the `@pytest.mark.asyncio` decorator.
@@ -89,7 +89,7 @@ uv run ruff check .
 uv run ruff format --check .
 
 # 3. Run tests (REQUIRED - CI will fail without this)
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 **Fix issues automatically:**
@@ -107,24 +107,25 @@ uv run ruff format .
 
 ```
 remarkable-mcp/
-├── server.py              # Entry point (backwards compatible)
-├── remarkable_mcp/        # Main package
-│   ├── __init__.py
-│   ├── server.py          # FastMCP server initialization
-│   ├── api.py             # reMarkable Cloud API helpers
-│   ├── extract.py         # Text extraction utilities
-│   ├── responses.py       # Response formatting
-│   ├── tools.py           # MCP tools with annotations
-│   ├── resources.py       # MCP resources
-│   └── prompts.py         # MCP prompts
-├── test_server.py         # Test suite
-├── pyproject.toml         # Project config and dependencies
-├── README.md              # User documentation (KEEP UPDATED)
-├── RESEARCH_NOTES.md      # Design decisions (do not commit)
-└── .github/
-    ├── copilot-instructions.md  # This file
-    └── workflows/
-        └── publish.yml    # PyPI + MCP Registry publishing
+├── remarkable_mcp/
+│   ├── server.py          # FastMCP server
+│   ├── tools.py           # Read and render tools
+│   ├── write_tools.py     # Write and authoring tools
+│   ├── api.py             # Transport selection
+│   ├── sync.py            # Cloud client
+│   ├── ssh.py             # SSH client
+│   ├── usb_web.py         # USB web client
+│   ├── local_dir.py       # Desktop cache client
+│   ├── extract.py         # Extraction and rendering
+│   └── app_canvas.py      # MCP Apps canvas
+├── test_server.py
+├── test_page_mapping.py
+├── test_local_dir.py
+├── test_integration.py
+├── docs/
+├── smoke/
+├── server.json
+└── pyproject.toml
 ```
 
 ## Documentation Requirements
@@ -138,9 +139,9 @@ remarkable-mcp/
 5. **Dependencies** - Note any new required system dependencies (e.g., Tesseract for OCR)
 
 When modifying `server.py`:
-- If you add a new tool → Update README tools table and examples
-- If you change tool parameters → Update README examples
-- If you add new dependencies → Update README installation section
+- If you add a tool, update the README tool table and examples.
+- If you change tool parameters, update examples and `docs/tools.md`.
+- If you add a dependency, update installation and development docs.
 
 ## MCP Tool Design Principles
 
@@ -173,14 +174,24 @@ def remarkable_example(param: str) -> str:
 ## Key Dependencies
 
 - `mcp` - Model Context Protocol SDK
-- `requests` - HTTP client for reMarkable Cloud API
-- `rmscene` - Native .rm file parser for text extraction (v3+ format)
-- `pytesseract` - OCR for handwritten content
-- `rmc` - reMarkable file conversion utilities
+- `requests` - HTTP client
+- `rmscene` - Native `.rm` parser
+- `pymupdf` - PDF and SVG rendering
+- `Pillow` - Image processing
+- `markdown-it-py` - Markdown parsing
+- `ebooklib` and `beautifulsoup4` - EPUB extraction
+- `pytesseract` - Optional local OCR
 
 ## Environment Variables
 
-- `REMARKABLE_TOKEN` - Authentication token for reMarkable Cloud
+- `REMARKABLE_TOKEN` - Optional cloud credential
+- `REMARKABLE_LOCAL_DIR` - Desktop cache or xochitl-style directory
+- `REMARKABLE_USB_HOST` - USB web URL
+- `REMARKABLE_SSH_HOST`, `REMARKABLE_SSH_USER`, `REMARKABLE_SSH_PORT` - SSH target
+- `REMARKABLE_SSH_KEY` - Explicit SSH private key
+- `REMARKABLE_READ_ONLY` - Disable write tools
+- `REMARKABLE_ROOT_PATH` - Scope access to one folder
+- `REMARKABLE_OCR_BACKEND` - OCR backend selection
 
 ## Testing Patterns
 
@@ -208,7 +219,7 @@ async def test_with_mock(mock_get_rmapi):
 2. Add tests in `test_server.py`
 3. Update README.md tools table
 4. Update README.md examples if relevant
-5. Run tests: `uv run pytest test_server.py -v`
+5. Run tests: `uv run pytest -v`
 
 ### Updating Dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
-        run: uv run pytest test_server.py -v
+        run: uv run pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,23 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
-        run: uv run pytest test_server.py -v
+        run: uv run pytest -v
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build wheel and source distribution
+        run: uv build
+
+      - name: Install built wheel
+        run: uv run --isolated --no-project --with dist/*.whl remarkable-mcp --help

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,4 +1,4 @@
-name: Conformance Test
+name: MCP Interface Conformance
 
 on:
   workflow_dispatch:
@@ -27,7 +27,12 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - uses: SamMorrowDrums/mcp-conformance-action@v3
+      - uses: SamMorrowDrums/mcp-server-diff@v3
         with:
-          install_command: uv sync
+          install_command: uv sync --frozen
           start_command: uv run python server.py
+          server_timeout: "30"
+          fail_on_diff: "false"
+          # Keep the probe hermetic: registration never reaches a real account.
+          env_vars: |
+            REMARKABLE_TOKEN={}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         run: uv sync --extra dev
       
       - name: Run tests
-        run: uv run pytest test_server.py -v
+        run: uv run pytest -v
       
       - name: Run linting
         run: uv run ruff check .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   create-release:
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -44,16 +45,19 @@ jobs:
         run: uv python install 3.12
       
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --all-extras
       
       - name: Run tests
-        run: uv run pytest test_server.py -v
+        run: uv run pytest -v
       
       - name: Run linting
         run: uv run ruff check .
 
+      - name: Check formatting
+        run: uv run ruff format --check .
+
   build:
-    needs: [create-release, test]
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,7 +89,7 @@ jobs:
           path: dist/
 
   publish-pypi:
-    needs: build
+    needs: [build, create-release]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Your reMarkable tablet is a powerful tool for thinking, note-taking, and researc
 - **Portable page rendering** — Renders notebook SVG and PDF pages with bundled Python dependencies only, then automatically falls back to a source PDF when local stroke parsing can't handle a page (USB/SSH use the tablet's own PDF export; cloud uses the original source PDF)
 - **Markdown writeback** — Render Markdown as a paginated PDF and upload it with a chosen document name
 - **OpenWebUI integration** — Run a local Streamable HTTP endpoint without a separate bridge script
+- **MCP 2026 compatibility** — Built on the stable MCP Python SDK 2.x; one
+  `MCPServer` handles 2026-07-28 requests and every earlier SDK-supported
+  protocol revision
 - **Smart search** — Find content across your entire library
 - **Second brain integration** — Use with Obsidian, note-taking apps, or any AI workflow
 
@@ -351,6 +354,12 @@ uvx remarkable-mcp --usb --http
 The bind address and port can also be set with `--host` / `--port` or
 `REMARKABLE_MCP_HOST` / `REMARKABLE_MCP_PORT`.
 
+The server uses MCP Python SDK 2.x's dual-era endpoint. Modern
+`2026-07-28` requests are sessionless; older clients continue to use the
+initialize handshake and legacy MCP sessions on the same `/mcp` route. The
+reMarkable token and selected tablet transport remain process-local CLI/env
+configuration and are never inferred from MCP HTTP authorization headers.
+
 > [!WARNING]
 > Streamable HTTP has **no built-in authentication**. It binds to
 > `127.0.0.1` by default and is intended for a local OpenWebUI instance. A
@@ -362,7 +371,7 @@ The bind address and port can also be set with `--host` / `--port` or
 ### Remote access through an authenticated reverse proxy
 
 Keep remarkable-mcp on its default loopback bind and put the proxy on the same
-host. FastMCP's DNS-rebinding protection only permits loopback `Host` and
+host. MCPServer's DNS-rebinding protection only permits loopback `Host` and
 `Origin` values by default. A proxy that forwards its public hostname unchanged
 will therefore receive **421 Misdirected Request**; a public browser `Origin`
 will receive **403 Forbidden**.
@@ -380,7 +389,7 @@ location /mcp {
     proxy_buffering off;
     proxy_read_timeout 3600s;
 
-    # Required by FastMCP's default DNS-rebinding protection.
+    # Required by MCPServer's default DNS-rebinding protection.
     proxy_set_header Host 127.0.0.1:8000;
     proxy_set_header Origin "";
 }
@@ -553,6 +562,11 @@ Set `REMARKABLE_OCR_BACKEND` in your MCP config:
 
 Uses your MCP client's AI model for OCR. Works with clients that support MCP sampling (VS Code + Copilot, Claude Desktop, etc.).
 
+On modern `2026-07-28` connections, the server returns a multi-round input
+request and the client retries the tool with the sampled OCR result. On legacy
+connections, the same resolver uses the established server-to-client sampling
+request. This compatibility routing is handled by MCP SDK 2.x.
+
 **Pros:**
 - No additional API keys needed
 - Quality depends on your client's model (GPT-4, Claude, etc.)
@@ -693,7 +707,7 @@ Or set the environment variable:
 
 - **Upload registers in cloud, SSH, and USB web mode** — local-directory mode never exposes write tools.
 - **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
-- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
+- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. MCP SDK 2.x carries that prompt as a multi-round input request for `2026-07-28` clients and as push elicitation for legacy clients. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(read_only_hint=False)` (and `destructive_hint=True` for delete) so an agent harness can gate writes at the MCP layer.
 - After each write operation in SSH mode, the tablet UI (`xochitl`) restarts automatically to reflect changes; the call waits for it to come back before returning so the next write doesn't race a restarting daemon. For bulk operations, pass `defer_restart=True` to each write — or set `REMARKABLE_DEFER_RESTART=1` — and call `remarkable_refresh()` once at the end, so the batch triggers a single restart instead of one per write (each restart forces a full document-store rescan).
 
 ### Examples
@@ -751,7 +765,7 @@ remarkable_author(method="create_document", name="Meeting notes", text="Agenda\n
 
 An interactive page viewer built on the [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) extension (SEP-1865). Clients that support MCP Apps (such as ChatGPT, Claude, VS Code, and the MCP Inspector) render a canvas in a side panel where you can view a document page and navigate through it.
 
-There is **no flag to enable it** — the `remarkable_canvas` tool and its `ui://remarkable/canvas` resource are always registered, and the capability is negotiated automatically at the MCP `initialize` handshake. App-capable clients open the interactive canvas; every other client simply receives the rendered page as an image, so the tool is safe and useful everywhere.
+There is **no flag to enable it** — the `remarkable_canvas` tool and its `ui://remarkable/canvas` resource are always registered, and the capability is negotiated automatically in client capabilities (modern discovery or a legacy initialize handshake). App-capable clients open the interactive canvas; every other client simply receives the rendered page as an image, so the tool is safe and useful everywhere.
 
 This registers one tool:
 
@@ -761,7 +775,7 @@ This registers one tool:
 
 How it behaves:
 
-- **App-capable clients** open the canvas (declared at `ui://remarkable/canvas`, MIME `text/html;profile=mcp-app`) and can page through the document via the MCP Apps postMessage bridge — the server delivers each rendered page in the tool result's `structuredContent`.
+- **App-capable clients** open the canvas (declared at `ui://remarkable/canvas`, MIME `text/html;profile=mcp-app`) and can page through the document via the MCP Apps postMessage bridge — the server delivers each rendered page in the wire result's `structuredContent` (`structured_content` in Python).
 - **Other clients** still get the rendered page back as an embedded PNG image, so the tool is useful everywhere; it just won't open the interactive panel. The `_meta.ui` / `ui://` metadata is inert to clients that don't advertise the MCP Apps UI extension.
 
 ### Drawing and authoring from the canvas
@@ -907,7 +921,7 @@ Treat your reMarkable as a second brain that AI can access. Combined with tools 
 git clone https://github.com/SamMorrowDrums/remarkable-mcp.git
 cd remarkable-mcp
 uv sync --all-extras
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 📖 **[Development Guide](docs/development.md)**

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
 # reMarkable MCP Server
 
-Unlock the full potential of your reMarkable tablet as a **second brain** for AI assistants. This MCP server lets Claude, VS Code Copilot, and other AI tools read, search, and traverse your entire reMarkable library — including handwritten notes via OCR.
+Access a reMarkable library from MCP clients such as Claude, VS Code Copilot,
+OpenWebUI, and other compatible tools.
 
 <!-- mcp-name: io.github.SamMorrowDrums/remarkable -->
 
-## Why remarkable-mcp?
+## Features
 
-Your reMarkable tablet is a powerful tool for thinking, note-taking, and research. But that knowledge stays trapped on the device. This MCP server changes that:
-
-- **Full library access** — Browse folders, search documents, read any file
-- **Typed text extraction** — Native support for Type Folio and typed annotations
-- **Handwriting OCR** — Convert handwritten notes to searchable text
-- **PDF & EPUB support** — Extract text plus an index of annotated pages, highlights, and notes
-- **Portable page rendering** — Renders notebook SVG and PDF pages with bundled Python dependencies only, then automatically falls back to a source PDF when local stroke parsing can't handle a page (USB/SSH use the tablet's own PDF export; cloud uses the original source PDF)
-- **Markdown writeback** — Render Markdown as a paginated PDF and upload it with a chosen document name
-- **OpenWebUI integration** — Run a local Streamable HTTP endpoint without a separate bridge script
-- **Smart search** — Find content across your entire library
-- **Second brain integration** — Use with Obsidian, note-taking apps, or any AI workflow
-
-Whether you're researching, writing, or developing ideas, remarkable-mcp lets you leverage everything on your reMarkable through AI.
+- Browse folders and recent documents.
+- Search names, tags, and extracted text.
+- Read typed text, PDF and EPUB text, highlights, and annotations.
+- Render notebooks and annotated PDFs as PNG or SVG.
+- Run handwriting OCR through MCP sampling, Google Vision, or Tesseract.
+- Upload files and manage folders in supported transports.
+- Render Markdown as PDF and upload it to the tablet.
+- Open an interactive canvas in clients that support MCP Apps.
+- Serve MCP over stdio or local Streamable HTTP.
 
 ---
 
@@ -58,25 +55,30 @@ Or install with WinGet:
 winget install --id=astral-sh.uv -e
 ```
 
-### 🔌 USB Web Interface (Recommended)
+### Choose a connection
+
+Start with the first mode that fits your setup.
+
+| Order | Mode | Setup | Writes | Use when |
+|---:|---|---|---|---|
+| 1 | USB web | Connect the tablet and enable USB web | Upload to root | You want the shortest setup without a subscription or developer mode |
+| 2 | Local directory | Install and sign in to the desktop app | No | You want offline, device-free reads from the desktop cache |
+| 3 | Cloud | Register once; Connect subscription required | Full document and folder management | You need wireless or remote access |
+| 4 | SSH | Enable developer mode and configure SSH | Full management and native authoring | You need direct filesystem access or native ink writes |
+
+### USB Web Interface
 
 Connect via USB and enable the web interface in your tablet's Storage Settings.
 
 [![Install USB Web Mode in VS Code](https://img.shields.io/badge/VS_Code-Install_USB_Web_Mode-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=remarkable&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22google_vision_api_key%22%2C%22description%22%3A%22Google%20Vision%20API%20Key%20(for%20handwriting%20OCR)%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22remarkable-mcp%22%2C%22--usb%22%5D%2C%22env%22%3A%7B%22GOOGLE_VISION_API_KEY%22%3A%22%24%7Binput%3Agoogle_vision_api_key%7D%22%7D%7D)
 [![Install USB Web Mode in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_USB_Web_Mode-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=remarkable&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22google_vision_api_key%22%2C%22description%22%3A%22Google%20Vision%20API%20Key%20(for%20handwriting%20OCR)%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22remarkable-mcp%22%2C%22--usb%22%5D%2C%22env%22%3A%7B%22GOOGLE_VISION_API_KEY%22%3A%22%24%7Binput%3Agoogle_vision_api_key%7D%22%7D%7D&quality=insiders)
 
-**Setup:**
 1. Connect your reMarkable via USB
-2. On your tablet: **Settings → Storage** → Enable **"USB web interface"**
+2. On your tablet, open **Settings > Storage** and enable **USB web interface**
 3. Install via the button above
 
-**Why USB Web?**
-- ✅ Fast offline access over USB
-- ✅ No subscription required
-- ✅ Simple — just enable in Storage Settings
-
 <details>
-<summary>📋 Manual USB Web Configuration</summary>
+<summary>Manual USB web configuration</summary>
 
 Add to `.vscode/mcp.json`:
 
@@ -94,55 +96,21 @@ Add to `.vscode/mcp.json`:
 }
 ```
 
-**Troubleshooting:**
 - Make sure your reMarkable is connected via USB and unlocked
-- Verify USB web interface is enabled in Settings → Storage
+- Verify USB web interface is enabled in Settings > Storage
 - The tablet should be accessible at `http://10.11.99.1`
 
 </details>
 
 ---
 
-### ⚡ SSH Mode (Advanced)
+### Local Directory Mode
 
-For power users who need direct filesystem access. Faster than USB Web but requires developer mode (factory reset).
-
-[![Install SSH Mode in VS Code](https://img.shields.io/badge/VS_Code-Install_SSH_Mode-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=remarkable&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22google_vision_api_key%22%2C%22description%22%3A%22Google%20Vision%20API%20Key%20(for%20handwriting%20OCR)%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22remarkable-mcp%22%2C%22--ssh%22%5D%2C%22env%22%3A%7B%22GOOGLE_VISION_API_KEY%22%3A%22%24%7Binput%3Agoogle_vision_api_key%7D%22%7D%7D)
-[![Install SSH Mode in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_SSH_Mode-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=remarkable&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22google_vision_api_key%22%2C%22description%22%3A%22Google%20Vision%20API%20Key%20(for%20handwriting%20OCR)%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22remarkable-mcp%22%2C%22--ssh%22%5D%2C%22env%22%3A%7B%22GOOGLE_VISION_API_KEY%22%3A%22%24%7Binput%3Agoogle_vision_api_key%7D%22%7D%7D&quality=insiders)
-
-**Requirements:** [Developer mode enabled](docs/ssh-setup.md) + USB connection to your reMarkable
+Read the official reMarkable desktop app's sync folder from disk. This mode is
+offline and read-only. The desktop app controls synchronization.
 
 <details>
-<summary>📋 Manual SSH Configuration</summary>
-
-Add to `.vscode/mcp.json`:
-
-```json
-{
-  "servers": {
-    "remarkable": {
-      "command": "uvx",
-      "args": ["remarkable-mcp", "--ssh"],
-      "env": {
-        "GOOGLE_VISION_API_KEY": "your-api-key"
-      }
-    }
-  }
-}
-```
-
-See [SSH Setup Guide](docs/ssh-setup.md) for detailed instructions.
-
-</details>
-
----
-
-### 💻 Local Directory Mode (Desktop App)
-
-Read the official **reMarkable desktop app's** sync folder straight from disk — fully offline, no cable, no cloud round-trip, and the tablet doesn't even need to be on. The desktop app keeps the folder synced whenever it is running. Strictly read-only.
-
-<details>
-<summary>📋 Local Directory Configuration</summary>
+<summary>Local directory configuration</summary>
 
 Add to `.vscode/mcp.json`:
 
@@ -177,23 +145,23 @@ Or point at any xochitl-style directory (e.g. a tablet backup):
 }
 ```
 
-**Notes:**
-- Content freshness depends on the desktop app syncing — keep it running and signed in
-- This mode is read-only by design: the folder is the desktop app's private sync cache, and writing to it directly would bypass sync and could corrupt the app's state
+- Content freshness depends on the desktop app. Keep it running and signed in.
+- This mode is read-only. Direct writes could bypass synchronization and corrupt the app cache.
 - If the directory can't be found and a cloud token is configured, the server falls back to cloud mode for read access (the server remains read-only because it was launched in local-directory mode)
 
 </details>
 
 ---
 
-### ☁️ Cloud Mode (Wireless)
+### Cloud Mode
 
-Wireless access with **no device connection required** — your reMarkable syncs to the cloud and the MCP reads from there, so it works from anywhere. Requires a reMarkable Connect subscription.
+Cloud mode works without a device connection and requires a reMarkable Connect subscription.
 
-Cloud mode fetches your whole library in parallel and caches content-addressed blobs on disk, so after the first run startups and document reads are near-instant (a 388-document library lists in ~4s cold, ~0.5s warm). See [Cloud Performance & Caching](#cloud-performance--caching) to tune it.
+It fetches metadata in parallel and caches content-addressed blobs on disk. See
+[Cloud performance and caching](#cloud-performance--caching) for configuration.
 
 <details>
-<summary>📋 Cloud Mode Setup</summary>
+<summary>Cloud mode setup</summary>
 
 #### 1. Get a One-Time Code
 
@@ -207,10 +175,7 @@ uvx remarkable-mcp --register YOUR_CODE
 
 Registration saves the token to `~/.rmapi`. When your MCP client runs the server as the same user on the same machine, remarkable-mcp reads that file automatically, so you do not need to put a token in the client configuration. Set `REMARKABLE_TOKEN` only when `~/.rmapi` is unavailable, such as when the server runs under another user or on another machine.
 
-#### 3. Install
-
-[![Install Cloud Mode in VS Code](https://img.shields.io/badge/VS_Code-Install_Cloud_Mode-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=remarkable&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22token%22%2C%22description%22%3A%22reMarkable%20API%20token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22google_vision_api_key%22%2C%22description%22%3A%22Google%20Vision%20API%20Key%20(for%20handwriting%20OCR)%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22remarkable-mcp%22%5D%2C%22env%22%3A%7B%22REMARKABLE_TOKEN%22%3A%22%24%7Binput%3Atoken%7D%22%2C%22GOOGLE_VISION_API_KEY%22%3A%22%24%7Binput%3Agoogle_vision_api_key%7D%22%7D%7D)
-[![Install Cloud Mode in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Cloud_Mode-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=remarkable&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22token%22%2C%22description%22%3A%22reMarkable%20API%20token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22google_vision_api_key%22%2C%22description%22%3A%22Google%20Vision%20API%20Key%20(for%20handwriting%20OCR)%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22remarkable-mcp%22%5D%2C%22env%22%3A%7B%22REMARKABLE_TOKEN%22%3A%22%24%7Binput%3Atoken%7D%22%2C%22GOOGLE_VISION_API_KEY%22%3A%22%24%7Binput%3Agoogle_vision_api_key%7D%22%7D%7D&quality=insiders)
+#### 3. Configure your MCP client
 
 ##### Minimal client-neutral server definition
 
@@ -227,32 +192,15 @@ No `env` entry is needed when the server can read the token from `~/.rmapi`.
 
 ##### VS Code
 
-VS Code's `.vscode/mcp.json` uses a top-level `servers` object. It also supports a top-level `inputs` array and `${input:...}` placeholders for values that VS Code should prompt for:
+VS Code's `.vscode/mcp.json` uses a top-level `servers` object. The saved
+`~/.rmapi` credential means no token input is required:
 
 ```json
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "remarkable-token",
-      "description": "reMarkable API Token",
-      "password": true
-    },
-    {
-      "type": "promptString",
-      "id": "google-vision-key",
-      "description": "Google Vision API Key",
-      "password": true
-    }
-  ],
   "servers": {
     "remarkable": {
       "command": "uvx",
-      "args": ["remarkable-mcp"],
-      "env": {
-        "REMARKABLE_TOKEN": "${input:remarkable-token}",
-        "GOOGLE_VISION_API_KEY": "${input:google-vision-key}"
-      }
+      "args": ["remarkable-mcp"]
     }
   }
 }
@@ -279,6 +227,28 @@ If the token file is unavailable, add `"env": {"REMARKABLE_TOKEN": "your-token"}
 
 ---
 
+### SSH Mode
+
+SSH provides direct filesystem access and native notebook authoring. It requires
+[developer mode](docs/ssh-setup.md), which factory-resets the tablet when enabled.
+Use this mode only when USB web, local directory, or cloud mode does not provide the
+operation you need.
+
+```json
+{
+  "servers": {
+    "remarkable": {
+      "command": "uvx",
+      "args": ["remarkable-mcp", "--ssh"]
+    }
+  }
+}
+```
+
+See the [SSH setup guide](docs/ssh-setup.md) for authentication and device setup.
+
+---
+
 <!-- Screenshots section - uncomment when screenshots are added
 ## Screenshots
 
@@ -299,19 +269,16 @@ AI assistants use the tools to read documents, search content, and more:
 
 ## Connection Modes
 
-All four modes support reading and rendering. **Cloud and SSH support full library management**, USB web supports upload-to-root, and local-directory mode is strictly read-only:
+All modes support reading and rendering. Cloud and SSH support full library
+management. USB web supports upload to the root folder. Local directory mode is
+read-only.
 
-- **💻 Local Directory** — *device-free AND offline.* Reads the official desktop app's sync folder straight from disk — no cable, no cloud round-trip, no subscription beyond what the app itself needs, and the tablet can be off. Read/render only (the folder is the app's private sync cache, so writes are disabled by design). Best when the desktop app is already part of your workflow.
-- **☁️ Cloud** — *device-free, works from anywhere.* Reads your library straight from reMarkable's cloud over Wi‑Fi with a Connect subscription — no cable, no developer mode. Full read/render plus full write (upload, create folder, move, rename, delete → trash). Parallel fetching and an on-disk blob cache make it fast after the first sync. Best for remote/headless setups or when you don't want to plug in.
-- **🔌 USB Web Interface** — *best when the tablet is plugged in.* Enable the web interface in Storage Settings — no subscription, no developer mode. Full read/render plus upload (to your root folder). The tablet's USB web firmware exposes no folder/move/rename/delete endpoints, so for those over a cable use SSH.
-- **⚡ SSH** — *for power users who want filesystem-level access.* Requires developer mode over USB. Full read/render plus full write including folder create/move/rename/delete, straight from the tablet filesystem.
-
-| Mode | Setup | Subscription | Offline | Tablet needed | Read + render | Raw PDF/EPUB | Upload | Folder ops¹ |
-|------|-------|--------------|---------|---------------|---------------|--------------|--------|-------------|
-| **💻 Local Dir** | Desktop app installed | Not required² | ✅ | ❌ | ✅ | ✅ PDF/EPUB | ❌ | ❌ |
-| **☁️ Cloud** | One-time code | Connect | ❌ | ❌ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
-| **🔌 USB Web** | Enable in Settings | Not required | ✅ | ✅ | ✅ | ✅ PDF | ✅ (to root) | ❌ |
-| **⚡ SSH** | Developer mode | Not required | ✅ | ✅ | ✅ | ✅ PDF/EPUB | ✅ | ✅ |
+| Mode | Setup | Subscription | Offline | Tablet required | Raw source | Upload | Folder operations¹ |
+|---|---|---|---|---|---|---|---|
+| Local directory | Desktop app installed | No² | Yes | No | PDF and EPUB | No | No |
+| USB web | Enable in Settings | No | Yes | Yes | PDF | Root only | No |
+| Cloud | One-time registration | Connect | No | No | PDF and EPUB | Yes | Yes |
+| SSH | Developer mode | No | Yes | Yes | PDF and EPUB | Yes | Yes |
 
 ¹ Folder ops = create folder / move / rename / delete. Upload and folder ops are enabled by default; pass `--read-only` to expose a read-only server. Deletes move items to the trash and prompt for confirmation when your client supports elicitation, and are refused without it unless `REMARKABLE_SKIP_CONFIRM=1` is set.
 
@@ -319,16 +286,22 @@ All four modes support reading and rendering. **Cloud and SSH support full libra
 
 ### Automatic cloud fallback
 
-If you select a device transport (`--usb`, `--ssh`, or `--local-dir`) but it isn't reachable at startup **and** a cloud token is configured (`REMARKABLE_TOKEN` or `~/.rmapi`), the server automatically falls back to cloud mode and logs a warning. This means a single configuration works whether or not the tablet is plugged in — plug in for fast local access, unplug to keep working over the cloud. A server launched with `--local-dir` remains read-only after fallback, preserving that mode's safety contract. `remarkable_status` reports the effective transport and a `fell_back_to_cloud` flag when this happens.
+If a selected device transport is unavailable and a cloud credential is configured,
+the server falls back to cloud mode. A server launched with `--local-dir` remains
+read-only after fallback. `remarkable_status` reports the effective transport and
+sets `fell_back_to_cloud`.
 
 Pass `--no-cloud-fallback` (or set `REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) to disable this and fail instead when the device is unreachable.
 
-> **Troubleshooting:** the transport is resolved once and cached for the MCP server's lifetime. If the server fell back to cloud (for example, the desktop app only started syncing after the server launched), **restart the MCP server** to pick up the local directory again — `remarkable_status` shows the active transport and a `fell_back_to_cloud` flag so you can tell when this has happened.
+The transport is resolved once per server process. Restart the MCP server after
+connecting a device or starting the desktop app if the process already fell back to
+cloud.
 
-**📖 Detailed Setup Guides:**
-- [USB Web Interface Setup](docs/usb-web-setup.md) — **recommended** — simple setup, full feature support
-- [SSH Setup Guide](docs/ssh-setup.md) — for advanced users who need filesystem access
-- Cloud setup is documented in the Quick Install section above; tuning in [Cloud Performance & Caching](#cloud-performance--caching)
+Detailed setup:
+
+- [USB web setup](docs/usb-web-setup.md)
+- [SSH setup](docs/ssh-setup.md)
+- [Cloud performance and caching](#cloud-performance--caching)
 
 ---
 
@@ -352,12 +325,11 @@ The bind address and port can also be set with `--host` / `--port` or
 `REMARKABLE_MCP_HOST` / `REMARKABLE_MCP_PORT`.
 
 > [!WARNING]
-> Streamable HTTP has **no built-in authentication**. It binds to
-> `127.0.0.1` by default and is intended for a local OpenWebUI instance. A
-> non-loopback bind such as `--host 0.0.0.0` exposes every enabled tool,
-> including write tools, to any client that can reach the port. The server
-> prints a prominent startup warning in that configuration and accepts only
-> `Host` and `Origin` values matching the explicitly selected bind host.
+> Streamable HTTP has no built-in authentication. It binds to `127.0.0.1` by
+> default. Keep that default unless you control the network boundary. Wildcard
+> binds such as `0.0.0.0` and `::` are rejected because they cannot provide a
+> strict Host allowlist. A concrete non-loopback address is allowed but exposes
+> every enabled tool, including writes, to clients that can reach the port.
 
 ### Remote access through an authenticated reverse proxy
 
@@ -443,18 +415,21 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages (supports OCR via sampling) |
 
-These six tools are **read-only** and return structured JSON with hints for next actions. **Write tools** (`remarkable_upload`, `remarkable_markdown_to_pdf`, `remarkable_mkdir`, `remarkable_move`, `remarkable_rename`, `remarkable_delete`, `remarkable_refresh`, and `remarkable_author` for native ink/notebooks) are enabled by default on transports that support them — pass `--read-only` to disable them — see [Write Tools](#write-tools-by-transport). An interactive **canvas app** (`remarkable_canvas`) is also registered automatically for clients that support [MCP Apps](#interactive-canvas-app-mcp-apps).
+These six tools are read-only and return structured JSON with next-step hints.
+Supported transports also register write tools by default; pass `--read-only` to
+disable them. See [Write Tools](#write-tools-by-transport). Clients that support
+[MCP Apps](#interactive-canvas-app-mcp-apps) can also open `remarkable_canvas`.
 
-📖 **[Full Tools Documentation](docs/tools.md)**
+[Full tools reference](docs/tools.md)
 
-### Smart Features
+### Tool behavior
 
-- **Auto-redirect** — Browsing a document path returns its content automatically
-- **Auto-OCR** — Notebooks with no typed text automatically enable OCR
-- **Batch search** — Search across multiple documents in one call
-- **Vision support** — Get page images for visual context (diagrams, mockups, sketches)
-- **Sampling OCR** — Use client's AI for OCR on images (no API key needed)
-- **Tag support** — Filter and organize documents by tags
+- Browsing a document path returns its content.
+- Empty notebook text can trigger OCR automatically.
+- Search can scan several matching documents.
+- Image tools return visual content that text extraction misses.
+- Sampling OCR uses the connected client's model when supported.
+- Browse and search accept tag filters.
 
 ### Example Usage
 
@@ -493,6 +468,9 @@ remarkable_image("Wireframe", output_format="svg")
 # Get image with OCR text extraction (uses sampling if configured)
 remarkable_image("Handwritten Notes", include_ocr=True)
 
+# Composite an imported PDF page with its reMarkable annotations
+remarkable_image("Research Paper", page=3, render_merged=True)
+
 # Transparent background for compositing
 remarkable_image("Logo Sketch", background="#00000000")
 
@@ -515,12 +493,12 @@ Documents are automatically registered as MCP resources:
 | URI Scheme | Description |
 |------------|-------------|
 | `remarkable:///{path}.txt` | Extracted text content |
-| `remarkableraw:///{path}.pdf` | Original PDF file (SSH only) |
-| `remarkableraw:///{path}.epub` | Original EPUB file (SSH only) |
+| `remarkableraw:///{path}.pdf.txt` | Extracted text from the original PDF |
+| `remarkableraw:///{path}.epub.txt` | Extracted text from the original EPUB |
 | `remarkableimg:///{path}.page-{N}.png` | PNG image of page N (notebooks only) |
 | `remarkablesvg:///{path}.page-{N}.svg` | SVG vector image of page N (notebooks only) |
 
-📖 **[Full Resources Documentation](docs/resources.md)**
+[Full resources reference](docs/resources.md)
 
 ---
 
@@ -528,11 +506,11 @@ Documents are automatically registered as MCP resources:
 
 For handwritten content, remarkable-mcp offers several OCR backends. Choose based on your setup and requirements:
 
-| Backend | Setup | Quality | Offline | Best For |
-|---------|-------|---------|---------|----------|
-| **Sampling** | No API key | Depends on client model | ✅ | Users with capable AI clients |
-| **Google Vision** | API key | Excellent | ❌ | Best handwriting accuracy |
-| **Tesseract** | System install | Poor for handwriting | ✅ | Printed text, offline fallback |
+| Backend | Setup | Offline | Notes |
+|---|---|---|---|
+| Sampling | No API key | Depends on the client | Uses the connected client's model |
+| Google Vision | API key | No | Good handwriting support |
+| Tesseract | System install | Yes | Better suited to printed text |
 
 ### Quick Setup
 
@@ -549,39 +527,32 @@ Set `REMARKABLE_OCR_BACKEND` in your MCP config:
 **Options:** `sampling`, `google`, `tesseract`, `auto`
 
 <details>
-<summary>📖 Sampling OCR (No API Key)</summary>
+<summary>Sampling OCR</summary>
 
 Uses your MCP client's AI model for OCR. Works with clients that support MCP sampling (VS Code + Copilot, Claude Desktop, etc.).
 
-**Pros:**
 - No additional API keys needed
-- Quality depends on your client's model (GPT-4, Claude, etc.)
-- Private — handwriting stays local to your client
-
-**Cons:**
+- Quality and data handling depend on your MCP client and model
 - Only available with sampling-capable clients
 - Falls back to Google Vision (if API key configured) or Tesseract if sampling unavailable
 
 </details>
 
 <details>
-<summary>📖 Google Cloud Vision</summary>
+<summary>Google Cloud Vision</summary>
 
-Provides consistently excellent handwriting recognition.
-
-**Setup:**
 1. Enable [Cloud Vision API](https://console.cloud.google.com/apis/library/vision.googleapis.com)
 2. Create an [API key](https://console.cloud.google.com/apis/credentials)
 3. Add to config: `"GOOGLE_VISION_API_KEY": "your-key"`
 
 **Cost:** 1,000 free requests/month, then ~$1.50 per 1,000.
 
-📖 **[Full Google Vision Setup Guide](docs/google-vision-setup.md)**
+[Google Vision setup guide](docs/google-vision-setup.md)
 
 </details>
 
 <details>
-<summary>📖 Tesseract (Fallback)</summary>
+<summary>Tesseract</summary>
 
 Open-source OCR designed for printed text. Poor results with handwriting, but useful as an offline fallback.
 
@@ -607,36 +578,17 @@ When `REMARKABLE_OCR_BACKEND=auto` (default):
 
 ---
 
-## Transport Comparison
-
-| Feature | Local Directory | SSH Mode | USB Web | Cloud API |
-|---------|-----------------|----------|---------|-----------|
-| Speed | ⚡ Local disk | ⚡ 10-100x faster | ⚡ Fast | ⚡ Fast (parallel + cached) |
-| Offline | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
-| Tablet needed | ❌ No | ✅ Yes | ✅ Yes | ❌ No |
-| Subscription | ✅ Not required¹ | ✅ Not required | ✅ Not required | ❌ Connect required |
-| Raw files | ✅ PDFs, EPUBs | ✅ PDFs, EPUBs | ✅ PDFs | ✅ PDFs, EPUBs |
-| Upload | ❌ | ✅ (default) | ✅ (default) | ✅ (default) |
-| mkdir/move/rename/delete | ❌ | ✅ (default) | ❌ | ✅ (default) |
-| Setup | Desktop app | Developer mode | Enable in Settings | One-time code |
-
-¹ The desktop app signs in to sync; this transport reads its existing local cache.
-
-📖 **[SSH Setup Guide](docs/ssh-setup.md)**
-
----
-
 ## Write Tools by Transport
 
 Write tools let you upload, organize, and manage documents on your reMarkable. **Enabled by default on write-capable transports.** Cloud and SSH modes support the full set; USB web supports upload only (its firmware exposes no folder operations); local-directory mode is always read-only. Pass `--read-only` to expose a read-only server elsewhere.
 
-| Feature | Local Directory | Cloud Mode | SSH Mode | USB Web Mode |
-|---------|:---------------:|:----------:|:--------:|:------------:|
-| Upload | ❌ | ✅ | ✅ | ✅ (to root) |
-| Mkdir | ❌ | ✅ | ✅ | ❌ |
-| Move | ❌ | ✅ | ✅ | ❌ |
-| Rename | ❌ | ✅ | ✅ | ❌ |
-| Delete | ❌ | ✅ (→ trash) | ✅ | ❌ |
+| Feature | Local directory | Cloud | SSH | USB web |
+|---|---:|---:|---:|---:|
+| Upload | No | Yes | Yes | Root only |
+| Create folder | No | Yes | Yes | No |
+| Move | No | Yes | Yes | No |
+| Rename | No | Yes | Yes | No |
+| Delete | No | Trash | Yes | No |
 
 ### Disabling Write Tools (read-only mode)
 
@@ -685,16 +637,16 @@ Or set the environment variable:
 | `remarkable_mkdir(folder_name, parent, defer_restart)` | Create a new folder (cloud and SSH) |
 | `remarkable_move(document, dest_folder, defer_restart)` | Move a document or folder (cloud and SSH) |
 | `remarkable_rename(document, new_name, defer_restart)` | Rename a document or folder (cloud and SSH) |
-| `remarkable_delete(document, defer_restart)` | Delete a document or folder — destructive (cloud and SSH) |
-| `remarkable_refresh()` | Restart `xochitl` once to apply writes made with `defer_restart=True` — **SSH only** |
-| `remarkable_author(method, ...)` | Author native ink and notebooks — `draw` (append strokes), `add_page` (append a blank notebook page), `create_document` (new notebook) — **SSH only** |
+| `remarkable_delete(document, defer_restart)` | Delete a document or folder (cloud and SSH; destructive) |
+| `remarkable_refresh()` | Restart `xochitl` once to apply deferred SSH writes |
+| `remarkable_author(method, ..., defer_restart)` | Author native ink and notebooks: `draw`, `add_page`, or `create_document` (SSH only) |
 
 ### Safety
 
-- **Upload registers in cloud, SSH, and USB web mode** — local-directory mode never exposes write tools.
-- **mkdir, move, rename, delete register in cloud and SSH modes only** — they are not exposed on USB web (the tablet's USB web firmware has no folder/move/rename/delete endpoints), keeping the tool list scoped to what the active transport actually supports.
-- **Delete prompts for confirmation when possible** — if the client supports MCP elicitation, `remarkable_delete` asks the user to confirm before deleting. If the client can't show a prompt, the delete is **refused** (not performed) unless `REMARKABLE_SKIP_CONFIRM=1` is set — so write-on-by-default can't silently delete from clients that lack elicitation. In cloud mode delete moves the item to the trash (recoverable from your device); set `REMARKABLE_SKIP_CONFIRM=1` to allow deletes without a prompt in automated setups. All write tools carry `ToolAnnotations(readOnlyHint=False)` (and `destructiveHint=True` for delete) so an agent harness can gate writes at the MCP layer.
-- After each write operation in SSH mode, the tablet UI (`xochitl`) restarts automatically to reflect changes; the call waits for it to come back before returning so the next write doesn't race a restarting daemon. For bulk operations, pass `defer_restart=True` to each write — or set `REMARKABLE_DEFER_RESTART=1` — and call `remarkable_refresh()` once at the end, so the batch triggers a single restart instead of one per write (each restart forces a full document-store rescan).
+- Upload is available in cloud, SSH, and USB web mode. Local directory mode never exposes write tools.
+- Create, move, rename, and delete are available in cloud and SSH mode.
+- Delete asks for confirmation when the client supports MCP elicitation. Without elicitation it is refused unless `REMARKABLE_SKIP_CONFIRM=1` is set. Cloud delete moves the item to trash.
+- SSH writes restart `xochitl` so the tablet notices filesystem changes. For a batch, pass `defer_restart=True` to every write, including `remarkable_author`, then call `remarkable_refresh()` once. Responses set `refresh_pending=true` until that refresh runs.
 
 ### Examples
 
@@ -718,7 +670,7 @@ remarkable_move("Meeting Notes", "/Archive/2024 Archive")
 # Rename a document
 remarkable_rename("Untitled", "Q4 Planning Notes")
 
-# Delete (destructive — confirms via elicitation when supported)
+# Delete (destructive; confirms via elicitation when supported)
 remarkable_delete("Old Draft")
 
 # Bulk import (SSH): defer the restart on each write, then refresh once.
@@ -738,7 +690,7 @@ remarkable_author(
 # Append a blank, drawable page to the end of a notebook
 remarkable_author(method="add_page", document="Ideas")
 
-# Create a new (blank) notebook — the common case
+# Create a new blank notebook
 remarkable_author(method="create_document", name="Sketches")
 
 # Only seed typed text when the user explicitly requested it.
@@ -751,7 +703,10 @@ remarkable_author(method="create_document", name="Meeting notes", text="Agenda\n
 
 An interactive page viewer built on the [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) extension (SEP-1865). Clients that support MCP Apps (such as ChatGPT, Claude, VS Code, and the MCP Inspector) render a canvas in a side panel where you can view a document page and navigate through it.
 
-There is **no flag to enable it** — the `remarkable_canvas` tool and its `ui://remarkable/canvas` resource are always registered, and the capability is negotiated automatically at the MCP `initialize` handshake. App-capable clients open the interactive canvas; every other client simply receives the rendered page as an image, so the tool is safe and useful everywhere.
+There is no enable flag. The `remarkable_canvas` tool and
+`ui://remarkable/canvas` resource are always registered. Capability negotiation
+at MCP initialization determines whether the client opens the app or receives a
+rendered page.
 
 This registers one tool:
 
@@ -761,15 +716,15 @@ This registers one tool:
 
 How it behaves:
 
-- **App-capable clients** open the canvas (declared at `ui://remarkable/canvas`, MIME `text/html;profile=mcp-app`) and can page through the document via the MCP Apps postMessage bridge — the server delivers each rendered page in the tool result's `structuredContent`.
+- App-capable clients open the canvas at `ui://remarkable/canvas` and receive each rendered page in `structuredContent`.
 - **Other clients** still get the rendered page back as an embedded PNG image, so the tool is useful everywhere; it just won't open the interactive panel. The `_meta.ui` / `ui://` metadata is inert to clients that don't advertise the MCP Apps UI extension.
 
 ### Drawing and authoring from the canvas
 
 When write mode is on (the default) **and** the active transport is SSH, the canvas becomes a write surface:
 
-- **Draw** — pick a pen or highlighter and colour, draw over the page, and **Save** writes the strokes back to the device as native `.rm` ink. Strokes are buffered locally per page (with **Undo** and **Cancel**) and only touch the device on Save.
-- **＋ Page** (native notebooks only) — queues a new blank page locally that you can navigate to and draw on immediately. **Save** materializes the queued page(s) on the device first, then writes any cached strokes.
+- **Draw**: choose a pen or highlighter, draw, then save native `.rm` ink to the device.
+- **Add page**: queue a blank native notebook page, draw on it, then save.
 - One source of truth: the canvas calls the **same** `remarkable_author` tool a model would call (`method="draw"` on Save, `method="add_page"` for ＋Page), so the human path and the model path produce byte-identical results.
 
 The Save / Draw / ＋Page controls are hidden when the page isn't writable (read-only mode, or a non-SSH transport), and the canvas falls back to a plain image viewer. The iframe bridge follows the MCP Apps spec but is best validated against your specific client.
@@ -826,8 +781,8 @@ Set the default background color for image rendering:
 ```
 
 Supported formats:
-- `#RRGGBB` — RGB hex (e.g., `#FFFFFF` for white)
-- `#RRGGBBAA` — RGBA hex (e.g., `#00000000` for transparent)
+- `#RRGGBB`: RGB hex, such as `#FFFFFF`
+- `#RRGGBBAA`: RGBA hex, such as `#00000000`
 
 Default is `#FBFBFB` (reMarkable paper color). This affects both the `remarkable_image` tool and image resources.
 
@@ -842,7 +797,8 @@ Cloud API requests automatically retry on transient failures (HTTP 429, 500, 502
 | `REMARKABLE_RETRY_ATTEMPTS` | `3` | Maximum number of request attempts (minimum 1) |
 | `REMARKABLE_RETRY_DELAY` | `2.0` | Base delay in seconds for exponential backoff |
 
-The retry logic honours the `Retry-After` header from rate-limited responses — both the numeric (seconds) form and the HTTP-date form (which Cloudflare, fronting the reMarkable cloud, often sends) — capped at 20 seconds. Auth failures (401) are not retried — they trigger automatic token renewal instead.
+Rate-limit retries honor numeric and HTTP-date `Retry-After` values, capped at
+20 seconds. Authentication failures trigger token renewal instead of retry.
 
 ---
 
@@ -850,9 +806,9 @@ The retry logic honours the `Retry-After` header from rate-limited responses —
 
 Cloud mode is built to make a device-free workflow fast:
 
-- **Parallel traversal** — document metadata is fetched concurrently instead of one document at a time, turning a multi-minute first load into a few seconds.
-- **Connection pooling** — HTTP connections are reused (keep-alive), avoiding a fresh TLS handshake per request.
-- **Content-addressed blob cache** — reMarkable's cloud is an immutable, hash-addressed store (like Git), so a blob's bytes can never change for a given hash. Downloaded blobs are cached on disk and reused on later runs; changed documents get new hashes and are re-fetched automatically. This makes warm startups and repeat document reads near-instant, and it is invalidation-safe by construction.
+- **Parallel traversal**: fetch document metadata concurrently.
+- **Connection pooling**: reuse HTTP connections.
+- **Content-addressed blob cache**: reuse immutable blobs by hash and fetch new hashes when documents change.
 
 You normally don't need to configure any of this, but these environment variables let you tune it:
 
@@ -867,23 +823,13 @@ The cache is purely a local accelerator: deleting `REMARKABLE_CACHE_DIR` only fo
 
 ---
 
-## Use Cases
+## Common Workflows
 
-### Research & Writing
-
-Use remarkable-mcp while working in an Obsidian vault or similar to transfer knowledge from your handwritten notes into structured documents. AI can read your research notes and help develop your ideas.
-
-### Daily Review
-
-Ask your AI assistant to summarize your recent notes, find action items, or identify patterns across your journal entries.
-
-### Document Search
-
-Find that half-remembered note by searching across your entire library — including handwritten content.
-
-### Knowledge Management
-
-Treat your reMarkable as a second brain that AI can access. Combined with tools like Obsidian, you can build a powerful personal knowledge system.
+- Read recent notes and extract action items.
+- Search names, tags, typed text, and OCR output.
+- Review annotated PDFs with the source page and annotations together.
+- Move selected notes into another local workflow.
+- Upload reference PDFs or generated Markdown documents.
 
 ---
 
@@ -907,23 +853,23 @@ Treat your reMarkable as a second brain that AI can access. Combined with tools 
 git clone https://github.com/SamMorrowDrums/remarkable-mcp.git
 cd remarkable-mcp
 uv sync --all-extras
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
-📖 **[Development Guide](docs/development.md)**
+[Development guide](docs/development.md)
 
 ### Multi-transport smoke test
 
 When something looks broken, run the deterministic, no-AI smoke test first. It
 drives the real server over MCP and exercises every available tool in every
-reachable transport (cloud → usb-web → ssh):
+reachable transport in this order: local directory, cloud, USB web, then SSH.
 
 ```bash
 uv run python smoke/run_smoke.py            # all available modes
 uv run python smoke/run_smoke.py --read-only # connectivity + reads only
 ```
 
-📖 **[smoke/README.md](smoke/README.md)** — what PASS / N/A / SKIP / FAIL mean
+[Smoke test guide](smoke/README.md)
 and per-mode expectations.
 
 ---

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -4,8 +4,8 @@ This folder contains screenshots used in the documentation.
 
 ## Required Images
 
-- `resources-screenshot.png` — MCP resources appearing in VS Code
-- `tool-calls-screenshot.png` — Tool calls being executed in VS Code
+- `resources-screenshot.png`: MCP resources in VS Code
+- `tool-calls-screenshot.png`: tool calls in VS Code
 
 ## How to Update
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,110 +1,102 @@
-# MCP Capability Negotiation
+# MCP Protocol and Capability Compatibility
 
-This server supports the MCP capability negotiation protocol. During the initialization handshake, clients declare their capabilities and the server responds with its supported features.
+remarkable-mcp uses stable MCP Python SDK 2.x. A single `MCPServer` serves both
+protocol eras:
 
-## Overview
+- `2026-07-28` clients use `server/discover`, sessionless requests, and
+  multi-round input results.
+- Clients negotiating `2025-11-25` or any earlier revision supported by the SDK
+  continue to use the initialize handshake and legacy sessions.
 
-When an MCP client connects, both sides exchange capability information:
+The same stdio process or Streamable HTTP `/mcp` endpoint handles both. No
+protocol-version flag or separate deployment is required.
 
-1. **Client → Server**: Client sends its capabilities (sampling, elicitation, roots, etc.)
-2. **Server → Client**: Server responds with its supported features
-3. **Tools adapt**: Tools can check client capabilities and adjust behavior accordingly
+## Client capabilities
 
-This enables features like:
-- **Sampling OCR**: Using the client's LLM for handwriting recognition
-- **Adaptive responses**: Returning embedded resources or URIs based on client support
-
-## Checking Client Capabilities
-
-Tools can check what the connected client supports using the capability utilities:
+Handlers receive the SDK v2 `Context` explicitly and can inspect the
+capabilities attached to that request:
 
 ```python
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
+
 from remarkable_mcp.capabilities import (
-    get_client_capabilities,
-    client_supports_sampling,
     client_supports_elicitation,
+    client_supports_sampling,
+    get_client_capabilities,
     get_client_info,
 )
 
+
 @mcp.tool()
 async def my_tool(ctx: Context) -> str:
-    # Check if client supports specific features
     if client_supports_sampling(ctx):
-        # Client can handle LLM sampling requests
-        pass
-
+        ...
     if client_supports_elicitation(ctx):
-        # Client can handle interactive user prompts
-        pass
+        ...
 
-    # Get full capabilities object
-    caps = get_client_capabilities(ctx)
-
-    # Get client info (name, version, protocol)
-    info = get_client_info(ctx)
-
+    capabilities = get_client_capabilities(ctx)
+    client = get_client_info(ctx)
     return "result"
 ```
 
-## Available Capability Checks
-
 | Function | Description |
 |----------|-------------|
-| `get_client_capabilities(ctx)` | Get the full ClientCapabilities object |
-| `client_supports_sampling(ctx)` | Check if client supports LLM sampling |
-| `client_supports_elicitation(ctx)` | Check if client supports user prompts |
-| `client_supports_roots(ctx)` | Check if client supports filesystem roots |
-| `client_supports_experimental(ctx, feature)` | Check for experimental features |
-| `get_client_info(ctx)` | Get client name, version, protocol |
-| `get_protocol_version(ctx)` | Get negotiated protocol version |
+| `get_client_capabilities(ctx)` | Return the request's `ClientCapabilities` |
+| `client_supports_sampling(ctx)` | Check for LLM sampling |
+| `client_supports_elicitation(ctx)` | Check for form/user elicitation |
+| `client_supports_roots(ctx)` | Check for filesystem roots |
+| `client_supports_experimental(ctx, feature)` | Check an experimental capability |
+| `get_client_info(ctx)` | Return client name, version, and protocol when supplied |
+| `get_protocol_version(ctx)` | Return the negotiated protocol revision |
+| `get_client_extensions(ctx)` | Return protocol extensions such as MCP Apps |
+| `client_supports_apps(ctx)` | Check for the MCP Apps UI extension |
 
-## Sampling Capability
+## Multi-round compatibility
 
-The most commonly used capability is **sampling**, which allows the server to request LLM completions from the client.
+MCP `2026-07-28` removes server-initiated requests. Sampling, roots, and
+elicitation therefore cannot be sent back over a modern request's transport.
+MCP SDK 2.x provides `Resolve` dependencies with `Sample`, `ListRoots`, and
+`Elicit` results:
 
-### How It Works
+- On a modern connection, the server returns an `InputRequiredResult`; the
+  client answers it and retries the original tool with sealed `requestState`.
+- On a legacy connection, the same resolver uses the established
+  server-to-client request.
 
-1. Server checks `client_supports_sampling(ctx)`
-2. If supported, server can call `ctx.session.create_message(...)` 
-3. Client's LLM processes the request and returns results
-4. Server uses the response (e.g., OCR results from an image)
+remarkable-mcp uses this compatibility layer for sampling OCR and destructive
+delete confirmation. Tool schemas do not expose the hidden resolver parameters.
+If the client does not advertise the required capability, OCR falls back to its
+configured local/provider backend and delete fails closed.
 
-### Use in remarkable-mcp
+`MCPServer` protects multi-round request state with a process-local key by
+default. This is appropriate for stdio and the supported single-process HTTP
+runner. A future multi-worker deployment must configure shared
+`RequestStateSecurity` keys and sticky routing for legacy sessions.
 
-When `REMARKABLE_OCR_BACKEND=sampling` is configured:
+## Embedded resources and structured output
 
-```python
-# In remarkable_image tool
-if include_ocr and client_supports_sampling(ctx):
-    ocr_text = await ocr_via_sampling(ctx, png_data)
-    # Returns handwriting transcription from client's LLM
-```
+Embedded text/image resources are part of the base protocol and require no
+separate capability. `remarkable_image` returns `EmbeddedResource` content by
+default and retains `compatibility=True` for clients that need a JSON/data-URI
+fallback.
 
-This allows OCR without external API keys — the client's own AI model handles it.
+The MCP Apps canvas keeps both:
 
-## Embedded Resource Support
+- embedded PNG content for ordinary clients;
+- `structuredContent` on the wire (`structured_content` in Python) for the app.
 
-The MCP protocol does not have a specific capability flag for embedded resources in tool responses. Support for `EmbeddedResource` and `ImageContent` in tool results is part of the base protocol.
+The `io.modelcontextprotocol/ui` extension controls whether a client renders the
+`ui://remarkable/canvas` HTML resource; clients without it still receive the
+image.
 
-All clients supporting protocol version `2024-11-05` or later should handle embedded resources, though actual client implementations may vary. The `remarkable_image` tool includes a `compatibility` parameter to return resource URIs instead of embedded resources for clients that may not fully support them.
+## Authentication and process state
 
-## Protocol Versions
+MCP HTTP authorization headers are not used to select a reMarkable account or
+transport. `REMARKABLE_TOKEN`, CLI flags, and the documented reMarkable
+environment variables configure one process-local client. That client and its
+transport resolution are protected by locks and shared safely by modern
+stateless requests and legacy sessions in the same process.
 
-| Version | Notable Features |
-|---------|------------------|
-| `2024-11-05` | Embedded resources, sampling |
-| Earlier | Basic tool calls only |
-
-Check the negotiated version:
-
-```python
-version = get_protocol_version(ctx)
-```
-
-## Best Practices
-
-1. **Always check capabilities** before using advanced features
-2. **Provide fallbacks** when capabilities are unavailable
-3. **Use `compatibility` flags** for features that may not be universally supported
-4. **Log capability info** for debugging connection issues
+Streamable HTTP continues to bind to loopback by default and enforces strict
+Host/Origin allowlists. See the README's reverse-proxy guidance before exposing
+it remotely.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,8 +6,8 @@ This server supports the MCP capability negotiation protocol. During the initial
 
 When an MCP client connects, both sides exchange capability information:
 
-1. **Client → Server**: Client sends its capabilities (sampling, elicitation, roots, etc.)
-2. **Server → Client**: Server responds with its supported features
+1. **Client to server**: the client sends capabilities such as sampling, elicitation, and roots
+2. **Server to client**: the server responds with supported features
 3. **Tools adapt**: Tools can check client capabilities and adjust behavior accordingly
 
 This enables features like:
@@ -58,6 +58,8 @@ async def my_tool(ctx: Context) -> str:
 | `client_supports_experimental(ctx, feature)` | Check for experimental features |
 | `get_client_info(ctx)` | Get client name, version, protocol |
 | `get_protocol_version(ctx)` | Get negotiated protocol version |
+| `get_client_extensions(ctx)` | Get negotiated client extensions |
+| `client_supports_apps(ctx)` | Check for MCP Apps UI support |
 
 ## Sampling Capability
 
@@ -81,7 +83,8 @@ if include_ocr and client_supports_sampling(ctx):
     # Returns handwriting transcription from client's LLM
 ```
 
-This allows OCR without external API keys — the client's own AI model handles it.
+This allows OCR without a separate OCR API key. Data handling depends on the
+connected client and model.
 
 ## Embedded Resource Support
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,41 +19,46 @@ cd remarkable-mcp
 uv sync --all-extras
 
 # Verify setup
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 ## Project Structure
 
 ```
 remarkable-mcp/
-├── server.py              # Entry point (backwards compatible)
-├── remarkable_mcp/        # Main package
-│   ├── __init__.py
-│   ├── server.py          # FastMCP server initialization
-│   ├── api.py             # reMarkable Cloud API helpers
-│   ├── ssh.py             # SSH transport implementation
-│   ├── extract.py         # Text extraction utilities
-│   ├── responses.py       # Response formatting
-│   ├── tools.py           # MCP tools with annotations
-│   ├── resources.py       # MCP resources
-│   └── prompts.py         # MCP prompts
-├── test_server.py         # Test suite
-├── pyproject.toml         # Project config and dependencies
-├── docs/                  # Documentation
-└── README.md              # Main documentation
+├── remarkable_mcp/
+│   ├── server.py           # FastMCP server and transport
+│   ├── tools.py            # Read and render tools
+│   ├── write_tools.py      # Upload, management, and authoring tools
+│   ├── api.py              # Transport selection and cloud fallback
+│   ├── sync.py             # Cloud sync client
+│   ├── ssh.py              # SSH client
+│   ├── usb_web.py          # USB web client
+│   ├── local_dir.py        # Desktop cache client
+│   ├── extract.py          # Text and image extraction
+│   ├── markdown_pdf.py     # Markdown-to-PDF rendering
+│   └── app_canvas.py       # MCP Apps canvas
+├── test_server.py
+├── test_page_mapping.py
+├── test_local_dir.py
+├── test_integration.py
+├── smoke/
+├── docs/
+├── server.json
+└── pyproject.toml
 ```
 
 ## Running Tests
 
 ```bash
 # Run all tests
-uv run pytest test_server.py -v
+uv run pytest -v
 
 # Run specific test class
-uv run pytest test_server.py -v -k "TestClassName"
+uv run pytest -v -k "TestClassName"
 
 # Run with coverage
-uv run pytest test_server.py -v --cov=remarkable_mcp
+uv run pytest -v --cov=remarkable_mcp
 ```
 
 Tests use `pytest-asyncio` for async testing. All async tests use the `@pytest.mark.asyncio` decorator.
@@ -98,15 +103,15 @@ Branch protection is enabled on `main` - all changes must go through pull reques
 3. Add tests in `test_server.py`
 4. Update the tools table in README.md
 5. Update `docs/tools.md` with detailed documentation
-6. Run tests: `uv run pytest test_server.py -v`
+6. Run tests: `uv run pytest -v`
 
 ### Tool Design Principles
 
-- **Intent-based design** — Tools should map to user intents, not API endpoints
-- **XML-structured docstrings** — Use `<usecase>`, `<instructions>`, `<parameters>`, `<examples>` tags
-- **Response hints** — Always include `_hint` field suggesting next actions
-- **Educational errors** — Errors should explain what went wrong and how to fix it
-- **Minimal tool count** — Prefer fewer, more capable tools over many simple ones
+- **Intent-based design**: tools should map to user intents, not API endpoints
+- **XML-structured docstrings**: use `<usecase>`, `<instructions>`, `<parameters>`, and `<examples>`
+- **Response hints**: include an actionable `_hint`
+- **Educational errors**: explain the failure and a safe next step
+- **Minimal tool count**: prefer fewer, more capable tools
 
 Example tool structure:
 
@@ -164,7 +169,7 @@ The workflow automatically:
 |---------|---------|
 | `mcp` | Model Context Protocol SDK |
 | `requests` | HTTP client for reMarkable Cloud API |
-| `paramiko` | SSH client for direct tablet access |
+| system `ssh` and `scp` | Direct tablet access; `sshpass` is optional for password auth |
 | `rmscene` | Native .rm file parser for text extraction |
 | `pymupdf` | PDF text extraction, Cairo-free SVG/PDF rendering, and Markdown PDF generation |
 | `markdown-it-py` | Safe Markdown-to-HTML parsing for PDF writeback |
@@ -177,8 +182,15 @@ The workflow automatically:
 | Variable | Description |
 |----------|-------------|
 | `REMARKABLE_TOKEN` | Cloud API authentication token |
+| `REMARKABLE_LOCAL_DIR` | Desktop cache or xochitl-style directory |
+| `REMARKABLE_USB_HOST` | USB web base URL |
 | `REMARKABLE_SSH_HOST` | SSH hostname (default: `10.11.99.1`) |
 | `REMARKABLE_SSH_USER` | SSH username (default: `root`) |
 | `REMARKABLE_SSH_PORT` | SSH port (default: `22`) |
+| `REMARKABLE_SSH_KEY` | Explicit private key path |
+| `REMARKABLE_READ_ONLY` | Disable write tools |
+| `REMARKABLE_ROOT_PATH` | Scope document access to one folder |
+| `REMARKABLE_MCP_HOST` | Streamable HTTP bind address |
+| `REMARKABLE_MCP_PORT` | Streamable HTTP port |
 | `GOOGLE_VISION_API_KEY` | Google Vision API key for OCR |
-| `REMARKABLE_OCR_BACKEND` | Force OCR backend: `auto`, `google`, `tesseract` |
+| `REMARKABLE_OCR_BACKEND` | OCR backend: `auto`, `sampling`, `google`, `tesseract` |

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ cd remarkable-mcp
 uv sync --all-extras
 
 # Verify setup
-uv run pytest test_server.py -v
+uv run pytest -v
 ```
 
 ## Project Structure
@@ -29,7 +29,7 @@ remarkable-mcp/
 ├── server.py              # Entry point (backwards compatible)
 ├── remarkable_mcp/        # Main package
 │   ├── __init__.py
-│   ├── server.py          # FastMCP server initialization
+│   ├── server.py          # MCPServer initialization
 │   ├── api.py             # reMarkable Cloud API helpers
 │   ├── ssh.py             # SSH transport implementation
 │   ├── extract.py         # Text extraction utilities
@@ -37,7 +37,8 @@ remarkable-mcp/
 │   ├── tools.py           # MCP tools with annotations
 │   ├── resources.py       # MCP resources
 │   └── prompts.py         # MCP prompts
-├── test_server.py         # Test suite
+├── test_server.py         # Main unit test suite
+├── test_mcp_v2.py         # Modern/legacy protocol compatibility tests
 ├── pyproject.toml         # Project config and dependencies
 ├── docs/                  # Documentation
 └── README.md              # Main documentation
@@ -47,7 +48,7 @@ remarkable-mcp/
 
 ```bash
 # Run all tests
-uv run pytest test_server.py -v
+uv run pytest -v
 
 # Run specific test class
 uv run pytest test_server.py -v -k "TestClassName"
@@ -98,7 +99,7 @@ Branch protection is enabled on `main` - all changes must go through pull reques
 3. Add tests in `test_server.py`
 4. Update the tools table in README.md
 5. Update `docs/tools.md` with detailed documentation
-6. Run tests: `uv run pytest test_server.py -v`
+6. Run tests: `uv run pytest -v`
 
 ### Tool Design Principles
 
@@ -113,9 +114,9 @@ Example tool structure:
 ```python
 EXAMPLE_ANNOTATIONS = ToolAnnotations(
     title="Descriptive Tool Name",  # Shown in VS Code
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
 )
 
 @mcp.tool(annotations=EXAMPLE_ANNOTATIONS)
@@ -162,7 +163,7 @@ The workflow automatically:
 
 | Package | Purpose |
 |---------|---------|
-| `mcp` | Model Context Protocol SDK |
+| `mcp>=2,<3` | Stable Model Context Protocol Python SDK 2.x |
 | `requests` | HTTP client for reMarkable Cloud API |
 | `paramiko` | SSH client for direct tablet access |
 | `rmscene` | Native .rm file parser for text extraction |

--- a/docs/future-plans.md
+++ b/docs/future-plans.md
@@ -1,104 +1,63 @@
-# Future Plans & Ideas
+# Future Work
 
-This document outlines potential future features for remarkable-mcp. These are ideas under consideration, not commitments.
+This file summarizes accepted problem areas. GitHub issues contain the current
+scope and acceptance criteria.
 
-> **Track progress:** See open [enhancement issues](https://github.com/SamMorrowDrums/remarkable-mcp/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) on GitHub.
+## Near-term work
 
-### Write Support ([#24](https://github.com/SamMorrowDrums/remarkable-mcp/issues/24))
+### SSH reliability
 
-Write tools (upload, create folders, move, rename, delete) are now enabled by default — pass `--read-only` to disable them. Further ideas under consideration:
+Track intermittent large-library SSH failures in
+[#157](https://github.com/SamMorrowDrums/remarkable-mcp/issues/157).
 
-- **Create documents** — Create new notebooks or upload PDFs
-- **Sync from Obsidian** — Push markdown notes to reMarkable as PDFs
-- **Template support** — Apply templates when creating notebooks
-- **Folder management** — Create, rename, move folders
+### Cloud authoring
 
-Write support requires careful consideration of:
-- Sync conflicts with reMarkable's own sync
-- Data safety and backup
-- API stability
+Add native notebook creation to cloud mode before considering page mutation.
+See [#118](https://github.com/SamMorrowDrums/remarkable-mcp/issues/118).
 
-### Additional OCR Providers ([#25](https://github.com/SamMorrowDrums/remarkable-mcp/issues/25))
+### Export
 
-Google Vision works well, but more options would be valuable:
+Provide reusable PDF and Markdown export for one document, then add folder and
+filter batching. See
+[#27](https://github.com/SamMorrowDrums/remarkable-mcp/issues/27).
 
-| Provider | Status | Notes |
-|----------|--------|-------|
-| Google Vision | ✅ Implemented | Excellent handwriting recognition |
-| Tesseract | ✅ Implemented | Offline fallback, poor for handwriting |
-| **Microsoft Azure** | 🔮 Planned | Competitive handwriting OCR |
-| **Mistral** | 🔮 Planned | Open-weight models with vision |
-| **Claude Vision** | 🔮 Possible | Direct integration with Claude |
-| **Local LLaVA** | 🔮 Possible | Fully offline, privacy-focused |
+## Search and OCR
 
-The goal is **BYOK (Bring Your Own Key)** — let users choose their preferred provider.
+### Persistent indexing
 
-### Enhanced Search ([#26](https://github.com/SamMorrowDrums/remarkable-mcp/issues/26))
+Build a local full-text index with incremental updates. Semantic search should
+remain optional and use the same indexed chunks. See
+[#26](https://github.com/SamMorrowDrums/remarkable-mcp/issues/26).
 
-- **Full-text indexing** — Index all documents for instant search
-- **Semantic search** — Find documents by meaning, not just keywords
-- **Cross-document search** — Search annotations across your entire library
+### Persistent cache
 
-### Obsidian Integration
+Cache OCR and extracted content with bounded storage, explicit invalidation, and
+corruption recovery. See
+[#28](https://github.com/SamMorrowDrums/remarkable-mcp/issues/28).
 
-Deep integration with Obsidian vaults:
+### OCR providers
 
-- **Bi-directional sync** — Notes flow between reMarkable and Obsidian
-- **Link resolution** — reMarkable documents as Obsidian attachments
-- **Daily notes** — Sync reMarkable journals to Obsidian daily notes
+Unify the existing sampling, Google Vision, and Tesseract backends behind one
+provider interface before adding more integrations. See
+[#25](https://github.com/SamMorrowDrums/remarkable-mcp/issues/25).
 
-### Export Features ([#27](https://github.com/SamMorrowDrums/remarkable-mcp/issues/27))
+## Workflow integrations
 
-- **PDF export** — Export notebooks as PDFs
-- **Markdown export** — Convert notebooks to markdown
-- **Batch export** — Export entire folders
+### Processed-page marker
 
-## Community Requests
+Define an idempotent on-device marker for pages that have already been exported
+or reviewed. See
+[#24](https://github.com/SamMorrowDrums/remarkable-mcp/issues/24).
 
-Have an idea? Open an issue on GitHub with the `enhancement` label.
+### Obsidian synchronization
 
-Popular requests we're tracking:
+Define stable identity, path mapping, conflict handling, and dry-run behavior
+before implementing synchronization. See
+[#158](https://github.com/SamMorrowDrums/remarkable-mcp/issues/158).
 
-1. **Handwriting-to-text conversion** — Beyond OCR, actual handwriting recognition
-2. **Tag support** — Organize documents with tags
-3. **Favorites** — Quick access to frequently-used documents
-4. **Version history** — Access previous versions of documents
+## Non-goals
 
-## Technical Improvements
-
-### Performance ([#28](https://github.com/SamMorrowDrums/remarkable-mcp/issues/28))
-
-- **Parallel resource registration** — Faster startup for large libraries
-- **Incremental sync** — Only fetch changed documents
-- **Persistent cache** — Cache OCR results across sessions
-
-### Reliability ([#29](https://github.com/SamMorrowDrums/remarkable-mcp/issues/29))
-
-- **Automatic reconnection** — Recover from dropped SSH connections
-- **Retry logic** — Handle transient API failures
-- **Health checks** — Proactive connection monitoring
-
-### Developer Experience
-
-- **TypeScript types** — Full type definitions for MCP clients
-- **Example integrations** — Sample code for common use cases
-- **Plugin system** — Extensible architecture for custom features
-
-## Contributing
-
-Interested in implementing any of these features? We welcome contributions!
-
-1. Check existing issues for the feature
-2. Open a discussion if it's a major change
-3. Fork, implement, and submit a PR
-
-See [Development Guide](development.md) for setup instructions.
-
-## Non-Goals
-
-Some things we're explicitly **not** planning:
-
-- **reMarkable firmware modifications** — We work with the official software
-- **Bypassing DRM** — We respect content protection
-- **Subscription circumvention** — Cloud API requires Connect subscription
-- **Real-time sync** — We're a query tool, not a sync service
+- Firmware modification
+- DRM bypass
+- Subscription circumvention
+- Silent overwrite or deletion during synchronization

--- a/docs/google-vision-setup.md
+++ b/docs/google-vision-setup.md
@@ -1,15 +1,16 @@
 # Google Cloud Vision Setup
 
-Google Cloud Vision provides **far superior handwriting recognition** compared to Tesseract. Unless your handwriting is exceptionally clear and print-like, we strongly recommend using Google Vision.
+Google Cloud Vision is an optional hosted OCR backend. It generally handles
+handwriting better than Tesseract, but sends page images to Google.
 
 ## Why Google Vision?
 
 | Feature | Google Vision | Tesseract |
 |---------|---------------|-----------|
-| Handwriting | ✅ Excellent | ❌ Poor |
-| Cursive | ✅ Handles well | ❌ Fails |
-| Mixed content | ✅ Text + drawings | ❌ Confused |
-| Languages | ✅ Auto-detect | Manual config |
+| Handwriting | Supported | Limited |
+| Cursive | Supported | Limited |
+| Mixed content | Supported | Limited |
+| Languages | Auto-detect | Manual configuration |
 | Setup | API key | System install |
 
 ## Quick Setup (API Key)
@@ -19,7 +20,7 @@ The easiest way to get started:
 ### 1. Create a Google Cloud Project
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Click **Select a project** → **New Project**
+2. Click **Select a project**, then **New Project**
 3. Name it (e.g., "remarkable-ocr") and click **Create**
 
 ### 2. Enable the Vision API
@@ -30,7 +31,7 @@ The easiest way to get started:
 ### 3. Create an API Key
 
 1. Go to [Credentials](https://console.cloud.google.com/apis/credentials)
-2. Click **Create Credentials** → **API Key**
+2. Click **Create Credentials**, then **API Key**
 3. Copy the key
 
 ### 4. (Optional) Restrict the Key
@@ -87,7 +88,7 @@ For production use or tighter security controls:
 
 1. Click on the service account
 2. Go to **Keys** tab
-3. Click **Add Key** → **Create new key**
+3. Click **Add Key**, then **Create new key**
 4. Select **JSON** and click **Create**
 5. Save the downloaded file securely
 
@@ -115,8 +116,8 @@ Or install the SDK with default credentials:
 # Install gcloud CLI and authenticate
 gcloud auth application-default login
 
-# Install SDK dependency
-pip install remarkable-mcp[ocr]
+# Install remarkable-mcp with the optional SDK dependency
+uv tool install "remarkable-mcp[ocr]"
 ```
 
 ## Environment Variables
@@ -144,7 +145,7 @@ pip install remarkable-mcp[ocr]
 
 - You've exceeded the free tier
 - Enable billing or wait until next month
-- Consider caching results (remarkable-mcp does this automatically)
+- Retry after quota is available or select another OCR backend
 
 ### OCR Not Running
 
@@ -154,10 +155,9 @@ pip install remarkable-mcp[ocr]
 
 ## Performance Tips
 
-1. **Caching**: OCR results are cached per document — reading multiple pages doesn't re-run OCR
-2. **Selective OCR**: Only enable `include_ocr` when you need handwritten content
-3. **Typed text**: Notebooks with Type Folio extract text without OCR
-4. **PDFs**: Text is extracted directly, OCR only needed for scanned documents
+1. Enable `include_ocr` only when you need handwriting recognition.
+2. Type Folio text does not require OCR.
+3. Text-based PDFs are extracted directly. Scanned PDFs may require OCR.
 
 ## Privacy Considerations
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -37,7 +37,8 @@ remarkable:///Journals/November.txt
 | **EPUB** | Your annotations, highlights, and typed notes |
 | **Notebook** | Typed text, highlights, and handwritten content (OCR) |
 
-**Note:** Text resources contain only user-created content—not the original PDF/EPUB text. Use raw resources (`remarkableraw:///`) for the original document content. OCR is automatically applied for notebooks with handwritten content.
+Text resources contain user-created content, not original PDF/EPUB text. Use
+`remarkableraw:///` for source text. Notebook handwriting may require OCR.
 
 ### Response
 
@@ -56,7 +57,8 @@ Action Items:
 
 ## Raw Resources (`remarkableraw:///`)
 
-Original PDF and EPUB text content is available as raw resources in SSH mode. These resources extract and return the full text from the original document file—the actual content of the PDF or EPUB, not your annotations.
+Original PDF and EPUB text is available as raw resources in supported transports.
+These resources return source text, not annotations.
 
 ### URI Format
 
@@ -86,12 +88,13 @@ This paper explores the relationship between...
 
 | Mode | Text Resources | Raw Resources |
 |------|----------------|---------------|
-| Cloud | ✅ Yes | ✅ Yes (PDF/EPUB) |
-| SSH | ✅ Yes | ✅ Yes (PDF/EPUB) |
-| USB Web | ✅ Yes | ✅ Yes (PDF) |
+| Local directory | Yes | Yes (PDF/EPUB) |
+| Cloud | Yes | Yes (PDF/EPUB) |
+| USB web | Yes | Yes (PDF) |
+| SSH | Yes | Yes (PDF/EPUB) |
 
 All modes can access the original source files. Cloud stores the source blob
-alongside the notebook data, so PDFs/EPUBs are available wirelessly — though
+alongside the notebook data, so PDFs/EPUBs are available wirelessly, though
 very large files that the device hasn't synced to the cloud may be missing.
 USB web exposes the tablet's PDF export.
 
@@ -139,10 +142,10 @@ remarkablesvg:///Sketches/Logo.page-2.svg
 
 On server startup, remarkable-mcp:
 
-1. Connects to your reMarkable (via SSH or Cloud)
+1. Resolves the configured local directory, cloud, USB web, or SSH transport
 2. Fetches the document list
 3. Registers each document as an MCP resource
-4. For SSH mode, also registers raw PDF/EPUB resources
+4. Registers raw resources when source files are available
 
 Resources are registered once at startup. If you add new documents, restart the MCP server to pick them up.
 
@@ -181,8 +184,8 @@ Paths in URIs must be URL-encoded:
 | `&` | `%26` |
 
 Examples:
-- `Meeting Notes` → `Meeting%20Notes`
-- `/Work/Q4 Report` → `/Work/Q4%20Report`
+- `Meeting Notes` becomes `Meeting%20Notes`
+- `/Work/Q4 Report` becomes `/Work/Q4%20Report`
 
 ## Filtering
 
@@ -201,7 +204,7 @@ When `REMARKABLE_ROOT_PATH` is configured, only documents within that folder are
 ```
 
 With this configuration:
-- `/Work/Meeting Notes` → `remarkable:///Meeting%20Notes.txt`
+- `/Work/Meeting Notes` becomes `remarkable:///Meeting%20Notes.txt`
 - Documents outside `/Work` are not registered
 
 ## Performance Considerations

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,7 @@
 # MCP Tools Reference
 
-This document provides detailed documentation for all MCP tools provided by remarkable-mcp.
+This document describes the read and render tools. Write tools are listed in the
+[README](../README.md#write-tools-by-transport).
 
 ## Overview
 
@@ -13,7 +14,7 @@ This document provides detailed documentation for all MCP tools provided by rema
 | [`remarkable_status`](#remarkable_status) | Check connection status |
 | [`remarkable_image`](#remarkable_image) | Get page images (PNG or SVG) |
 
-These core tools are **read-only** and return structured JSON with hints for logical next actions. Write tools (upload, mkdir, move, rename, delete) are enabled by default and documented in the [README](../README.md#write-tools-cloud-ssh--usb-web).
+These tools are read-only and return structured JSON with next-step hints.
 
 ## Root Path Filtering
 
@@ -50,9 +51,9 @@ With this configuration:
 
 ### Content Types
 
-- **`"text"`** — Full extracted text: raw document content plus annotations, highlights, and typed text (default)
-- **`"raw"`** — Only the original PDF/EPUB text, no annotations. Works in all modes when the source file is present (very large PDFs/EPUBs may not be synced to the cloud).
-- **`"annotations"`** — Only annotations: highlights, typed text from notebooks, and OCR content
+- **`"text"`**: source text plus annotations, highlights, and typed text (default)
+- **`"raw"`**: original PDF/EPUB text without annotations
+- **`"annotations"`**: highlights, typed notebook text, and OCR content
 
 ### Examples
 
@@ -119,6 +120,7 @@ When `more: true`, use the `page` parameter to continue reading.
 |-----------|------|---------|-------------|
 | `path` | string | `"/"` | Folder path to browse |
 | `query` | string | `None` | Search documents by name |
+| `tags` | list[string] | `None` | Require all listed tags (case-insensitive) |
 
 ### Examples
 
@@ -134,6 +136,9 @@ remarkable_browse(query="meeting")
 
 # Combine path and search
 remarkable_browse("/Work", query="report")
+
+# Filter by tag
+remarkable_browse("/Work", tags=["project", "active"])
 ```
 
 ### Response Format
@@ -176,6 +181,7 @@ remarkable_browse("/Work", query="report")
 | `grep` | string | `None` | Pattern to search within content |
 | `limit` | int | `5` | Maximum documents to search (max: 5) |
 | `include_ocr` | bool | `False` | Enable OCR for handwritten content |
+| `tags` | list[string] | `None` | Require all listed tags (case-insensitive) |
 
 ### Examples
 
@@ -188,6 +194,9 @@ remarkable_search("meeting", grep="action items")
 
 # Search journals for a specific topic
 remarkable_search("journal", grep="project idea", include_ocr=True)
+
+# Search only tagged documents
+remarkable_search("project", tags=["work"])
 ```
 
 ### Response Format
@@ -300,7 +309,7 @@ remarkable_status()
 | Field | Description |
 |-------|-------------|
 | `authenticated` | Whether authentication succeeded |
-| `transport` | `"cloud"`, `"ssh"`, or `"usb-web"` |
+| `transport` | `"local-dir"`, `"cloud"`, `"usb-web"`, or `"ssh"` |
 | `connection` | Connection details |
 | `document_count` | Total documents in library (filtered by root if configured) |
 | `write_enabled` | Whether write tools are enabled (the default; `false` only with `--read-only`) |
@@ -325,13 +334,14 @@ remarkable_status()
 | `output_format` | string | `"png"` | Output format: `"png"` or `"svg"` |
 | `include_ocr` | bool | `False` | Enable OCR on the image (uses sampling if configured) |
 | `compatibility` | bool | `False` | Return resource URI instead of embedded resource |
+| `render_merged` | bool | `False` | Composite an imported PDF page with its reMarkable annotations (PNG only) |
 
 ### Background Colors
 
-- **`"#FBFBFB"`** — Default reMarkable paper color (light cream)
-- **`"#FFFFFF"`** — Pure white
-- **`"#00000000"`** — Fully transparent (RGBA format)
-- **`"#80008080"`** — Semi-transparent purple (RGBA format)
+- **`"#FBFBFB"`**: default reMarkable paper color
+- **`"#FFFFFF"`**: white
+- **`"#00000000"`**: fully transparent
+- **`"#80008080"`**: semi-transparent purple
 
 **Tip:** Set `REMARKABLE_BACKGROUND_COLOR` environment variable to change the default for all image operations.
 
@@ -361,6 +371,9 @@ remarkable_image("Handwritten Notes", include_ocr=True)
 
 # Compatibility mode: return resource URI instead of embedded resource
 remarkable_image("Diagram", compatibility=True)
+
+# Composite a PDF page with annotations
+remarkable_image("Research Paper", page=3, render_merged=True)
 ```
 
 ### Response Format
@@ -407,6 +420,6 @@ All tools return structured errors with suggestions:
 ```
 
 Common error types:
-- `document_not_found` — Document doesn't exist (includes suggestions)
-- `authentication_failed` — Token invalid or SSH connection failed
-- `connection_error` — Network or SSH connection issue
+- `document_not_found`: document does not exist (includes suggestions)
+- `authentication_failed`: token invalid or SSH connection failed
+- `connection_error`: network or SSH connection issue

--- a/docs/usb-web-setup.md
+++ b/docs/usb-web-setup.md
@@ -1,22 +1,17 @@
 # USB Web Interface Setup Guide
 
-The USB web interface is the **easiest way** to connect remarkable-mcp to your tablet. It works entirely offline over USB.
+The USB web interface provides read, render, and root-folder upload over USB.
 
 ## Overview
 
-The USB web interface is an official reMarkable feature that provides HTTP API access when your tablet is connected via USB. This gives you:
-
-- ✅ **No subscription needed** — Works without reMarkable Connect
-- ✅ **Fast offline access** — Direct USB connection
-- ✅ **Officially supported** — Part of the standard reMarkable OS
-- ✅ **Simple setup** — Just enable in Settings and connect
+It does not require a Connect subscription or developer mode.
 
 ## Quick Start
 
 ### 1. Enable USB Web Interface
 
 On your reMarkable tablet:
-1. Go to **Settings** (gear icon)
+1. Open **Settings**
 2. Tap **Storage**
 3. Toggle **USB web interface** to **On**
 
@@ -59,61 +54,54 @@ uvx remarkable-mcp --usb
 
 ### Cannot Connect to 10.11.99.1
 
-**Symptoms:** Browser shows "Cannot connect" or "Connection refused"
+Symptoms: the browser shows "Cannot connect" or "Connection refused".
 
-**Solutions:**
-1. **Check tablet is on and unlocked** — The web interface only works when the tablet is active
-2. **Verify USB connection** — Try a different USB port or cable
-3. **Check USB web interface is enabled** — Settings → Storage → USB web interface
-4. **Check network interface** — The tablet creates a USB Ethernet device (usually `usb0` on Linux)
+1. Check that the tablet is on and unlocked.
+2. Try a different USB port or cable.
+3. Check **Settings > Storage > USB web interface**.
+4. Check that a USB Ethernet interface appeared.
 
 On Linux, verify the interface:
 ```bash
-ip addr show usb0
-# Should show: inet 10.11.99.2/29
+ip -brief address
+# Look for an interface with an address in the tablet's 10.11.99.0 network.
 ```
 
-On macOS, check System Preferences → Network for the USB device.
+On macOS, check System Settings > Network for the USB device.
 
 On Windows, check Network Connections for "USB Ethernet/RNDIS Gadget".
 
 ### Connection Times Out
 
-**Symptoms:** Request starts but never completes
+Symptoms: a request starts but does not complete.
 
-**Solutions:**
-1. **Check firewall settings** — Allow connections to 10.11.99.1
-2. **Restart the tablet** — Turn off and on again
-3. **Reconnect USB** — Unplug and plug back in
-4. **Try a different USB port** — Preferably a direct port, not a hub
+1. Allow connections to `10.11.99.1` in the host firewall.
+2. Retry. The client retries bounded tablet-generated HTTP 408 responses for safe GET requests.
+3. Disable and re-enable the USB web interface.
+4. Reconnect USB or restart the tablet if 408 responses continue.
+5. Use a direct USB port rather than a hub.
 
 ### Documents Don't Appear
 
-**Symptoms:** Connection works but no documents are listed
-
-**Solutions:**
-1. **Check sync status** — Make sure documents are synced to the device (not cloud-only)
-2. **Restart remarkable-mcp** — The server caches document listings
-3. **Check tablet storage** — Settings → Storage → check free space
+1. Make sure documents are stored on the device, not cloud-only.
+2. Restart remarkable-mcp to rebuild the cached listing.
+3. Check free storage on the tablet.
 
 ### Slow Performance
 
-**Symptoms:** Listing/downloading documents takes a long time
-
-**Solutions:**
-1. **USB connection quality** — Use a high-quality USB-C cable
-2. **Large library** — First load with many documents is slower, subsequent loads are cached
-3. **USB 2.0 vs 3.0** — USB 3.0 ports are faster
+1. Use a reliable USB-C cable.
+2. Allow the first full-library load to finish.
+3. Avoid concurrent tools that scan a large library.
 
 ## How It Works
 
 The reMarkable USB web interface provides several HTTP endpoints:
 
-- `GET /documents/` — List all documents
-- `GET /documents/{guid}` — List documents in a folder
-- `GET /download/{guid}/rmdoc` — Download document as `.rmdoc` archive
-- `GET /download/{guid}/pdf` — Download document as PDF
-- `POST /upload` — Upload new documents
+- `GET /documents/`: list root documents
+- `GET /documents/{guid}`: list a folder
+- `GET /download/{guid}/rmdoc`: download an `.rmdoc` archive
+- `GET /download/{guid}/pdf`: download a PDF export
+- `POST /upload`: upload a document
 
 The remarkable-mcp USB web client:
 1. Recursively fetches document listings from all folders
@@ -133,39 +121,21 @@ export REMARKABLE_USB_HOST="http://192.168.1.100:8080"
 export REMARKABLE_USB_TIMEOUT="30"
 ```
 
-## Comparison: USB Web vs SSH vs Cloud
-
-| Feature | USB Web | SSH | Cloud |
-|---------|---------|-----|-------|
-| **Setup** | ✅ Easy | ⚠️ Complex | ✅ Easy |
-| **Developer Mode** | ✅ Not needed | ❌ Required | ✅ Not needed |
-| **Factory Reset** | ✅ No | ❌ Yes | ✅ No |
-| **Subscription** | ✅ Not needed | ✅ Not needed | ❌ Required |
-| **Speed** | ✅ Fast | ✅✅ Very Fast | ⚠️ Slow |
-| **Offline** | ✅ Yes | ✅ Yes | ❌ No |
-| **Connection** | USB only | USB only | Internet |
-| **Stability** | ✅ Good | ✅ Good | ⚠️ Variable |
-
-**Recommendation:**
-- **Most users:** USB Web Interface — Best balance of ease and performance
-- **Advanced users:** SSH — Fastest, but requires developer mode enabled
-- **Remote access:** Cloud API — Works anywhere, but slower and needs subscription
-
 ## Technical Details
 
 ### Network Configuration
 
 When you enable USB web interface:
 1. reMarkable creates a USB Ethernet gadget device
-2. The tablet assigns itself `10.11.99.1/29`
-3. Your computer gets `10.11.99.2/29` (via DHCP or auto-config)
+2. The tablet uses `10.11.99.1`
+3. The host receives an address on the same USB network; the prefix varies by device and firmware
 4. A web server starts on port 80 on the tablet
 
 ### Security Considerations
 
-- **No authentication** — Anyone with USB access can read/write documents
-- **Local only** — Only accessible over USB, not remotely
-- **HTTP, not HTTPS** — Data is not encrypted (but local to USB)
+- There is no HTTP authentication.
+- The endpoint is available only through the USB network.
+- Traffic is plain HTTP.
 
 For better security:
 - Keep your computer locked when connected
@@ -192,9 +162,9 @@ See [reMarkable Guide](https://remarkable.guide/tech/usb-web-interface.html) for
 
 Other tools that use the USB web interface:
 
-- [reMarkable-Offline-Sync](https://github.com/ChrWesp/reMarkable-Offline-Sync) — Python sync tool
-- [rmfakecloud](https://github.com/ddvk/rmfakecloud) — Self-hosted cloud replacement
-- Browser — Direct access at `http://10.11.99.1` for manual file management
+- [reMarkable-Offline-Sync](https://github.com/ChrWesp/reMarkable-Offline-Sync): Python sync tool
+- [rmfakecloud](https://github.com/ddvk/rmfakecloud): self-hosted cloud replacement
+- Browser access at `http://10.11.99.1`
 
 ## Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.27.0,<2.0.0",
+    "mcp>=2.0.0,<3.0.0",
     "rmscene>=0.8.0",
     "pytesseract>=0.3.10",
     "Pillow>=10.0.0",

--- a/remarkable-mcp-bridge.nix
+++ b/remarkable-mcp-bridge.nix
@@ -63,6 +63,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.host != "0.0.0.0" && cfg.host != "::";
+      message = ''
+        services.remarkable-mcp.host must be loopback or a concrete interface
+        address. Wildcard binds cannot use a strict Host allowlist.
+      '';
+    }];
     warnings = lib.optional (!(builtins.elem cfg.host loopbackHosts)) ''
       services.remarkable-mcp.host is non-loopback. Streamable HTTP has no
       authentication. Prefer the loopback default; an authenticated reverse

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -28,7 +28,7 @@ import logging
 from typing import Optional
 
 from mcp import types
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from remarkable_mcp.capabilities import APP_UI_MIME, client_supports_apps
 
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 CANVAS_RESOURCE_URI = "ui://remarkable/canvas"
 
 # Read-only viewer annotations (no device mutation in this phase).
-CANVAS_ANNOTATIONS = types.ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+CANVAS_ANNOTATIONS = types.ToolAnnotations(read_only_hint=True, open_world_hint=False)
 
 
 # The canvas app: a self-contained, dependency-free HTML/JS surface that speaks
@@ -817,7 +817,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     }
 
     resource_uri = f"remarkableimg:///{doc_path.lstrip('/')}.page-{page}.png"
-    blob = types.BlobResourceContents(uri=resource_uri, mimeType="image/png", blob=png_base64)
+    blob = types.BlobResourceContents(uri=resource_uri, mime_type="image/png", blob=png_base64)
     # Audience split (MCP content annotations): the rendered page image is for the
     # USER (it's large base64 the model never needs to read), while a lean text
     # digest carries the page/doc/writable facts the model may want — keeping the
@@ -861,7 +861,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     )
     return types.CallToolResult(
         content=[info, image],
-        structuredContent=structured,
+        structured_content=structured,
     )
 
 

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -676,7 +676,7 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     )
 
     background = await run_blocking(get_background_color)
-    client = get_rmapi()
+    client = await run_blocking(get_rmapi)
     collection = await run_blocking(client.get_meta_items)
     items_by_id = get_items_by_id(collection)
 

--- a/remarkable_mcp/capabilities.py
+++ b/remarkable_mcp/capabilities.py
@@ -2,7 +2,7 @@
 Client capability checking utilities for reMarkable MCP Server.
 
 This module provides utilities to check MCP client capabilities during
-the request lifecycle. FastMCP supports capability negotiation through
+the request lifecycle. MCPServer supports capability negotiation through
 the MCP protocol's initialize handshake.
 
 ## How MCP Capability Negotiation Works
@@ -34,7 +34,7 @@ Servers declare what they offer:
 Use the Context object in tools to check what the client supports:
 
 ```python
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from remarkable_mcp.capabilities import get_client_capabilities, client_supports_sampling
 
 @mcp.tool()
@@ -64,7 +64,7 @@ supporting protocol version 2024-11-05 or later should handle embedded resources
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import Context
+    from mcp.server.mcpserver import Context
     from mcp.types import ClientCapabilities
 
 
@@ -73,8 +73,7 @@ if TYPE_CHECKING:
 #   capabilities.extensions["io.modelcontextprotocol/ui"] = {
 #       "mimeTypes": ["text/html;profile=mcp-app"]
 #   }
-# The MCP SDK (as of 1.27) has no typed field for this, but ClientCapabilities
-# allows extra fields, so we read it from model_extra.
+# MCP SDK v2 exposes this as ClientCapabilities.extensions.
 APP_UI_EXTENSION_ID = "io.modelcontextprotocol/ui"
 APP_UI_MIME = "text/html;profile=mcp-app"
 
@@ -85,7 +84,7 @@ def get_client_capabilities(ctx: "Context") -> Optional["ClientCapabilities"]:
     Returns None if the context is not available or client hasn't sent capabilities.
 
     Args:
-        ctx: The FastMCP Context object from a tool or resource function
+        ctx: The MCPServer Context object from a tool or resource function
 
     Returns:
         ClientCapabilities object or None if not available
@@ -99,9 +98,7 @@ def get_client_capabilities(ctx: "Context") -> Optional["ClientCapabilities"]:
                 pass
     """
     try:
-        session = ctx.session
-        if session and hasattr(session, "client_params") and session.client_params:
-            return session.client_params.capabilities
+        return ctx.client_capabilities
     except (ValueError, AttributeError):
         # Context not available (e.g., outside of request lifecycle)
         pass
@@ -114,7 +111,7 @@ def client_supports_sampling(ctx: "Context") -> bool:
     When true, the server can request the client's LLM to generate completions.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         True if client supports sampling, False otherwise
@@ -129,7 +126,7 @@ def client_supports_elicitation(ctx: "Context") -> bool:
     When true, the server can request interactive user input during tool execution.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         True if client supports elicitation, False otherwise
@@ -144,7 +141,7 @@ def client_supports_roots(ctx: "Context") -> bool:
     When true, the server can query for filesystem root directories.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         True if client supports roots, False otherwise
@@ -157,7 +154,7 @@ def client_supports_experimental(ctx: "Context", feature: str) -> bool:
     """Check if the client supports a specific experimental feature.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
         feature: The experimental feature name to check
 
     Returns:
@@ -175,19 +172,25 @@ def get_client_info(ctx: "Context") -> Optional[dict]:
     Returns client name, version, and other metadata from the initialize request.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         Dictionary with client info or None if not available
     """
     try:
         session = ctx.session
-        if session and hasattr(session, "client_params") and session.client_params:
-            params = session.client_params
+        params = session.client_params if session else None
+        if params:
             return {
-                "name": params.clientInfo.name if params.clientInfo else None,
-                "version": params.clientInfo.version if params.clientInfo else None,
-                "protocol_version": params.protocolVersion,
+                "name": params.client_info.name if params.client_info else None,
+                "version": params.client_info.version if params.client_info else None,
+                "protocol_version": ctx.protocol_version,
+            }
+        if ctx.protocol_version:
+            return {
+                "name": None,
+                "version": None,
+                "protocol_version": ctx.protocol_version,
             }
     except (ValueError, AttributeError):
         pass
@@ -198,15 +201,13 @@ def get_protocol_version(ctx: "Context") -> Optional[str]:
     """Get the MCP protocol version negotiated with the client.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         Protocol version string (e.g., "2024-11-05") or None
     """
     try:
-        session = ctx.session
-        if session and hasattr(session, "client_params") and session.client_params:
-            return session.client_params.protocolVersion
+        return ctx.protocol_version
     except (ValueError, AttributeError):
         pass
     return None
@@ -215,11 +216,10 @@ def get_protocol_version(ctx: "Context") -> Optional[str]:
 def get_client_extensions(ctx: "Context") -> dict:
     """Get the client's declared protocol extensions (SEP-1724).
 
-    Extensions are not a typed field on ClientCapabilities in the current MCP
-    SDK, but the model permits extra fields, so they are read from model_extra.
+    Extensions are a typed field on ClientCapabilities in MCP SDK v2.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         The extensions mapping (extension id -> config dict), or {} if none.
@@ -227,8 +227,10 @@ def get_client_extensions(ctx: "Context") -> dict:
     caps = get_client_capabilities(ctx)
     if caps is None:
         return {}
-    extra = getattr(caps, "model_extra", None) or {}
-    extensions = extra.get("extensions")
+    extensions = getattr(caps, "extensions", None)
+    if extensions is None:
+        extra = getattr(caps, "model_extra", None) or {}
+        extensions = extra.get("extensions")
     return extensions if isinstance(extensions, dict) else {}
 
 
@@ -246,7 +248,7 @@ def client_supports_apps(ctx: "Context") -> bool:
     app-capable, app tools should still return a useful text/image fallback.
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         True if the client advertises the MCP Apps UI extension, else False.

--- a/remarkable_mcp/cli.py
+++ b/remarkable_mcp/cli.py
@@ -31,6 +31,11 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _is_wildcard_host(host: str) -> bool:
+    """Return whether a bind address is unspecified rather than routable."""
+    return host.strip().strip("[]") in ("0.0.0.0", "::")
+
+
 def _warn_for_http_binding(host: str) -> None:
     """Warn prominently when unauthenticated HTTP is exposed off-host."""
     if not _is_loopback_host(host):
@@ -186,8 +191,8 @@ Streamable HTTP Security:
         "--host",
         help=(
             "Streamable HTTP bind address (default: REMARKABLE_MCP_HOST or "
-            "127.0.0.1). Non-loopback addresses are unauthenticated and unsafe "
-            "unless protected by a correctly configured reverse proxy; see README."
+            "127.0.0.1). Use a concrete interface address for direct network access. "
+            "Wildcard addresses are rejected. See README for the safer reverse-proxy setup."
         ),
     )
     parser.add_argument(
@@ -209,13 +214,10 @@ Streamable HTTP Security:
 
         try:
             print(f"Registering with reMarkable using code: {args.register}")
-            token = register_and_get_token(args.register)
-            print("\n✅ Successfully registered!\n")
-            print("Your token (add to mcp.json env):")
-            print("-" * 50)
-            print(token)
-            print("-" * 50)
-            print("\nAdd to your .vscode/mcp.json:")
+            register_and_get_token(args.register)
+            print("\nRegistration complete.")
+            print("The credential was saved to ~/.rmapi.")
+            print("\nAdd this server to .vscode/mcp.json:")
             print(
                 json.dumps(
                     {
@@ -223,7 +225,6 @@ Streamable HTTP Security:
                             "remarkable": {
                                 "command": "uvx",
                                 "args": ["remarkable-mcp"],
-                                "env": {"REMARKABLE_TOKEN": token},
                             }
                         }
                     },
@@ -231,7 +232,7 @@ Streamable HTTP Security:
                 )
             )
         except Exception as e:
-            print(f"❌ Registration failed: {e}", file=sys.stderr)
+            print(f"Registration failed: {e}", file=sys.stderr)
             sys.exit(1)
     else:
         if args.local_dir:
@@ -267,6 +268,11 @@ Streamable HTTP Security:
                 parser.error("REMARKABLE_MCP_PORT must be an integer")
             if not 1 <= port <= 65535:
                 parser.error("REMARKABLE_MCP_PORT must be between 1 and 65535")
+            if _is_wildcard_host(host):
+                parser.error(
+                    "Wildcard HTTP bind addresses are not supported. Use 127.0.0.1 "
+                    "with an authenticated reverse proxy, or bind to a concrete interface address."
+                )
             _warn_for_http_binding(host)
             run(transport="streamable-http", host=host, port=port)
         else:

--- a/remarkable_mcp/concurrency.py
+++ b/remarkable_mcp/concurrency.py
@@ -1,6 +1,6 @@
 """Concurrency helpers for offloading blocking work from the asyncio event loop.
 
-FastMCP awaits ``async def`` tool handlers directly on the asyncio event loop
+MCPServer awaits ``async def`` tool handlers directly on the asyncio event loop
 without dispatching them to a thread pool, and it also calls plain ``def``
 handlers inline. Any blocking I/O performed inside a tool handler — SSH
 subprocess calls, ``requests`` HTTP requests, ``pymupdf`` rendering,

--- a/remarkable_mcp/resources.py
+++ b/remarkable_mcp/resources.py
@@ -237,9 +237,7 @@ def _make_svg_resource(client, document):
                 tmp_path, page_num, background_color=get_background_color()
             )
             if svg_content is None:
-                raise RuntimeError(
-                    f"Failed to render page {page_num} to SVG. Make sure 'rmc' is installed."
-                )
+                raise RuntimeError(f"Failed to render page {page_num} to SVG.")
             return svg_content
         finally:
             tmp_path.unlink(missing_ok=True)

--- a/remarkable_mcp/sampling.py
+++ b/remarkable_mcp/sampling.py
@@ -24,10 +24,18 @@ API keys or services.
 import base64
 from typing import TYPE_CHECKING, List, Optional
 
-from mcp.types import ImageContent, ModelHint, ModelPreferences, SamplingMessage, TextContent
+from mcp.server.mcpserver import Sample
+from mcp.types import (
+    CreateMessageResult,
+    ImageContent,
+    ModelHint,
+    ModelPreferences,
+    SamplingMessage,
+    TextContent,
+)
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import Context
+    from mcp.server.mcpserver import Context
 
 
 # Model preferences for OCR tasks - prioritize intelligence for better vision/OCR
@@ -49,9 +57,9 @@ OCR_MODEL_PREFERENCES = ModelPreferences(
         ModelHint(name="claude-3-5-sonnet"),
         ModelHint(name="gemini-1.5-pro"),
     ],
-    intelligencePriority=1.0,  # Maximize intelligence for OCR accuracy
-    speedPriority=0.2,  # Speed is not critical for OCR
-    costPriority=0.0,  # Cost doesn't matter - we need accuracy
+    intelligence_priority=1.0,  # Maximize intelligence for OCR accuracy
+    speed_priority=0.2,  # Speed is not critical for OCR
+    cost_priority=0.0,  # Cost doesn't matter - we need accuracy
 )
 
 
@@ -73,6 +81,44 @@ You are extracting handwritten notes from a reMarkable tablet. Focus on accuracy
 OCR_USER_PROMPT = "Extract all text from this image. Output only the text content, nothing else."
 
 
+def make_ocr_sample(png_data: bytes, max_tokens: int = 2000) -> Sample:
+    """Build an era-portable OCR sampling request for a resolver."""
+    image_b64 = base64.b64encode(png_data).decode("utf-8")
+    return Sample(
+        [
+            SamplingMessage(
+                role="user",
+                content=ImageContent(
+                    type="image",
+                    data=image_b64,
+                    mime_type="image/png",
+                ),
+            ),
+            SamplingMessage(
+                role="user",
+                content=TextContent(type="text", text=OCR_USER_PROMPT),
+            ),
+        ],
+        system_prompt=OCR_SYSTEM_PROMPT,
+        max_tokens=max_tokens,
+        temperature=0.0,
+        model_preferences=OCR_MODEL_PREFERENCES,
+    )
+
+
+def sampling_result_text(result: CreateMessageResult | None) -> Optional[str]:
+    """Extract a usable OCR string from an MCP sampling result."""
+    if result is None:
+        return None
+    content = result.content
+    if not isinstance(content, TextContent):
+        return None
+    text = content.text
+    if not text or "[NO TEXT DETECTED]" in text:
+        return None
+    return text.strip()
+
+
 async def ocr_via_sampling(
     ctx: "Context",
     png_data: bytes,
@@ -82,7 +128,7 @@ async def ocr_via_sampling(
     Perform OCR on an image using the client's LLM via MCP sampling.
 
     Args:
-        ctx: The FastMCP Context object from a tool function
+        ctx: The MCPServer Context object from a tool function
         png_data: PNG image bytes to perform OCR on
         max_tokens: Maximum tokens for the response (default: 2000)
 
@@ -103,49 +149,18 @@ async def ocr_via_sampling(
         if not session:
             return None
 
-        # Encode image as base64
-        image_b64 = base64.b64encode(png_data).decode("utf-8")
-
-        # Create the sampling message with image
-        messages = [
-            SamplingMessage(
-                role="user",
-                content=ImageContent(
-                    type="image",
-                    data=image_b64,
-                    mimeType="image/png",
-                ),
-            ),
-            SamplingMessage(
-                role="user",
-                content=TextContent(type="text", text=OCR_USER_PROMPT),
-            ),
-        ]
+        request = make_ocr_sample(png_data, max_tokens)
 
         # Request completion from the client's LLM
         # Use model preferences to request a capable vision model
         result = await session.create_message(
-            messages=messages,
-            system_prompt=OCR_SYSTEM_PROMPT,
-            max_tokens=max_tokens,
-            temperature=0.0,  # Use low temperature for consistency
-            model_preferences=OCR_MODEL_PREFERENCES,
+            messages=request.params.messages,
+            system_prompt=request.params.system_prompt,
+            max_tokens=request.params.max_tokens,
+            temperature=request.params.temperature,
+            model_preferences=request.params.model_preferences,
         )
-
-        # Extract text from the result
-        if result and result.content:
-            if isinstance(result.content, TextContent):
-                text = result.content.text
-            elif hasattr(result.content, "text"):
-                text = result.content.text
-            else:
-                return None
-
-            # Check for "no text" response
-            if text and "[NO TEXT DETECTED]" not in text:
-                return text.strip()
-
-        return None
+        return sampling_result_text(result)
 
     except Exception:
         # Sampling may fail for various reasons: client doesn't support sampling,
@@ -164,7 +179,7 @@ async def ocr_pages_via_sampling(
     Perform OCR on multiple pages using the client's LLM via MCP sampling.
 
     Args:
-        ctx: The FastMCP Context object from a tool function
+        ctx: The MCPServer Context object from a tool function
         png_data_list: List of PNG image bytes to perform OCR on
         max_tokens: Maximum tokens for each response (default: 2000)
 
@@ -217,7 +232,7 @@ def should_use_sampling_ocr(ctx: "Context") -> bool:
     2. The client supports the sampling capability
 
     Args:
-        ctx: The FastMCP Context object
+        ctx: The MCPServer Context object
 
     Returns:
         True if sampling OCR should be used, False otherwise

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -348,6 +348,8 @@ _app_canvas.register_app_tools()
 def _transport_security_for_host(host: str) -> TransportSecuritySettings:
     """Build a strict Host/Origin allowlist for the actual HTTP bind address."""
     normalized = host.strip().strip("[]")
+    if normalized in ("0.0.0.0", "::"):
+        raise ValueError("Wildcard HTTP bind addresses are not supported; use a concrete address.")
     if normalized in _LOOPBACK_HOSTS:
         return TransportSecuritySettings(
             enable_dns_rebinding_protection=True,

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -5,11 +5,13 @@ reMarkable MCP Server initialization.
 import logging
 import os
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError, version
 from ipaddress import ip_address
 from typing import AsyncIterator
 from urllib.parse import quote, unquote
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
 from mcp.server.transport_security import TransportSecuritySettings
 
 logger = logging.getLogger(__name__)
@@ -17,8 +19,8 @@ logger = logging.getLogger(__name__)
 _LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
 
 
-class RemarkableMCP(FastMCP):
-    """Custom FastMCP server that handles VS Code's URI quirks.
+class RemarkableMCP(MCPServer):
+    """Custom MCP server that handles VS Code's URI quirks.
 
     VS Code:
     - Appends ?version=... to resource URIs for cache busting
@@ -28,7 +30,7 @@ class RemarkableMCP(FastMCP):
     normalize incoming URIs to match.
     """
 
-    async def read_resource(self, uri):
+    async def read_resource(self, uri, context: Context | None = None):
         """Read a resource, normalizing the URI for lookup.
 
         Handles:
@@ -57,7 +59,7 @@ class RemarkableMCP(FastMCP):
             uri_str = scheme + encoded_path
             logger.debug(f"Normalized resource URI path: {path} -> {encoded_path}")
 
-        return await super().read_resource(uri_str)
+        return await super().read_resource(uri_str, context)
 
 
 def _build_instructions() -> str:
@@ -267,7 +269,7 @@ on handwriting. For better results, either:
 
 
 @asynccontextmanager
-async def lifespan(app: FastMCP) -> AsyncIterator[None]:
+async def lifespan(app: MCPServer) -> AsyncIterator[None]:
     """Lifespan context manager for the MCP server."""
     import asyncio
     import os
@@ -315,8 +317,20 @@ async def lifespan(app: FastMCP) -> AsyncIterator[None]:
         await stop_background_loader(task)
 
 
-# Initialize FastMCP server with lifespan and instructions
-mcp = RemarkableMCP("remarkable", instructions=_build_instructions(), lifespan=lifespan)
+try:
+    _SERVER_VERSION = version("remarkable-mcp")
+except PackageNotFoundError:
+    _SERVER_VERSION = ""
+
+# One MCPServer serves modern 2026-07-28 requests and legacy initialize/session
+# clients concurrently. reMarkable credentials and transport selection remain
+# process configuration; MCP HTTP authorization headers are intentionally unused.
+mcp = RemarkableMCP(
+    "remarkable",
+    instructions=_build_instructions(),
+    version=_SERVER_VERSION,
+    lifespan=lifespan,
+)
 
 # Import tools, resources, and prompts to register them
 from remarkable_mcp import (  # noqa: E402
@@ -385,7 +399,11 @@ def run(
 ):
     """Run the MCP server over stdio or Streamable HTTP."""
     if transport == "streamable-http":
-        mcp.settings.host = host
-        mcp.settings.port = port
-        mcp.settings.transport_security = _transport_security_for_host(host)
+        mcp.run(
+            transport=transport,
+            host=host,
+            port=port,
+            transport_security=_transport_security_for_host(host),
+        )
+        return
     mcp.run(transport=transport)

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -326,7 +326,7 @@ async def remarkable_read(
     </examples>
     """
     try:
-        client = get_rmapi()
+        client = await run_blocking(get_rmapi)
         collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
@@ -862,7 +862,7 @@ async def remarkable_browse(
     </examples>
     """
     try:
-        client = get_rmapi()
+        client = await run_blocking(get_rmapi)
         collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
         items_by_parent = get_items_by_parent(collection)
@@ -1090,7 +1090,7 @@ async def remarkable_recent(limit: int = 10, include_preview: bool = False) -> s
     </examples>
     """
     try:
-        client = get_rmapi()
+        client = await run_blocking(get_rmapi)
         collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 
@@ -1423,7 +1423,7 @@ async def remarkable_status() -> str:
     transport = selected_transport
 
     try:
-        client = get_rmapi()
+        client = await run_blocking(get_rmapi)
         # Reflect any startup fallback to cloud (device unreachable + token set).
         transport = get_active_transport()
         fell_back = transport != selected_transport
@@ -1636,7 +1636,7 @@ async def remarkable_image(
         if background is None:
             background = await run_blocking(get_background_color)
 
-        client = get_rmapi()
+        client = await run_blocking(get_rmapi)
         collection = await run_blocking(client.get_meta_items)
         items_by_id = get_items_by_id(collection)
 

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -7,16 +7,22 @@ USB web) and do not modify any documents.
 """
 
 import base64
+import logging
 import os
 import re
 import tempfile
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Literal, Optional
+from typing import Annotated, List, Literal, Optional
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context, Resolve, Sample
 from mcp.types import (
     BlobResourceContents,
+    CreateMessageResult,
     EmbeddedResource,
     TextContent,
     TextResourceContents,
@@ -32,6 +38,7 @@ from remarkable_mcp.api import (
     get_items_by_parent,
     get_rmapi,
 )
+from remarkable_mcp.capabilities import client_supports_sampling
 from remarkable_mcp.concurrency import run_blocking
 from remarkable_mcp.extract import (
     cache_page_ocr,
@@ -53,10 +60,109 @@ from remarkable_mcp.extract import (
 from remarkable_mcp.responses import make_error, make_response
 from remarkable_mcp.sampling import (
     get_ocr_backend,
-    ocr_via_sampling,
-    should_use_sampling_ocr,
+    make_ocr_sample,
+    sampling_result_text,
 )
 from remarkable_mcp.server import mcp
+
+logger = logging.getLogger(__name__)
+
+_SAMPLING_PAGE_CACHE_TTL = 600.0
+_SAMPLING_PAGE_CACHE_MAX = 8
+
+
+@dataclass(frozen=True)
+class _PreparedImageSampling:
+    """Rendered page retained across modern multi-round resolver retries."""
+
+    cache_key: tuple
+    total_pages: int
+    png_data: bytes
+    merged_note: Optional[str]
+    is_merged: bool
+    rendered_via_pdf: bool
+
+
+@dataclass(frozen=True)
+class _PreparedReadSampling:
+    """Notebook page retained across modern multi-round resolver retries."""
+
+    cache_key: tuple
+    total_pages: int
+    png_data: Optional[bytes]
+    cached_text: Optional[str]
+    content: Optional[dict]
+
+
+_sampling_page_cache: OrderedDict[
+    tuple, tuple[float, _PreparedImageSampling | _PreparedReadSampling]
+] = OrderedDict()
+_sampling_page_cache_lock = threading.Lock()
+
+
+def _sampling_document_revision(document) -> tuple:
+    """Build a stable revision token from metadata supplied by each transport."""
+    revision = []
+    for field in ("ModifiedClient", "Version", "version", "last_modified"):
+        value = getattr(document, field, None)
+        if isinstance(value, datetime):
+            value = value.isoformat()
+        if isinstance(value, (str, int, float, bool)):
+            revision.append((field, value))
+    return tuple(revision)
+
+
+def _image_sampling_cache_key(document, page: int, background: str, render_merged: bool) -> tuple:
+    return (
+        "image",
+        str(document.ID),
+        _sampling_document_revision(document),
+        page,
+        background,
+        render_merged,
+    )
+
+
+def _get_prepared_page(
+    key: tuple,
+) -> Optional[_PreparedImageSampling | _PreparedReadSampling]:
+    now = time.monotonic()
+    with _sampling_page_cache_lock:
+        cached = _sampling_page_cache.get(key)
+        if cached is None:
+            return None
+        created, prepared = cached
+        if now - created > _SAMPLING_PAGE_CACHE_TTL:
+            del _sampling_page_cache[key]
+            return None
+        _sampling_page_cache.move_to_end(key)
+        return prepared
+
+
+def _cache_prepared_page(
+    prepared: _PreparedImageSampling | _PreparedReadSampling,
+) -> None:
+    with _sampling_page_cache_lock:
+        _sampling_page_cache[prepared.cache_key] = (time.monotonic(), prepared)
+        _sampling_page_cache.move_to_end(prepared.cache_key)
+        while len(_sampling_page_cache) > _SAMPLING_PAGE_CACHE_MAX:
+            _sampling_page_cache.popitem(last=False)
+
+
+def _read_sampling_cache_key(
+    document,
+    page: int,
+    content_type: Literal["text", "raw", "annotations"],
+    include_ocr: bool,
+) -> tuple:
+    return (
+        "read",
+        str(document.ID),
+        _sampling_document_revision(document),
+        page,
+        content_type,
+        include_ocr,
+    )
 
 
 def _get_root_path() -> str:
@@ -118,12 +224,30 @@ def _resolve_root_path(path: str) -> str:
     return root + path
 
 
+def _find_target_document(collection, items_by_id: dict, document: str):
+    """Find an in-scope document by display name or full path."""
+    root = _get_root_path()
+    actual_document = _resolve_root_path(document) if document.startswith("/") else document
+    document_lower = actual_document.lower().strip("/")
+    for item in collection:
+        if item.is_folder:
+            continue
+        item_path = get_item_path(item, items_by_id)
+        if not _is_within_root(item_path, root):
+            continue
+        if item.VissibleName.lower() == document_lower:
+            return item
+        if item_path.lower().strip("/") == document_lower:
+            return item
+    return None
+
+
 # Base annotations for read-only operations
 _BASE_ANNOTATIONS = {
-    "readOnlyHint": True,
-    "destructiveHint": False,
-    "idempotentHint": True,
-    "openWorldHint": False,  # Private cloud account, not open world
+    "read_only_hint": True,
+    "destructive_hint": False,
+    "idempotent_hint": True,
+    "open_world_hint": False,  # Private cloud account, not open world
 }
 
 # Unique annotations for each tool with descriptive titles
@@ -279,6 +403,94 @@ def _ocr_png_google_vision(png_path: Path) -> Optional[str]:
     return None
 
 
+async def _prepare_read_sampling(
+    document: str,
+    content_type: Literal["text", "raw", "annotations"],
+    page: int,
+    include_ocr: bool,
+    ctx: Context,
+) -> Optional[_PreparedReadSampling]:
+    """Prepare one notebook page for an era-portable sampling request."""
+    if (
+        content_type == "raw"
+        or get_ocr_backend() != "sampling"
+        or not client_supports_sampling(ctx)
+    ):
+        return None
+
+    try:
+        client = get_rmapi()
+        collection = await run_blocking(client.get_meta_items)
+        items_by_id = get_items_by_id(collection)
+        target_doc = _find_target_document(collection, items_by_id, document)
+        if target_doc is None:
+            return None
+
+        file_type = await run_blocking(get_file_type, client, target_doc)
+        if file_type in ("pdf", "epub"):
+            return None
+
+        page = max(1, page)
+        cache_key = _read_sampling_cache_key(target_doc, page, content_type, include_ocr)
+        prepared = _get_prepared_page(cache_key)
+        if isinstance(prepared, _PreparedReadSampling):
+            return prepared
+
+        cached_text = await run_blocking(get_cached_page_ocr, target_doc.ID, page, "sampling")
+
+        raw_doc = await run_blocking(client.download, target_doc)
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(raw_doc)
+            tmp_path = Path(tmp.name)
+        try:
+            page_count = await run_blocking(get_document_page_count, tmp_path)
+            if page > page_count:
+                return None
+
+            content = None
+            if not include_ocr:
+                content = await run_blocking(
+                    extract_text_from_document_zip,
+                    tmp_path,
+                    include_ocr=False,
+                    doc_id=target_doc.ID,
+                )
+                if content.get("typed_text") or content.get("highlights"):
+                    return None
+
+            png_data = None
+            if cached_text is None:
+                png_data = await run_blocking(render_page_from_document_zip, tmp_path, page)
+                if png_data is None:
+                    return None
+
+            prepared = _PreparedReadSampling(
+                cache_key=cache_key,
+                total_pages=page_count,
+                png_data=png_data,
+                cached_text=cached_text,
+                content=content,
+            )
+            _cache_prepared_page(prepared)
+            return prepared
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    except Exception as exc:
+        # Sampling is an optional enhancement. Let the tool body preserve its
+        # educational connection/render error or use the configured local fallback.
+        logger.debug("Could not prepare sampling OCR for remarkable_read: %s", exc)
+        return None
+
+
+def _resolve_read_sampling(
+    prepared_read: Annotated[Optional[_PreparedReadSampling], Resolve(_prepare_read_sampling)],
+) -> Sample | None:
+    """Build one era-portable sampling request from the retained page."""
+    if prepared_read is None or prepared_read.png_data is None:
+        return None
+    return make_ocr_sample(prepared_read.png_data)
+
+
 @mcp.tool(annotations=READ_ANNOTATIONS)
 async def remarkable_read(
     document: str,
@@ -287,6 +499,12 @@ async def remarkable_read(
     grep: Optional[str] = None,
     include_ocr: bool = False,
     ctx: Optional[Context] = None,
+    prepared_read: Annotated[
+        Optional[_PreparedReadSampling], Resolve(_prepare_read_sampling)
+    ] = None,
+    sampling_result: Annotated[
+        Optional[CreateMessageResult], Resolve(_resolve_read_sampling)
+    ] = None,
 ) -> str:
     """
     <usecase>Read and extract text content from a reMarkable document.</usecase>
@@ -336,27 +554,8 @@ async def remarkable_read(
         page_size = DEFAULT_PAGE_SIZE
 
         root = _get_root_path()
-        # Resolve user-provided path to actual device path
-        actual_document = _resolve_root_path(document) if document.startswith("/") else document
-
-        # Find the document by name or path (case-insensitive, not folders)
         documents = [item for item in collection if not item.is_folder]
-        target_doc = None
-        document_lower = actual_document.lower().strip("/")
-
-        for doc in documents:
-            doc_path = get_item_path(doc, items_by_id)
-            # Filter by root path
-            if not _is_within_root(doc_path, root):
-                continue
-            # Match by name (case-insensitive)
-            if doc.VissibleName.lower() == document_lower:
-                target_doc = doc
-                break
-            # Also try matching by full path (case-insensitive)
-            if doc_path.lower().strip("/") == document_lower:
-                target_doc = doc
-                break
+        target_doc = _find_target_document(collection, items_by_id, document)
 
         if not target_doc:
             # Find similar documents for suggestion (only within root)
@@ -377,6 +576,12 @@ async def remarkable_read(
 
         doc_path = get_item_path(target_doc, items_by_id)
         file_type = await run_blocking(get_file_type, client, target_doc)
+        expected_read_key = _read_sampling_cache_key(target_doc, page, content_type, include_ocr)
+        prepared_sampling = (
+            prepared_read
+            if prepared_read is not None and prepared_read.cache_key == expected_read_key
+            else None
+        )
 
         # Collect content based on content_type
         text_parts = []
@@ -415,75 +620,31 @@ async def remarkable_read(
         ocr_backend_used = None  # Track which OCR backend was used
         content = None  # Will hold extraction result
         total_notebook_pages = 0  # Track total pages for sampling mode
+        sampling_auto_enabled = False
 
         if content_type in ("text", "annotations"):
             # For notebooks (no PDF/EPUB), use page-based pagination
             is_notebook = file_type not in ("pdf", "epub")
 
-            # Determine if we should use sampling OCR
-            use_sampling = is_notebook and include_ocr and ctx and should_use_sampling_ocr(ctx)
+            use_sampling = is_notebook and prepared_sampling is not None
+            sampling_auto_enabled = use_sampling and not include_ocr
 
-            # For sampling OCR: use per-page caching and only OCR requested page
             if use_sampling:
-                # Check per-page cache first
-                cached_text = await run_blocking(
-                    get_cached_page_ocr, target_doc.ID, page, "sampling"
-                )
-                if cached_text is not None:
-                    # We have cached OCR for this page
-                    # Still need to get total page count
-                    raw_doc = await run_blocking(client.download, target_doc)
-                    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                        tmp.write(raw_doc)
-                        tmp_path = Path(tmp.name)
-                    try:
-                        total_notebook_pages = await run_blocking(get_document_page_count, tmp_path)
-                    finally:
-                        tmp_path.unlink(missing_ok=True)
-
-                    # Build notebook_pages list with just the cached page
+                total_notebook_pages = prepared_sampling.total_pages
+                content = prepared_sampling.content
+                ocr_text = prepared_sampling.cached_text or sampling_result_text(sampling_result)
+                if ocr_text is not None:
+                    if prepared_sampling.cached_text is None:
+                        await run_blocking(
+                            cache_page_ocr,
+                            target_doc.ID,
+                            page,
+                            "sampling",
+                            ocr_text,
+                        )
                     notebook_pages = [""] * total_notebook_pages
-                    notebook_pages[page - 1] = cached_text
+                    notebook_pages[page - 1] = ocr_text
                     ocr_backend_used = "sampling"
-                else:
-                    # No cache - render and OCR just the requested page
-                    raw_doc = await run_blocking(client.download, target_doc)
-                    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                        tmp.write(raw_doc)
-                        tmp_path = Path(tmp.name)
-
-                    try:
-                        total_notebook_pages = await run_blocking(get_document_page_count, tmp_path)
-
-                        if page > total_notebook_pages:
-                            return make_error(
-                                error_type="page_out_of_range",
-                                message=f"Page {page} does not exist. "
-                                f"Document has {total_notebook_pages} notebook page(s).",
-                                suggestion=f"Use page=1 to {total_notebook_pages} "
-                                "to read different pages.",
-                            )
-
-                        # Render just the requested page
-                        png_data = await run_blocking(render_page_from_document_zip, tmp_path, page)
-                        if png_data:
-                            # OCR the single page
-                            ocr_text = await ocr_via_sampling(ctx, png_data)
-                            if ocr_text:
-                                # Cache the result
-                                await run_blocking(
-                                    cache_page_ocr,
-                                    target_doc.ID,
-                                    page,
-                                    "sampling",
-                                    ocr_text,
-                                )
-                                # Build notebook_pages list
-                                notebook_pages = [""] * total_notebook_pages
-                                notebook_pages[page - 1] = ocr_text
-                                ocr_backend_used = "sampling"
-                    finally:
-                        tmp_path.unlink(missing_ok=True)
 
             # For non-sampling: check full document cache or extract all
             if not use_sampling and is_notebook and include_ocr:
@@ -643,15 +804,18 @@ async def remarkable_read(
                 ),
             }
 
-            # Add OCR backend info if OCR was used
-            if include_ocr and ocr_backend_used:
+            if ocr_backend_used:
                 result["ocr_backend"] = ocr_backend_used
+            if sampling_auto_enabled:
+                result["_ocr_auto_enabled"] = True
 
             if grep:
                 result["grep"] = grep
                 result["grep_matches"] = grep_matches
 
             hint_parts = [f"Notebook page {page}/{total_pages}."]
+            if sampling_auto_enabled:
+                hint_parts.insert(0, "OCR auto-enabled (notebook had no typed text).")
             if has_more:
                 doc_name = target_doc.VissibleName
                 hint_parts.append(f"Next: remarkable_read('{doc_name}', page={page + 1}).")
@@ -714,6 +878,7 @@ async def remarkable_read(
                 grep=grep,
                 include_ocr=True,  # Enable OCR automatically
                 ctx=ctx,  # Pass context for sampling OCR
+                sampling_result=sampling_result,
             )
             result_data = json.loads(ocr_result)
             if "_error" not in result_data:
@@ -1560,6 +1725,128 @@ async def remarkable_status() -> str:
         return make_response(result, hint)
 
 
+async def _render_png_page(
+    client,
+    target_doc,
+    tmp_path: Path,
+    page: int,
+    background: str,
+    render_merged: bool,
+) -> tuple[Optional[bytes], Optional[str], bool, bool]:
+    """Render a PNG with the same fallbacks used by remarkable_image."""
+    merged_note = None
+    is_merged = False
+    if render_merged:
+        png_data, merged_note = await run_blocking(
+            render_merged_page_from_document_zip,
+            tmp_path,
+            page,
+            background_color=background,
+        )
+        is_merged = png_data is not None and merged_note is None
+    else:
+        png_data = await run_blocking(
+            render_page_from_document_zip,
+            tmp_path,
+            page,
+            background_color=background,
+        )
+
+    rendered_via_pdf = False
+    if png_data is None:
+        png_data, has_source_pdf = await run_blocking(
+            render_mapped_pdf_page_from_document_zip, tmp_path, page
+        )
+        rendered_via_pdf = png_data is not None
+        if png_data is None and not has_source_pdf:
+            pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
+            if pdf_bytes:
+                png_data = await run_blocking(render_tablet_pdf_page_to_png, pdf_bytes, page)
+                rendered_via_pdf = png_data is not None
+
+    if png_data is None:
+        full = await run_blocking(
+            render_page_full_page_from_document_zip,
+            tmp_path,
+            page,
+            background_color=background,
+        )
+        if full is not None:
+            png_data = full[0]
+
+    return png_data, merged_note, is_merged, rendered_via_pdf
+
+
+async def _prepare_image_sampling(
+    document: str,
+    page: int,
+    background: Optional[str],
+    output_format: str,
+    include_ocr: bool,
+    render_merged: bool,
+    ctx: Context,
+) -> Optional[_PreparedImageSampling]:
+    """Render and retain one page across all rounds of a sampling tool call."""
+    if (
+        not include_ocr
+        or output_format.lower() != "png"
+        or get_ocr_backend() != "sampling"
+        or not client_supports_sampling(ctx)
+    ):
+        return None
+
+    try:
+        if background is None:
+            background = await run_blocking(get_background_color)
+        client = get_rmapi()
+        collection = await run_blocking(client.get_meta_items)
+        items_by_id = get_items_by_id(collection)
+        target_doc = _find_target_document(collection, items_by_id, document)
+        if target_doc is None:
+            return None
+
+        cache_key = _image_sampling_cache_key(target_doc, page, background, render_merged)
+        prepared = _get_prepared_page(cache_key)
+        if isinstance(prepared, _PreparedImageSampling):
+            return prepared
+
+        raw_doc = await run_blocking(client.download, target_doc)
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(raw_doc)
+            tmp_path = Path(tmp.name)
+        try:
+            page_count = await run_blocking(get_document_page_count, tmp_path)
+            if page < 1 or page > page_count:
+                return None
+            png_data, merged_note, is_merged, rendered_via_pdf = await _render_png_page(
+                client, target_doc, tmp_path, page, background, render_merged
+            )
+            if png_data is None:
+                return None
+            prepared = _PreparedImageSampling(
+                cache_key=cache_key,
+                total_pages=page_count,
+                png_data=png_data,
+                merged_note=merged_note,
+                is_merged=is_merged,
+                rendered_via_pdf=rendered_via_pdf,
+            )
+            _cache_prepared_page(prepared)
+            return prepared
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    except Exception as exc:
+        logger.debug("Could not prepare sampling OCR for remarkable_image: %s", exc)
+        return None
+
+
+def _resolve_image_sampling(
+    prepared_image: Annotated[Optional[_PreparedImageSampling], Resolve(_prepare_image_sampling)],
+) -> Sample | None:
+    """Build one era-portable sampling request from the retained page."""
+    return make_ocr_sample(prepared_image.png_data) if prepared_image else None
+
+
 @mcp.tool(annotations=IMAGE_ANNOTATIONS)
 async def remarkable_image(
     document: str,
@@ -1570,6 +1857,12 @@ async def remarkable_image(
     include_ocr: bool = False,
     render_merged: bool = False,
     ctx: Optional[Context] = None,
+    prepared_image: Annotated[
+        Optional[_PreparedImageSampling], Resolve(_prepare_image_sampling)
+    ] = None,
+    sampling_result: Annotated[
+        Optional[CreateMessageResult], Resolve(_resolve_image_sampling)
+    ] = None,
 ):
     """
     <usecase>Get an image of a specific page from a reMarkable document.</usecase>
@@ -1641,27 +1934,8 @@ async def remarkable_image(
         items_by_id = get_items_by_id(collection)
 
         root = _get_root_path()
-        # Resolve user-provided path to actual device path
-        actual_document = _resolve_root_path(document) if document.startswith("/") else document
-
-        # Find the document by name or path (case-insensitive, not folders)
         documents = [item for item in collection if not item.is_folder]
-        target_doc = None
-        document_lower = actual_document.lower().strip("/")
-
-        for doc in documents:
-            doc_path = get_item_path(doc, items_by_id)
-            # Filter by root path
-            if not _is_within_root(doc_path, root):
-                continue
-            # Match by name (case-insensitive)
-            if doc.VissibleName.lower() == document_lower:
-                target_doc = doc
-                break
-            # Also try matching by full path (case-insensitive)
-            if doc_path.lower().strip("/") == document_lower:
-                target_doc = doc
-                break
+        target_doc = _find_target_document(collection, items_by_id, document)
 
         if not target_doc:
             # Find similar documents for suggestion (only within root)
@@ -1680,24 +1954,38 @@ async def remarkable_image(
                 did_you_mean=similar if similar else None,
             )
 
-        # Download the document
-        raw_doc = await run_blocking(client.download, target_doc)
-        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-            tmp.write(raw_doc)
-            tmp_path = Path(tmp.name)
+        format_lower = output_format.lower()
+        if format_lower not in ("png", "svg"):
+            return make_error(
+                error_type="invalid_format",
+                message=f"Invalid format: '{output_format}'. Supported formats: png, svg",
+                suggestion="Use output_format='png' for raster or 'svg' for vectors.",
+            )
+
+        expected_prepared_key = _image_sampling_cache_key(
+            target_doc, page, background, render_merged
+        )
+        prepared = (
+            prepared_image
+            if format_lower == "png"
+            and prepared_image is not None
+            and prepared_image.cache_key == expected_prepared_key
+            else None
+        )
+
+        tmp_path = None
+        if prepared is None:
+            raw_doc = await run_blocking(client.download, target_doc)
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                tmp.write(raw_doc)
+                tmp_path = Path(tmp.name)
 
         try:
-            # Validate format parameter
-            format_lower = output_format.lower()
-            if format_lower not in ("png", "svg"):
-                return make_error(
-                    error_type="invalid_format",
-                    message=f"Invalid format: '{output_format}'. Supported formats: png, svg",
-                    suggestion="Use output_format='png' for raster or 'svg' for vectors.",
-                )
-
-            # Get total page count
-            total_pages = await run_blocking(get_document_page_count, tmp_path)
+            total_pages = (
+                prepared.total_pages
+                if prepared is not None
+                else await run_blocking(get_document_page_count, tmp_path)
+            )
 
             if total_pages == 0:
                 return make_error(
@@ -1725,6 +2013,7 @@ async def remarkable_image(
             is_merged = False
 
             if format_lower == "svg":
+                assert tmp_path is not None
                 if render_merged:
                     merged_note = (
                         "render_merged is only supported with PNG format; "
@@ -1774,7 +2063,7 @@ async def remarkable_image(
                     # Return SVG as embedded TextResourceContents with info hint
                     text_resource = TextResourceContents(
                         uri=resource_uri,
-                        mimeType="image/svg+xml",
+                        mime_type="image/svg+xml",
                         text=svg_content,
                     )
                     embedded = EmbeddedResource(type="resource", resource=text_resource)
@@ -1787,61 +2076,26 @@ async def remarkable_image(
                     info = TextContent(type="text", text=info_text)
                     return [info, embedded]
             else:
-                # PNG format
-                if render_merged:
-                    png_data, merged_note = await run_blocking(
-                        render_merged_page_from_document_zip,
-                        tmp_path,
-                        page,
-                        background_color=background,
-                    )
-                    is_merged = png_data is not None and merged_note is None
+                if prepared is not None:
+                    png_data = prepared.png_data
+                    merged_note = prepared.merged_note
+                    is_merged = prepared.is_merged
+                    rendered_via_pdf = prepared.rendered_via_pdf
                 else:
-                    png_data = await run_blocking(
-                        render_page_from_document_zip,
+                    assert tmp_path is not None
+                    (
+                        png_data,
+                        merged_note,
+                        is_merged,
+                        rendered_via_pdf,
+                    ) = await _render_png_page(
+                        client,
+                        target_doc,
                         tmp_path,
                         page,
-                        background_color=background,
+                        background,
+                        render_merged,
                     )
-
-                # Portable fallback: the local stroke renderer can fail to
-                # produce an image for empty pages or newer .rm block formats.
-                # In that case we rasterize the requested page from the document's
-                # source PDF. USB/SSH expose the tablet's natively-rendered (merged)
-                # PDF; cloud exposes the original source PDF — either covers the
-                # failure cases above. Both SVG and PDF rasterization use PyMuPDF,
-                # which needs no system Cairo. Notebooks have no PDF, so
-                # download_raw_file returns None and this safely no-ops.
-                # Credit: ljdutel (#95).
-                rendered_via_pdf = False
-                if png_data is None:
-                    png_data, has_source_pdf = await run_blocking(
-                        render_mapped_pdf_page_from_document_zip, tmp_path, page
-                    )
-                    rendered_via_pdf = png_data is not None
-                    if png_data is None and not has_source_pdf:
-                        pdf_bytes = await run_blocking(download_raw_file, client, target_doc, "pdf")
-                        if pdf_bytes:
-                            png_data = await run_blocking(
-                                render_tablet_pdf_page_to_png, pdf_bytes, page
-                            )
-                            rendered_via_pdf = png_data is not None
-
-                # Blank-page fallback: the stroke renderer returns None for a
-                # notebook page with no drawable strokes (e.g. a freshly-created
-                # or blank page). The interactive canvas already renders such
-                # pages full-bleed at their own paper size; do the same here so a
-                # blank page yields a blank image instead of render_failed,
-                # keeping remarkable_image consistent with remarkable_canvas.
-                if png_data is None:
-                    full = await run_blocking(
-                        render_page_full_page_from_document_zip,
-                        tmp_path,
-                        page,
-                        background_color=background,
-                    )
-                    if full is not None:
-                        png_data = full[0]
 
                 if png_data is None:
                     return make_error(
@@ -1862,8 +2116,8 @@ async def remarkable_image(
                 if include_ocr:
                     # Try sampling-based OCR if configured and available
                     # This sends the image to the client's LLM to extract text
-                    if ctx and should_use_sampling_ocr(ctx):
-                        ocr_text = await ocr_via_sampling(ctx, png_data)
+                    if get_ocr_backend() == "sampling":
+                        ocr_text = sampling_result_text(sampling_result)
                         if ocr_text:
                             ocr_backend_used = "sampling"
 
@@ -1945,7 +2199,7 @@ async def remarkable_image(
                     # Return PNG as embedded BlobResourceContents with info hint
                     blob_resource = BlobResourceContents(
                         uri=resource_uri,
-                        mimeType="image/png",
+                        mime_type="image/png",
                         blob=png_base64,
                     )
                     embedded = EmbeddedResource(type="resource", resource=blob_resource)
@@ -1970,7 +2224,8 @@ async def remarkable_image(
                     return [info, embedded]
 
         finally:
-            tmp_path.unlink(missing_ok=True)
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
 
     except Exception as e:
         return make_error(

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -488,7 +488,7 @@ async def _prepare_read_sampling(
 
 
 def _resolve_read_sampling(
-    prepared_read: Annotated[Optional[_PreparedReadSampling], Resolve(_prepare_read_sampling)],
+    prepared_read: Annotated[_PreparedReadSampling, Resolve(_prepare_read_sampling)],
 ) -> Sample | None:
     """Build one era-portable sampling request from the retained page."""
     if prepared_read is None or prepared_read.png_data is None:
@@ -504,12 +504,9 @@ async def remarkable_read(
     grep: Optional[str] = None,
     include_ocr: bool = False,
     ctx: Optional[Context] = None,
-    prepared_read: Annotated[
-        Optional[_PreparedReadSampling], Resolve(_prepare_read_sampling)
-    ] = None,
-    sampling_result: Annotated[
-        Optional[CreateMessageResult], Resolve(_resolve_read_sampling)
-    ] = None,
+    *,
+    prepared_read: Annotated[_PreparedReadSampling, Resolve(_prepare_read_sampling)],
+    sampling_result: Annotated[CreateMessageResult, Resolve(_resolve_read_sampling)],
 ) -> str:
     """
     <usecase>Read and extract text content from a reMarkable document.</usecase>
@@ -884,6 +881,7 @@ async def remarkable_read(
                 grep=grep,
                 include_ocr=True,  # Enable OCR automatically
                 ctx=ctx,  # Pass context for sampling OCR
+                prepared_read=prepared_read,
                 sampling_result=sampling_result,
             )
             result_data = json.loads(ocr_result)
@@ -1143,7 +1141,12 @@ async def remarkable_browse(
                                 suggestion="Check REMARKABLE_ROOT_PATH configuration.",
                             )
                         # Call remarkable_read internally and add redirect note
-                        read_result = remarkable_read(_apply_root_filter(doc_path), page=1)
+                        read_result = await remarkable_read(
+                            _apply_root_filter(doc_path),
+                            page=1,
+                            prepared_read=None,
+                            sampling_result=None,
+                        )
                         import json
 
                         result_data = json.loads(read_result)
@@ -1430,6 +1433,8 @@ async def remarkable_search(
                     page=1,
                     grep=grep,
                     include_ocr=include_ocr,
+                    prepared_read=None,
+                    sampling_result=None,
                 )
                 read_data = json.loads(read_result)
 
@@ -1847,7 +1852,7 @@ async def _prepare_image_sampling(
 
 
 def _resolve_image_sampling(
-    prepared_image: Annotated[Optional[_PreparedImageSampling], Resolve(_prepare_image_sampling)],
+    prepared_image: Annotated[_PreparedImageSampling, Resolve(_prepare_image_sampling)],
 ) -> Sample | None:
     """Build one era-portable sampling request from the retained page."""
     return make_ocr_sample(prepared_image.png_data) if prepared_image else None
@@ -1863,12 +1868,9 @@ async def remarkable_image(
     include_ocr: bool = False,
     render_merged: bool = False,
     ctx: Optional[Context] = None,
-    prepared_image: Annotated[
-        Optional[_PreparedImageSampling], Resolve(_prepare_image_sampling)
-    ] = None,
-    sampling_result: Annotated[
-        Optional[CreateMessageResult], Resolve(_resolve_image_sampling)
-    ] = None,
+    *,
+    prepared_image: Annotated[_PreparedImageSampling, Resolve(_prepare_image_sampling)],
+    sampling_result: Annotated[CreateMessageResult, Resolve(_resolve_image_sampling)],
 ):
     """
     <usecase>Get an image of a specific page from a reMarkable document.</usecase>

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -27,9 +27,9 @@ import logging
 import os
 import time
 import uuid
-from typing import Optional
+from typing import Annotated, Optional
 
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context, Elicit, ElicitationResult, Resolve
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
@@ -45,12 +45,12 @@ from remarkable_mcp.ssh import XOCHITL_PATH, SSHClient
 logger = logging.getLogger(__name__)
 
 # Tool annotations for write operations
-WRITE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False)
+WRITE_ANNOTATIONS = ToolAnnotations(read_only_hint=False)
 UPLOAD_ANNOTATIONS = WRITE_ANNOTATIONS
 MKDIR_ANNOTATIONS = WRITE_ANNOTATIONS
 MOVE_ANNOTATIONS = WRITE_ANNOTATIONS
 RENAME_ANNOTATIONS = WRITE_ANNOTATIONS
-DELETE_ANNOTATIONS = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+DELETE_ANNOTATIONS = ToolAnnotations(read_only_hint=False, destructive_hint=True)
 
 
 def read_only_enabled() -> bool:
@@ -611,8 +611,39 @@ class _DeleteConfirmation(BaseModel):
     )
 
 
-async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str]:
-    """Confirm a destructive delete before it runs.
+def _delete_confirmation_available(ctx: Context) -> bool:
+    """Return whether this request can confirm a delete interactively."""
+    if os.environ.get("REMARKABLE_SKIP_CONFIRM", "").lower() in ("1", "true", "yes"):
+        return True
+    return client_supports_elicitation(ctx)
+
+
+def _resolve_delete_confirmation(
+    document: str,
+    confirmation_available: Annotated[bool, Resolve(_delete_confirmation_available)],
+) -> _DeleteConfirmation | Elicit[_DeleteConfirmation]:
+    """Resolve confirmation over a legacy back-channel or a modern input round."""
+    skip = os.environ.get("REMARKABLE_SKIP_CONFIRM", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if skip:
+        return _DeleteConfirmation(confirm=True)
+    if not confirmation_available:
+        return _DeleteConfirmation(confirm=False)
+    return Elicit(
+        f"Delete '{document}' from your reMarkable? This moves it to the trash.",
+        _DeleteConfirmation,
+    )
+
+
+def _delete_confirmation_abort(
+    confirmation: ElicitationResult[_DeleteConfirmation],
+    confirmation_available: bool,
+    document: str,
+) -> Optional[str]:
+    """Return an abort response unless a destructive delete was confirmed.
 
     Returns None to proceed with the delete, or a response string (a
     cancellation or a refusal) to abort.
@@ -625,9 +656,7 @@ async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str
     are on by default, and most MCP clients don't support elicitation yet, so
     this refusal path is the common case for unattended setups.
     """
-    if os.environ.get("REMARKABLE_SKIP_CONFIRM", "").lower() in ("1", "true", "yes"):
-        return None
-    if ctx is None or not client_supports_elicitation(ctx):
+    if not confirmation_available:
         return make_error(
             "confirmation_unavailable",
             (
@@ -641,25 +670,7 @@ async def _confirm_delete(ctx: Optional[Context], document: str) -> Optional[str
                 "(e.g. for headless automation)."
             ),
         )
-    try:
-        result = await ctx.elicit(
-            message=f"Delete '{document}' from your reMarkable? This moves it to the trash.",
-            schema=_DeleteConfirmation,
-        )
-    except Exception as e:  # elicitation advertised but failed — refuse, don't delete
-        logger.debug(f"Elicitation failed, refusing delete without confirmation: {e}")
-        return make_error(
-            "confirmation_unavailable",
-            (
-                f"Refused to delete '{document}': the confirmation prompt could "
-                "not be shown and delete is a destructive operation."
-            ),
-            (
-                "Retry from a client that can display confirmation prompts, or "
-                "set REMARKABLE_SKIP_CONFIRM=1 to allow deletes without a prompt."
-            ),
-        )
-    if result.action != "accept" or not getattr(result.data, "confirm", False):
+    if confirmation.action != "accept" or not getattr(confirmation.data, "confirm", False):
         return make_response(
             {"deleted": False, "cancelled": True, "document": document},
             "Delete cancelled — nothing was changed.",
@@ -1637,7 +1648,13 @@ def register_write_tools():
         async def remarkable_delete(
             document: str,
             defer_restart: bool = False,
-            ctx: Optional[Context] = None,
+            confirmation: Annotated[
+                ElicitationResult[_DeleteConfirmation],
+                Resolve(_resolve_delete_confirmation),
+            ] = None,
+            confirmation_available: Annotated[
+                bool, Resolve(_delete_confirmation_available)
+            ] = False,
         ) -> str:
             """
             <usecase>Delete a document or folder on the reMarkable tablet.</usecase>
@@ -1669,7 +1686,7 @@ def register_write_tools():
             if error:
                 return error
 
-            abort = await _confirm_delete(ctx, document)
+            abort = _delete_confirmation_abort(confirmation, confirmation_available, document)
             if abort:
                 return abort
 

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1728,13 +1728,12 @@ def register_write_tools():
             document: str,
             defer_restart: bool = False,
             permanent: bool = False,
+            *,
             confirmation: Annotated[
                 ElicitationResult[_DeleteConfirmation],
                 Resolve(_resolve_delete_confirmation),
-            ] = None,
-            confirmation_available: Annotated[
-                bool, Resolve(_delete_confirmation_available)
-            ] = False,
+            ],
+            confirmation_available: Annotated[bool, Resolve(_delete_confirmation_available)],
         ) -> str:
             """
             <usecase>Delete a document or folder on the reMarkable tablet.</usecase>

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.SamMorrowDrums/remarkable",
   "title": "reMarkable MCP Server",
-  "description": "Access your reMarkable tablet - read documents, browse files, extract text and OCR",
+  "description": "Read, render, search, and manage reMarkable documents through MCP",
   "repository": {
     "url": "https://github.com/SamMorrowDrums/remarkable-mcp",
     "source": "github"
@@ -19,8 +19,8 @@
       "environmentVariables": [
         {
           "name": "REMARKABLE_TOKEN",
-          "description": "Authentication token for reMarkable Cloud API. Get one by registering at https://my.remarkable.com/device/browser/connect",
-          "isRequired": true,
+          "description": "Optional cloud credential. Prefer `remarkable-mcp --register CODE`, which saves it to ~/.rmapi. USB, SSH, and local-directory modes do not require it.",
+          "isRequired": false,
           "format": "string",
           "isSecret": true
         }

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -4,6 +4,8 @@
 deterministic, no-AI diagnostic that drives the *real* `remarkable-mcp` server
 over the MCP protocol (stdio, via the official `mcp` client SDK — no models, no
 mocks) and exercises **every available tool in every available transport**.
+The SDK 2.x `Client` probes modern discovery first and falls back to the legacy
+initialize handshake, so the harness also checks real protocol negotiation.
 
 It answers one question quickly: *"does each mode this machine can reach actually
 work, tool by tool?"*

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -54,7 +54,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 
-from mcp import ClientSession, StdioServerParameters
+from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -216,7 +216,7 @@ def _parse_payload(result) -> dict:
                 return json.loads(text)
             except (json.JSONDecodeError, TypeError):
                 continue
-    structured = getattr(result, "structuredContent", None)
+    structured = getattr(result, "structured_content", None)
     if isinstance(structured, dict):
         return structured
     return {}
@@ -265,7 +265,7 @@ async def call_tool(session, tool, args, timeout):
     except Exception as exc:  # noqa: BLE001 - report any client/transport error
         return {}, True, f"{type(exc).__name__}: {exc}"
     payload = _parse_payload(result)
-    return payload, bool(getattr(result, "isError", False)), None
+    return payload, bool(getattr(result, "is_error", False)), None
 
 
 def classify_ok(payload, is_error, exc, ok_error_types=()):
@@ -602,47 +602,46 @@ async def run_mode(mode: str, rec: Recorder, read_only: bool):
     )
 
     try:
-        async with stdio_client(params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await asyncio.wait_for(session.initialize(), 60)
+        async with Client(stdio_client(params)) as session:
+            # Client auto-negotiates 2026-07-28 and falls back to initialize
+            # when this smoke harness is pointed at a legacy server.
+            # status decides availability for real (handles fallback / auth).
+            payload, is_err, exc = await call_tool(
+                session, "remarkable_status", {}, TIMEOUTS["remarkable_status"]
+            )
+            authed = isinstance(payload, dict) and payload.get("authenticated") is True
+            transport = payload.get("transport") if isinstance(payload, dict) else None
+            fell_back = (
+                bool(payload.get("fell_back_to_cloud")) if isinstance(payload, dict) else False
+            )
+            want_transport = spec["transport"]
 
-                # status decides availability for real (handles fallback / auth).
-                payload, is_err, exc = await call_tool(
-                    session, "remarkable_status", {}, TIMEOUTS["remarkable_status"]
+            if exc or not authed or transport != want_transport or fell_back:
+                detail = exc or (
+                    f"authenticated={authed} transport={transport} "
+                    f"expected={want_transport} fell_back={fell_back}"
                 )
-                authed = isinstance(payload, dict) and payload.get("authenticated") is True
-                transport = payload.get("transport") if isinstance(payload, dict) else None
-                fell_back = (
-                    bool(payload.get("fell_back_to_cloud")) if isinstance(payload, dict) else False
-                )
-                want_transport = spec["transport"]
+                rec.mode_unavailable(mode, f"status check failed: {detail}")
+                return
 
-                if exc or not authed or transport != want_transport or fell_back:
-                    detail = exc or (
-                        f"authenticated={authed} transport={transport} "
-                        f"expected={want_transport} fell_back={fell_back}"
-                    )
-                    rec.mode_unavailable(mode, f"status check failed: {detail}")
-                    return
+            rec.ensure_mode(mode, transport, payload.get("document_count"), "connected")
+            rec.record(
+                mode, "remarkable_status", PASS, "", _detail_for("remarkable_status", payload)
+            )
 
-                rec.ensure_mode(mode, transport, payload.get("document_count"), "connected")
-                rec.record(
-                    mode, "remarkable_status", PASS, "", _detail_for("remarkable_status", payload)
-                )
+            # tools/list is the source of truth for what this mode supports.
+            tools_result = await asyncio.wait_for(session.list_tools(), 30)
+            registered = {t.name for t in tools_result.tools}
+            rec.modes[mode]["registered_tools"] = sorted(registered)
+            _mark_hidden_tools_na(mode, rec, registered)
 
-                # tools/list is the source of truth for what this mode supports.
-                tools_result = await asyncio.wait_for(session.list_tools(), 30)
-                registered = {t.name for t in tools_result.tools}
-                rec.modes[mode]["registered_tools"] = sorted(registered)
-                _mark_hidden_tools_na(mode, rec, registered)
-
-                await run_read_phase(session, mode, rec, registered)
-                if read_only:
-                    for tool in WRITE_TOOLS:
-                        if tool in registered:
-                            rec.record(mode, tool, SKIP, "write phase skipped (--read-only)")
-                else:
-                    await run_write_phase(session, mode, rec, registered)
+            await run_read_phase(session, mode, rec, registered)
+            if read_only:
+                for tool in WRITE_TOOLS:
+                    if tool in registered:
+                        rec.record(mode, tool, SKIP, "write phase skipped (--read-only)")
+            else:
+                await run_write_phase(session, mode, rec, registered)
     except Exception as exc:  # noqa: BLE001
         rec.mode_unavailable(mode, f"server launch/session error: {type(exc).__name__}: {exc}")
 

--- a/test_integration.py
+++ b/test_integration.py
@@ -177,7 +177,7 @@ class TestMCPTools:
             from remarkable_mcp.server import mcp
 
             result = await mcp.call_tool("remarkable_status", {})
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["authenticated"] is True
             assert data["transport"] == "ssh"
             assert data["document_count"] > 0

--- a/test_mcp_v2.py
+++ b/test_mcp_v2.py
@@ -1,0 +1,289 @@
+"""MCP SDK v2 protocol-era compatibility tests."""
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from mcp import Client
+from mcp.client import ClientRequestContext
+from mcp.types import (
+    CreateMessageRequestParams,
+    CreateMessageResult,
+    ElicitRequestParams,
+    ElicitResult,
+    TextContent,
+)
+
+from remarkable_mcp.app_canvas import CANVAS_RESOURCE_URI
+from remarkable_mcp.server import mcp
+
+
+def _document(name: str = "Test Document") -> Mock:
+    document = Mock()
+    document.VissibleName = name
+    document.ID = "doc-1"
+    document.Parent = ""
+    document.ModifiedClient = None
+    document.is_folder = False
+    return document
+
+
+def _without_background_loader():
+    return (
+        patch("remarkable_mcp.resources.start_background_loader", return_value=None),
+        patch(
+            "remarkable_mcp.resources.stop_background_loader",
+            new_callable=AsyncMock,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_server_serves_modern_and_legacy_catalogs():
+    """The same server exposes equivalent surfaces in both protocol eras."""
+    api_client = Mock()
+    api_client.get_meta_items.return_value = []
+
+    loader_start, loader_stop = _without_background_loader()
+    with (
+        loader_start,
+        loader_stop,
+        patch("remarkable_mcp.tools.get_rmapi", return_value=api_client),
+    ):
+        async with (
+            Client(mcp) as modern,
+            Client(mcp, mode="legacy") as legacy,
+        ):
+            assert modern.protocol_version == "2026-07-28"
+            assert legacy.protocol_version == "2025-11-25"
+
+            modern_tools = await modern.list_tools()
+            legacy_tools = await legacy.list_tools()
+            assert {tool.name for tool in modern_tools.tools} == {
+                tool.name for tool in legacy_tools.tools
+            }
+
+            modern_prompts = await modern.list_prompts()
+            legacy_prompts = await legacy.list_prompts()
+            assert {prompt.name for prompt in modern_prompts.prompts} == {
+                prompt.name for prompt in legacy_prompts.prompts
+            }
+
+            canvas = next(tool for tool in modern_tools.tools if tool.name == "remarkable_canvas")
+            assert canvas.meta["ui"]["resourceUri"] == CANVAS_RESOURCE_URI
+
+            resource = await modern.read_resource(CANVAS_RESOURCE_URI)
+            assert resource.contents[0].mime_type == "text/html;profile=mcp-app"
+            assert "<!doctype html>" in resource.contents[0].text
+
+            modern_status, legacy_status = (
+                await modern.call_tool("remarkable_status", {}),
+                await legacy.call_tool("remarkable_status", {}),
+            )
+            assert json.loads(modern_status.content[0].text)["transport"] == "cloud"
+            assert json.loads(legacy_status.content[0].text)["transport"] == "cloud"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_version"),
+    [("auto", "2026-07-28"), ("legacy", "2025-11-25")],
+)
+async def test_sampling_ocr_uses_era_portable_resolver(
+    monkeypatch, mode: str, expected_version: str
+):
+    """Sampling OCR works through MRTR and the legacy server back-channel."""
+    from remarkable_mcp import tools
+
+    with tools._sampling_page_cache_lock:
+        tools._sampling_page_cache.clear()
+    monkeypatch.setenv("REMARKABLE_OCR_BACKEND", "sampling")
+    document = _document()
+    api_client = Mock()
+    api_client.get_meta_items.return_value = [document]
+    api_client.download.return_value = b"fixture"
+    sample_calls = 0
+
+    async def sample(
+        context: ClientRequestContext, params: CreateMessageRequestParams
+    ) -> CreateMessageResult:
+        nonlocal sample_calls
+        sample_calls += 1
+        assert params.messages[0].content.type == "image"
+        return CreateMessageResult(
+            role="assistant",
+            model="fixture-vision",
+            content=TextContent(type="text", text="handwritten fixture"),
+        )
+
+    loader_start, loader_stop = _without_background_loader()
+    with (
+        loader_start,
+        loader_stop,
+        patch("remarkable_mcp.tools.get_rmapi", return_value=api_client),
+        patch("remarkable_mcp.tools.get_document_page_count", return_value=1),
+        patch(
+            "remarkable_mcp.tools.render_page_from_document_zip",
+            return_value=b"\x89PNG\r\nfixture",
+        ) as render_page,
+    ):
+        async with Client(mcp, mode=mode, sampling_callback=sample) as client:
+            result = await client.call_tool(
+                "remarkable_image",
+                {
+                    "document": "Test Document",
+                    "include_ocr": True,
+                    "compatibility": True,
+                },
+            )
+            assert client.protocol_version == expected_version
+
+    payload = json.loads(result.content[0].text)
+    assert payload["ocr_backend"] == "sampling"
+    assert payload["ocr_text"] == "handwritten fixture"
+    assert sample_calls == 1
+    assert api_client.download.call_count == 1
+    assert render_page.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["auto", "legacy"])
+async def test_read_sampling_reuses_prepared_page(monkeypatch, mode: str):
+    """Read sampling downloads and renders once across every protocol round."""
+    from remarkable_mcp import tools
+
+    with tools._sampling_page_cache_lock:
+        tools._sampling_page_cache.clear()
+    monkeypatch.setenv("REMARKABLE_OCR_BACKEND", "sampling")
+    document = _document()
+    api_client = Mock()
+    api_client.get_meta_items.return_value = [document]
+    api_client.download.return_value = b"fixture"
+
+    async def sample(
+        context: ClientRequestContext, params: CreateMessageRequestParams
+    ) -> CreateMessageResult:
+        return CreateMessageResult(
+            role="assistant",
+            model="fixture-vision",
+            content=TextContent(type="text", text="read fixture"),
+        )
+
+    loader_start, loader_stop = _without_background_loader()
+    with (
+        loader_start,
+        loader_stop,
+        patch("remarkable_mcp.tools.get_rmapi", return_value=api_client),
+        patch("remarkable_mcp.tools.get_file_type", return_value="notebook"),
+        patch("remarkable_mcp.tools.get_cached_page_ocr", return_value=None),
+        patch("remarkable_mcp.tools.cache_page_ocr"),
+        patch("remarkable_mcp.tools.get_document_page_count", return_value=1),
+        patch(
+            "remarkable_mcp.tools.render_page_from_document_zip",
+            return_value=b"\x89PNG\r\nfixture",
+        ) as render_page,
+    ):
+        async with Client(mcp, mode=mode, sampling_callback=sample) as client:
+            result = await client.call_tool(
+                "remarkable_read",
+                {"document": "Test Document", "include_ocr": True},
+            )
+
+    payload = json.loads(result.content[0].text)
+    assert payload["content"] == "read fixture"
+    assert payload["ocr_backend"] == "sampling"
+    assert api_client.download.call_count == 1
+    assert render_page.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_read_sampling_without_capability_skips_sample_render(monkeypatch):
+    """A client without sampling goes directly to the local OCR fallback."""
+    from remarkable_mcp import tools
+
+    with tools._sampling_page_cache_lock:
+        tools._sampling_page_cache.clear()
+    monkeypatch.setenv("REMARKABLE_OCR_BACKEND", "sampling")
+    document = _document()
+    api_client = Mock()
+    api_client.get_meta_items.return_value = [document]
+    api_client.download.return_value = b"fixture"
+    extracted = {
+        "typed_text": [],
+        "highlights": [],
+        "handwritten_text": ["local fallback"],
+        "annotated_pages": [],
+        "pages": 1,
+        "ocr_backend": "tesseract",
+    }
+
+    loader_start, loader_stop = _without_background_loader()
+    with (
+        loader_start,
+        loader_stop,
+        patch("remarkable_mcp.tools.get_rmapi", return_value=api_client),
+        patch("remarkable_mcp.tools.get_file_type", return_value="notebook"),
+        patch(
+            "remarkable_mcp.tools.extract_text_from_document_zip",
+            return_value=extracted,
+        ),
+        patch("remarkable_mcp.tools.render_page_from_document_zip") as render_page,
+    ):
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "remarkable_read",
+                {"document": "Test Document", "include_ocr": True},
+            )
+
+    payload = json.loads(result.content[0].text)
+    assert payload["content"] == "local fallback"
+    assert payload["ocr_backend"] == "tesseract"
+    assert api_client.download.call_count == 1
+    render_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_version"),
+    [("auto", "2026-07-28"), ("legacy", "2025-11-25")],
+)
+async def test_delete_confirmation_works_in_both_protocol_eras(
+    monkeypatch, mode: str, expected_version: str
+):
+    """A confirmed delete uses MRTR for modern clients and push for legacy."""
+    for variable in (
+        "REMARKABLE_SKIP_CONFIRM",
+        "REMARKABLE_READ_ONLY",
+        "REMARKABLE_USE_LOCAL_DIR",
+        "REMARKABLE_LOCAL_DIR",
+        "REMARKABLE_USE_SSH",
+        "REMARKABLE_USE_USB_WEB",
+    ):
+        monkeypatch.delenv(variable, raising=False)
+
+    document = _document("Old Notes")
+    document.is_folder = False
+    api_client = Mock(spec=["get_meta_items", "delete"])
+    api_client.get_meta_items.return_value = [document]
+    confirmation_calls = 0
+
+    async def confirm(context: ClientRequestContext, params: ElicitRequestParams) -> ElicitResult:
+        nonlocal confirmation_calls
+        confirmation_calls += 1
+        assert "Old Notes" in params.message
+        return ElicitResult(action="accept", content={"confirm": True})
+
+    loader_start, loader_stop = _without_background_loader()
+    with (
+        loader_start,
+        loader_stop,
+        patch("remarkable_mcp.write_tools.get_rmapi", return_value=api_client),
+    ):
+        async with Client(mcp, mode=mode, elicitation_callback=confirm) as client:
+            result = await client.call_tool("remarkable_delete", {"document": "Old Notes"})
+            assert client.protocol_version == expected_version
+
+    payload = json.loads(result.content[0].text)
+    assert payload["deleted"] is True
+    assert confirmation_calls == 1
+    api_client.delete.assert_called_once_with("doc-1")

--- a/test_server.py
+++ b/test_server.py
@@ -4824,6 +4824,22 @@ class TestCanvasRegisteredByDefault:
 class TestCLIFlags:
     """CLI flag wiring for the write/read-only gate."""
 
+    def test_register_does_not_print_saved_token(self, capsys):
+        from remarkable_mcp import cli
+
+        token = '{"devicetoken": "secret-value"}'
+        with (
+            patch.object(sys, "argv", ["remarkable-mcp", "--register", "one-time-code"]),
+            patch("remarkable_mcp.api.register_and_get_token", return_value=token),
+        ):
+            cli.main()
+
+        output = capsys.readouterr().out
+        assert "Registration complete." in output
+        assert "~/.rmapi" in output
+        assert "secret-value" not in output
+        assert "REMARKABLE_TOKEN" not in output
+
     def test_write_and_read_only_mutually_exclusive(self):
         """Passing both --write and --read-only is an argparse error (exit 2)."""
         from remarkable_mcp.cli import main
@@ -4897,7 +4913,7 @@ class TestCLIFlags:
             patch.object(
                 sys,
                 "argv",
-                ["remarkable-mcp", "--http", "--host", "0.0.0.0", "--port", "9000"],
+                ["remarkable-mcp", "--http", "--host", "192.0.2.10", "--port", "9000"],
             ),
             patch("remarkable_mcp.server.run") as mock_run,
         ):
@@ -4905,14 +4921,28 @@ class TestCLIFlags:
 
         mock_run.assert_called_once_with(
             transport="streamable-http",
-            host="0.0.0.0",
+            host="192.0.2.10",
             port=9000,
         )
         warning = capsys.readouterr().err
         assert "WARNING" in warning
         assert "no authentication" in warning
         assert "including writes" in warning
-        assert "matching '0.0.0.0'" in warning
+        assert "matching '192.0.2.10'" in warning
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "[::]"])
+    def test_http_rejects_wildcard_binding(self, host):
+        from remarkable_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["remarkable-mcp", "--http", "--host", host]),
+            patch("remarkable_mcp.server.run") as mock_run,
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.main()
+
+        assert exc.value.code == 2
+        mock_run.assert_not_called()
 
     def test_default_transport_security_requires_proxy_header_rewrite(self):
         from mcp.server.transport_security import TransportSecurityMiddleware
@@ -4923,7 +4953,7 @@ class TestCLIFlags:
         assert middleware._validate_origin("https://openwebui.example.com") is False
         assert middleware._validate_origin(None) is True
 
-    def test_runtime_transport_security_matches_explicit_wildcard_host(self):
+    def test_runtime_transport_security_matches_explicit_non_loopback_host(self):
         from mcp.server.transport_security import TransportSecurityMiddleware
 
         import remarkable_mcp.server as server
@@ -4935,19 +4965,26 @@ class TestCLIFlags:
             with patch.object(mcp, "run") as fastmcp_run:
                 server.run(
                     transport="streamable-http",
-                    host="0.0.0.0",
+                    host="192.0.2.10",
                     port=9000,
                 )
             fastmcp_run.assert_called_once_with(transport="streamable-http")
             middleware = TransportSecurityMiddleware(mcp.settings.transport_security)
-            assert middleware._validate_host("0.0.0.0:9000") is True
-            assert middleware._validate_origin("http://0.0.0.0:3000") is True
+            assert middleware._validate_host("192.0.2.10:9000") is True
+            assert middleware._validate_origin("http://192.0.2.10:3000") is True
             assert middleware._validate_host("mcp.example.com") is False
             assert middleware._validate_origin("https://openwebui.example.com") is False
         finally:
             mcp.settings.host = previous_host
             mcp.settings.port = previous_port
             mcp.settings.transport_security = previous_security
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "[::]"])
+    def test_transport_security_rejects_wildcard_host(self, host):
+        from remarkable_mcp.server import _transport_security_for_host
+
+        with pytest.raises(ValueError, match="Wildcard"):
+            _transport_security_for_host(host)
 
     def test_read_only_instructions_do_not_advertise_markdown_writeback(self):
         from remarkable_mcp.server import _build_instructions

--- a/test_server.py
+++ b/test_server.py
@@ -2,7 +2,8 @@
 """
 Tests for reMarkable MCP Server
 
-Tests the 4 intent-based tools using FastMCP's testing capabilities.
+Focused handler tests call MCPServer directly. Dual-era protocol behavior is
+covered through SDK v2's first-class in-memory Client in test_mcp_v2.py.
 """
 
 import json
@@ -16,6 +17,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 import requests
+from mcp import Client
 
 from remarkable_mcp.api import (
     get_item_path,
@@ -32,6 +34,22 @@ from remarkable_mcp.responses import (
     make_response,
 )
 from remarkable_mcp.server import mcp
+
+
+async def _call_tool(name: str, arguments: dict):
+    """Call a tool directly for focused handler tests."""
+    return await mcp.call_tool(name, arguments)
+
+
+async def _list_tools():
+    """List registered tools for focused schema tests."""
+    return await mcp.list_tools()
+
+
+async def _list_resources():
+    """List registered resources for focused schema tests."""
+    return await mcp.list_resources()
+
 
 # =============================================================================
 # Test Fixtures
@@ -93,7 +111,7 @@ class TestMCPServerInitialization:
     @pytest.mark.asyncio
     async def test_tools_registered(self):
         """Test that all expected tools are registered."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
         tool_names = [tool.name for tool in tools]
 
         expected_tools = [
@@ -116,23 +134,23 @@ class TestMCPServerInitialization:
         ``remarkable_author`` is SSH-only and therefore hidden in cloud mode, so
         the default (cloud) surface is 13 tools, not 14.
         """
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
         assert len(tools) == 13, f"Expected 13 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
         """Test that tools have proper schemas."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
 
         for tool in tools:
             assert tool.name, "Tool should have a name"
             assert tool.description, "Tool should have a description"
-            assert hasattr(tool, "inputSchema"), "Tool should have inputSchema"
+            assert hasattr(tool, "input_schema"), "Tool should have input_schema"
 
     @pytest.mark.asyncio
     async def test_all_tools_have_xml_docstrings(self):
         """Test that all tools have XML-structured documentation."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
 
         for tool in tools:
             # Check for XML tags in description
@@ -276,8 +294,8 @@ class TestRemarkableStatus:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_status", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_status", {})
+        data = json.loads(result.content[0].text)
 
         assert data["authenticated"] is True
         assert "transport" in data
@@ -293,8 +311,8 @@ class TestRemarkableStatus:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_status", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_status", {})
+        data = json.loads(result.content[0].text)
 
         assert "write_enabled" in data
         assert "capabilities" in data
@@ -327,8 +345,8 @@ class TestRemarkableStatus:
         """Test status when not authenticated."""
         mock_get_rmapi.side_effect = RuntimeError("Failed to authenticate")
 
-        result = await mcp.call_tool("remarkable_status", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_status", {})
+        data = json.loads(result.content[0].text)
 
         assert data["authenticated"] is False
         assert "error" in data
@@ -351,8 +369,8 @@ class TestRemarkableStatus:
         mock_client.get_meta_items.return_value = []
         mock_get_rmapi.return_value = mock_client
 
-        result = await mcp.call_tool("remarkable_status", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_status", {})
+        data = json.loads(result.content[0].text)
 
         assert data["authenticated"] is True
         assert data["transport"] == "cloud"
@@ -379,8 +397,8 @@ class TestRemarkableBrowse:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_browse", {"path": "/"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_browse", {"path": "/"})
+        data = json.loads(result.content[0].text)
 
         assert data["mode"] == "browse"
         assert data["path"] == "/"
@@ -402,8 +420,8 @@ class TestRemarkableBrowse:
 
         mock_client.get_meta_items.return_value = [mock_doc]
 
-        result = await mcp.call_tool("remarkable_browse", {"query": "Test"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_browse", {"query": "Test"})
+        data = json.loads(result.content[0].text)
 
         assert data["mode"] == "search"
         assert data["query"] == "Test"
@@ -416,8 +434,8 @@ class TestRemarkableBrowse:
         """Test error handling in browse."""
         mock_get_rmapi.side_effect = RuntimeError("Connection failed")
 
-        result = await mcp.call_tool("remarkable_browse", {"path": "/"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_browse", {"path": "/"})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "browse_failed"
@@ -439,8 +457,8 @@ class TestRemarkableRecent:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_recent", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_recent", {})
+        data = json.loads(result.content[0].text)
 
         assert "count" in data
         assert "documents" in data
@@ -454,8 +472,8 @@ class TestRemarkableRecent:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_recent", {"limit": 5})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_recent", {"limit": 5})
+        data = json.loads(result.content[0].text)
 
         assert "count" in data
         assert "documents" in data
@@ -469,9 +487,9 @@ class TestRemarkableRecent:
         mock_client.get_meta_items.return_value = []
 
         # Test with limit > 50
-        result = await mcp.call_tool("remarkable_recent", {"limit": 100})
+        result = await _call_tool("remarkable_recent", {"limit": 100})
         # Should not raise an error
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
         assert "count" in data
 
     @pytest.mark.asyncio
@@ -480,8 +498,8 @@ class TestRemarkableRecent:
         """Test error handling in recent."""
         mock_get_rmapi.side_effect = RuntimeError("Connection failed")
 
-        result = await mcp.call_tool("remarkable_recent", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_recent", {})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "recent_failed"
@@ -518,8 +536,8 @@ class TestRemarkableRecent:
 
         # Simulate get_file_type returning "pdf"
         with patch("remarkable_mcp.tools.get_file_type", return_value="pdf"):
-            result = await mcp.call_tool("remarkable_recent", {"include_preview": True})
-        data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_recent", {"include_preview": True})
+        data = json.loads(result.content[0].text)
 
         # Should not crash with AttributeError; may return empty preview but no error
         assert "_error" not in data
@@ -556,8 +574,8 @@ class TestRemarkableRecent:
             FakeDoc("c", "Aware Newest", datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)),
         ]
 
-        result = await mcp.call_tool("remarkable_recent", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_recent", {})
+        data = json.loads(result.content[0].text)
 
         assert "_error" not in data
         names = [d["name"] for d in data["documents"]]
@@ -609,8 +627,8 @@ class TestRemarkableSearch:
             zf.writestr("doc-mcp-1.content", '{"fileType": "notebook"}')
         mock_client.download.return_value = zip_buffer.getvalue()
 
-        result = await mcp.call_tool("remarkable_search", {"query": "mcp", "limit": 2})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_search", {"query": "mcp", "limit": 2})
+        data = json.loads(result.content[0].text)
 
         # Top-level call must succeed (not surface a coroutine TypeError)
         assert "_error" not in data, f"Unexpected top-level error: {data.get('_error')}"
@@ -630,8 +648,8 @@ class TestRemarkableSearch:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_search", {"query": "nonexistent-xyz"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_search", {"query": "nonexistent-xyz"})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "no_documents_found"
@@ -653,8 +671,8 @@ class TestRemarkableRead:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_read", {"document": "NonExistent"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_read", {"document": "NonExistent"})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "document_not_found"
@@ -666,8 +684,8 @@ class TestRemarkableRead:
         """Test error handling in read."""
         mock_get_rmapi.side_effect = RuntimeError("Connection failed")
 
-        result = await mcp.call_tool("remarkable_read", {"document": "Test"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_read", {"document": "Test"})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "read_failed"
@@ -681,8 +699,8 @@ class TestRemarkableRead:
         mock_client.get_meta_items.return_value = [mock_document]
 
         # Search for something similar but not exact
-        result = await mcp.call_tool("remarkable_read", {"document": "Test Doc"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_read", {"document": "Test Doc"})
+        data = json.loads(result.content[0].text)
 
         # Should get a not found error with suggestions
         assert "_error" in data
@@ -725,8 +743,8 @@ class TestRemarkableRead:
 
         # This should NOT raise "the JSON object must be str, bytes or bytearray, not coroutine"
         # Previously failed because remarkable_read() was called without 'await'
-        result = await mcp.call_tool("remarkable_read", {"document": "Quick sheets"})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_read", {"document": "Quick sheets"})
+        data = json.loads(result.content[0].text)
 
         # Should return a valid response (not a coroutine error)
         assert (
@@ -775,10 +793,10 @@ class TestRemarkableRead:
             "tags": [],
         }
 
-        result = await mcp.call_tool(
+        result = await _call_tool(
             "remarkable_read", {"document": "Annotated PDF", "content_type": "annotations"}
         )
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
 
         assert "_error" not in data, f"Unexpected error: {data}"
         assert "Page 2: handwritten notes" in data["content"]
@@ -824,10 +842,10 @@ class TestRemarkableRead:
             "tags": [],
         }
 
-        result = await mcp.call_tool(
+        result = await _call_tool(
             "remarkable_read", {"document": "Annotated PDF", "content_type": "annotations"}
         )
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
 
         assert "_error" not in data
         assert "Page 3: handwritten notes, 1 highlight" in data["content"]
@@ -850,8 +868,8 @@ class TestRemarkableImage:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_image", {"document": "NonExistent"})
-        data = json.loads(result[0].text)
+        result = await _call_tool("remarkable_image", {"document": "NonExistent"})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "document_not_found"
@@ -863,8 +881,8 @@ class TestRemarkableImage:
         """Test error handling in image tool."""
         mock_get_rmapi.side_effect = RuntimeError("Connection failed")
 
-        result = await mcp.call_tool("remarkable_image", {"document": "Test"})
-        data = json.loads(result[0].text)
+        result = await _call_tool("remarkable_image", {"document": "Test"})
+        data = json.loads(result.content[0].text)
 
         assert "_error" in data
         assert data["_error"]["type"] == "image_failed"
@@ -878,8 +896,8 @@ class TestRemarkableImage:
         mock_client.get_meta_items.return_value = [mock_document]
 
         # Search for something similar but not exact
-        result = await mcp.call_tool("remarkable_image", {"document": "Test Doc"})
-        data = json.loads(result[0].text)
+        result = await _call_tool("remarkable_image", {"document": "Test Doc"})
+        data = json.loads(result.content[0].text)
 
         # Should get a not found error with suggestions
         assert "_error" in data
@@ -888,12 +906,12 @@ class TestRemarkableImage:
     @pytest.mark.asyncio
     async def test_image_compatibility_parameter_in_schema(self):
         """Test that remarkable_image tool has the compatibility parameter in its schema."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
         image_tool = next(t for t in tools if t.name == "remarkable_image")
 
         # Check that compatibility parameter exists in the input schema
-        assert "compatibility" in image_tool.inputSchema.get("properties", {})
-        compat_schema = image_tool.inputSchema["properties"]["compatibility"]
+        assert "compatibility" in image_tool.input_schema.get("properties", {})
+        compat_schema = image_tool.input_schema["properties"]["compatibility"]
         assert compat_schema.get("type") == "boolean"
         assert compat_schema.get("default") is False
 
@@ -913,17 +931,17 @@ class TestRemarkableImage:
         mock_client.download.return_value = document_zip
 
         with _cairo_unavailable():
-            embedded = await mcp.call_tool(
+            embedded = await _call_tool(
                 "remarkable_image",
                 {"document": "Test Document"},
             )
-            compatible = await mcp.call_tool(
+            compatible = await _call_tool(
                 "remarkable_image",
                 {"document": "Test Document", "compatibility": True},
             )
 
-        assert any(isinstance(content, EmbeddedResource) for content in embedded)
-        compatible_data = json.loads(compatible[0].text)
+        assert any(isinstance(content, EmbeddedResource) for content in embedded.content)
+        compatible_data = json.loads(compatible.content[0].text)
         assert compatible_data["mime_type"] == "image/png"
         assert compatible_data["image_base64"]
 
@@ -939,12 +957,12 @@ class TestMergedRendering:
     @pytest.mark.asyncio
     async def test_render_merged_parameter_in_schema(self):
         """Test that remarkable_image tool has the render_merged parameter in its schema."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
         image_tool = next(t for t in tools if t.name == "remarkable_image")
 
         # Check that render_merged parameter exists in the input schema
-        assert "render_merged" in image_tool.inputSchema.get("properties", {})
-        merged_schema = image_tool.inputSchema["properties"]["render_merged"]
+        assert "render_merged" in image_tool.input_schema.get("properties", {})
+        merged_schema = image_tool.input_schema["properties"]["render_merged"]
         assert merged_schema.get("type") == "boolean"
         assert merged_schema.get("default") is False
 
@@ -980,7 +998,7 @@ class TestMergedRendering:
             mock_tmp.name = "/tmp/test.zip"
             mock_tmpfile.return_value = mock_tmp
             with patch("pathlib.Path.unlink"):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_image",
                     {
                         "document": "Test Document",
@@ -989,7 +1007,7 @@ class TestMergedRendering:
                     },
                 )
 
-        data = json.loads(result[0].text)
+        data = json.loads(result.content[0].text)
         # Should fall back to annotation-only since no PDF underlay
         assert data.get("merged") is False
 
@@ -1017,7 +1035,7 @@ class TestMergedRendering:
             mock_tmp.name = "/tmp/test.zip"
             mock_tmpfile.return_value = mock_tmp
             with patch("pathlib.Path.unlink"):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_image",
                     {
                         "document": "Test Document",
@@ -1027,7 +1045,7 @@ class TestMergedRendering:
                     },
                 )
 
-        data = json.loads(result[0].text)
+        data = json.loads(result.content[0].text)
         # SVG should return successfully but merged=False
         assert data.get("merged") is False
         assert "render_merged is only supported with PNG" in data.get("_hint", "")
@@ -1061,7 +1079,7 @@ class TestMergedRendering:
             mock_tmp.name = "/tmp/test.zip"
             mock_tmpfile.return_value = mock_tmp
             with patch("pathlib.Path.unlink"):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_image",
                     {
                         "document": "Test Document",
@@ -1070,7 +1088,7 @@ class TestMergedRendering:
                     },
                 )
 
-        data = json.loads(result[0].text)
+        data = json.loads(result.content[0].text)
         assert data.get("merged") is True
         assert data.get("resource_uri", "").endswith(".merged.png")
         hint = data.get("_hint", "")
@@ -1284,12 +1302,12 @@ class TestRenderTabletPdfFallback:
             mock_tmp.name = "/tmp/test.zip"
             mock_tmpfile.return_value = mock_tmp
             with patch("pathlib.Path.unlink"):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_image",
                     {"document": "Test Document", "page": 2, "compatibility": True},
                 )
 
-        data = json.loads(result[0].text)
+        data = json.loads(result.content[0].text)
         assert "_error" not in data
         assert data.get("render_source") == "tablet_pdf"
         assert data.get("image_base64")
@@ -1329,12 +1347,12 @@ class TestRenderTabletPdfFallback:
             mock_tmp.name = "/tmp/test.zip"
             mock_tmpfile.return_value = mock_tmp
             with patch("pathlib.Path.unlink"):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_image",
                     {"document": "Test Document", "page": 1, "compatibility": True},
                 )
 
-        data = json.loads(result[0].text)
+        data = json.loads(result.content[0].text)
         assert data["_error"]["type"] == "render_failed"
         # The misleading "v5 / rmc" message is gone; guidance is actionable
         suggestion = data["_error"]["suggestion"].lower()
@@ -1380,12 +1398,12 @@ class TestRenderTabletPdfFallback:
             mock_tmp.name = "/tmp/test.zip"
             mock_tmpfile.return_value = mock_tmp
             with patch("pathlib.Path.unlink"):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_image",
                     {"document": "Test Document", "page": 1, "compatibility": True},
                 )
 
-        data = json.loads(result[0].text)
+        data = json.loads(result.content[0].text)
         assert "_error" not in data
         assert data.get("image_base64")
         mock_full.assert_called_once()
@@ -1456,7 +1474,7 @@ class TestE2E:
     @pytest.mark.asyncio
     async def test_server_lists_all_tools(self):
         """Test that server can list all tools (e2e)."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
 
         assert len(tools) == 13
 
@@ -1475,17 +1493,17 @@ class TestE2E:
         mock_client.get_meta_items.return_value = []
 
         # Call status tool
-        result = await mcp.call_tool("remarkable_status", {})
+        result = await _call_tool("remarkable_status", {})
 
         # Verify we get valid JSON back
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
         assert "authenticated" in data
         assert "_hint" in data
 
     @pytest.mark.asyncio
     async def test_tool_parameters_schema(self):
         """Test that tool parameters have proper schemas."""
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
 
         # Check specific tools exist
         browse_tool = next(t for t in tools if t.name == "remarkable_browse")
@@ -1509,18 +1527,18 @@ class TestE2E:
             mock_client.get_meta_items.return_value = []
 
             # Test status
-            result = await mcp.call_tool("remarkable_status", {})
-            data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_status", {})
+            data = json.loads(result.content[0].text)
             assert "_hint" in data
 
             # Test browse
-            result = await mcp.call_tool("remarkable_browse", {"path": "/"})
-            data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_browse", {"path": "/"})
+            data = json.loads(result.content[0].text)
             assert "_hint" in data or "_error" in data
 
             # Test recent
-            result = await mcp.call_tool("remarkable_recent", {})
-            data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_recent", {})
+            data = json.loads(result.content[0].text)
             assert "_hint" in data or "_error" in data
 
 
@@ -1546,8 +1564,8 @@ class TestResponseConsistency:
         ]
 
         for tool_name, args in tools_to_test:
-            result = await mcp.call_tool(tool_name, args)
-            data = json.loads(result[0][0].text)
+            result = await _call_tool(tool_name, args)
+            data = json.loads(result.content[0].text)
 
             # Either success with _hint or error with _error
             has_hint = "_hint" in data
@@ -1573,9 +1591,8 @@ class TestCapabilityChecking:
         """Test get_client_capabilities returns None without valid context."""
         from remarkable_mcp.capabilities import get_client_capabilities
 
-        # Create mock context without session
         mock_ctx = Mock()
-        mock_ctx.session = None
+        mock_ctx.client_capabilities = None
 
         result = get_client_capabilities(mock_ctx)
         assert result is None
@@ -1585,8 +1602,7 @@ class TestCapabilityChecking:
         from remarkable_mcp.capabilities import get_client_capabilities
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = None
+        mock_ctx.client_capabilities = None
 
         result = get_client_capabilities(mock_ctx)
         assert result is None
@@ -1600,9 +1616,7 @@ class TestCapabilityChecking:
         mock_caps = ClientCapabilities(sampling=SamplingCapability())
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         result = get_client_capabilities(mock_ctx)
         assert result is not None
@@ -1617,9 +1631,7 @@ class TestCapabilityChecking:
         mock_caps = ClientCapabilities(sampling=SamplingCapability())
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         result = client_supports_sampling(mock_ctx)
         assert result is True
@@ -1633,9 +1645,7 @@ class TestCapabilityChecking:
         mock_caps = ClientCapabilities(sampling=None)
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         result = client_supports_sampling(mock_ctx)
         assert result is False
@@ -1650,15 +1660,13 @@ class TestCapabilityChecking:
         mock_caps = ClientCapabilities(elicitation=ElicitationCapability())
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         assert client_supports_elicitation(mock_ctx) is True
 
         # Test with elicitation disabled
         mock_caps = ClientCapabilities(elicitation=None)
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         assert client_supports_elicitation(mock_ctx) is False
 
@@ -1672,15 +1680,13 @@ class TestCapabilityChecking:
         mock_caps = ClientCapabilities(roots=RootsCapability())
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         assert client_supports_roots(mock_ctx) is True
 
         # Test with roots disabled
         mock_caps = ClientCapabilities(roots=None)
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         assert client_supports_roots(mock_ctx) is False
 
@@ -1694,16 +1700,14 @@ class TestCapabilityChecking:
         mock_caps = ClientCapabilities(experimental={"my_feature": {}})
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         assert client_supports_experimental(mock_ctx, "my_feature") is True
         assert client_supports_experimental(mock_ctx, "other_feature") is False
 
         # Test with no experimental features
         mock_caps = ClientCapabilities(experimental=None)
-        mock_ctx.session.client_params.capabilities = mock_caps
+        mock_ctx.client_capabilities = mock_caps
 
         assert client_supports_experimental(mock_ctx, "my_feature") is False
 
@@ -1714,10 +1718,10 @@ class TestCapabilityChecking:
         mock_ctx = Mock()
         mock_ctx.session = Mock()
         mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.clientInfo = Mock()
-        mock_ctx.session.client_params.clientInfo.name = "Test Client"
-        mock_ctx.session.client_params.clientInfo.version = "1.0.0"
-        mock_ctx.session.client_params.protocolVersion = "2024-11-05"
+        mock_ctx.session.client_params.client_info = Mock()
+        mock_ctx.session.client_params.client_info.name = "Test Client"
+        mock_ctx.session.client_params.client_info.version = "1.0.0"
+        mock_ctx.protocol_version = "2024-11-05"
 
         result = get_client_info(mock_ctx)
         assert result is not None
@@ -1732,8 +1736,8 @@ class TestCapabilityChecking:
         mock_ctx = Mock()
         mock_ctx.session = Mock()
         mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.clientInfo = None
-        mock_ctx.session.client_params.protocolVersion = "2024-11-05"
+        mock_ctx.session.client_params.client_info = None
+        mock_ctx.protocol_version = "2024-11-05"
 
         result = get_client_info(mock_ctx)
         assert result is not None
@@ -1746,9 +1750,7 @@ class TestCapabilityChecking:
         from remarkable_mcp.capabilities import get_protocol_version
 
         mock_ctx = Mock()
-        mock_ctx.session = Mock()
-        mock_ctx.session.client_params = Mock()
-        mock_ctx.session.client_params.protocolVersion = "2024-11-05"
+        mock_ctx.protocol_version = "2024-11-05"
 
         result = get_protocol_version(mock_ctx)
         assert result == "2024-11-05"
@@ -1758,7 +1760,7 @@ class TestCapabilityChecking:
         from remarkable_mcp.capabilities import get_protocol_version
 
         mock_ctx = Mock()
-        mock_ctx.session = None
+        mock_ctx.protocol_version = None
 
         result = get_protocol_version(mock_ctx)
         assert result is None
@@ -1845,9 +1847,7 @@ class TestSamplingOCR:
             # Create mock context with sampling capability
             mock_caps = ClientCapabilities(sampling=SamplingCapability())
             mock_ctx = Mock()
-            mock_ctx.session = Mock()
-            mock_ctx.session.client_params = Mock()
-            mock_ctx.session.client_params.capabilities = mock_caps
+            mock_ctx.client_capabilities = mock_caps
 
             # Should return False because backend is "auto", not "sampling"
             result = should_use_sampling_ocr(mock_ctx)
@@ -1871,9 +1871,7 @@ class TestSamplingOCR:
             # Create mock context with sampling capability
             mock_caps = ClientCapabilities(sampling=SamplingCapability())
             mock_ctx = Mock()
-            mock_ctx.session = Mock()
-            mock_ctx.session.client_params = Mock()
-            mock_ctx.session.client_params.capabilities = mock_caps
+            mock_ctx.client_capabilities = mock_caps
 
             result = should_use_sampling_ocr(mock_ctx)
             assert result is True
@@ -1898,9 +1896,7 @@ class TestSamplingOCR:
             # Create mock context WITHOUT sampling capability
             mock_caps = ClientCapabilities(sampling=None)
             mock_ctx = Mock()
-            mock_ctx.session = Mock()
-            mock_ctx.session.client_params = Mock()
-            mock_ctx.session.client_params.capabilities = mock_caps
+            mock_ctx.client_capabilities = mock_caps
 
             result = should_use_sampling_ocr(mock_ctx)
             assert result is False
@@ -2008,8 +2004,8 @@ class TestTagSupport:
 
         with patch("remarkable_mcp.tools.get_rmapi", return_value=mock_client):
             with patch("remarkable_mcp.tools._is_cloud_archived", return_value=False):
-                result = await mcp.call_tool("remarkable_browse", {"path": "/"})
-                data = json.loads(result[0][0].text)
+                result = await _call_tool("remarkable_browse", {"path": "/"})
+                data = json.loads(result.content[0].text)
 
                 assert data["mode"] == "browse"
                 assert len(data["documents"]) == 1
@@ -2042,8 +2038,8 @@ class TestTagSupport:
 
         with patch("remarkable_mcp.tools.get_rmapi", return_value=mock_client):
             with patch("remarkable_mcp.tools._is_cloud_archived", return_value=False):
-                result = await mcp.call_tool("remarkable_browse", {"path": "/", "tags": ["work"]})
-                data = json.loads(result[0][0].text)
+                result = await _call_tool("remarkable_browse", {"path": "/", "tags": ["work"]})
+                data = json.loads(result.content[0].text)
 
                 assert data["mode"] == "browse"
                 assert len(data["documents"]) == 1
@@ -2067,8 +2063,8 @@ class TestTagSupport:
 
         with patch("remarkable_mcp.tools.get_rmapi", return_value=mock_client):
             with patch("remarkable_mcp.tools._is_cloud_archived", return_value=False):
-                result = await mcp.call_tool("remarkable_browse", {"query": "meeting"})
-                data = json.loads(result[0][0].text)
+                result = await _call_tool("remarkable_browse", {"query": "meeting"})
+                data = json.loads(result.content[0].text)
 
                 assert data["mode"] == "search"
                 assert len(data["results"]) == 1
@@ -2100,10 +2096,10 @@ class TestTagSupport:
 
         with patch("remarkable_mcp.tools.get_rmapi", return_value=mock_client):
             with patch("remarkable_mcp.tools._is_cloud_archived", return_value=False):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_browse", {"query": "meeting", "tags": ["work"]}
                 )
-                data = json.loads(result[0][0].text)
+                data = json.loads(result.content[0].text)
 
                 assert data["mode"] == "search"
                 assert len(data["results"]) == 1
@@ -2565,8 +2561,8 @@ class TestUSBWebInterface:
             mock_client.get_meta_items.return_value = [mock_doc]
             mock_get_rmapi.return_value = mock_client
 
-            result = await mcp.call_tool("remarkable_status", {})
-            data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_status", {})
+            data = json.loads(result.content[0].text)
 
             assert data["authenticated"] is True
             assert data["transport"] == "usb-web"
@@ -2988,7 +2984,7 @@ class TestWriteTools:
         therefore hidden in cloud mode (the mode these tests import). See
         ``test_author_only_registered_in_ssh_mode`` for its gating.
         """
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
         tool_names = [tool.name for tool in tools]
 
         write_tool_names = [
@@ -3017,7 +3013,7 @@ class TestWriteTools:
             register_write_tools()
 
         try:
-            tools = await mcp.list_tools()
+            tools = await _list_tools()
             tool_names = [tool.name for tool in tools]
 
             write_tool_names = [
@@ -3094,13 +3090,13 @@ class TestWriteTools:
                     )
                     mock_get_rmapi.return_value = mock_client
 
-                    result = await mcp.call_tool(
+                    result = await _call_tool(
                         "remarkable_delete",
                         {
                             "document": "Test Doc",
                         },
                     )
-                    data = json.loads(result[0][0].text)
+                    data = json.loads(result.content[0].text)
                     assert data["deleted"] is True
                     assert data["name"] == "Test Doc"
                     # Verify metadata was written with deleted=True
@@ -3132,7 +3128,7 @@ class TestWriteTools:
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
-                tools = await mcp.list_tools()
+                tools = await _list_tools()
                 names = {t.name for t in tools}
                 assert "remarkable_upload" in names
                 assert "remarkable_mkdir" in names
@@ -3158,7 +3154,7 @@ class TestWriteTools:
             register_write_tools()
 
         try:
-            tools = await mcp.list_tools()
+            tools = await _list_tools()
             write_tools = [
                 t
                 for t in tools
@@ -3209,11 +3205,11 @@ class TestWriteTools:
                 mock_client.upload_document.return_value = mock_doc
 
                 with patch("remarkable_mcp.write_tools.get_rmapi", return_value=mock_client):
-                    result = await mcp.call_tool(
+                    result = await _call_tool(
                         "remarkable_upload",
                         {"file_path": pdf_path, "document_name": "My Doc"},
                     )
-                data = json.loads(result[0][0].text)
+                data = json.loads(result.content[0].text)
                 assert data["uploaded"] is True
                 assert data["transport"] == "cloud"
                 assert data["uuid"] == "new-doc-id"
@@ -3244,7 +3240,7 @@ class TestWriteTools:
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
-                tools = await mcp.list_tools()
+                tools = await _list_tools()
                 names = {t.name for t in tools}
                 assert "remarkable_upload" in names  # upload works on USB web
                 assert "remarkable_mkdir" not in names
@@ -3275,7 +3271,7 @@ class TestWriteTools:
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
             register_write_tools()
             try:
-                names = {t.name for t in await mcp.list_tools()}
+                names = {t.name for t in await _list_tools()}
                 assert "remarkable_author" in names
             finally:
                 mcp._tool_manager._tools.pop("remarkable_author", None)
@@ -3286,7 +3282,7 @@ class TestWriteTools:
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
-                names = {t.name for t in await mcp.list_tools()}
+                names = {t.name for t in await _list_tools()}
                 assert "remarkable_author" not in names
             finally:
                 for name in [
@@ -3305,7 +3301,7 @@ class TestWriteTools:
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
-                names = {t.name for t in await mcp.list_tools()}
+                names = {t.name for t in await _list_tools()}
                 assert "remarkable_author" not in names
             finally:
                 mcp._tool_manager._tools.pop("remarkable_author", None)
@@ -3359,7 +3355,7 @@ class TestMarkdownPDFWriteback:
             patch.dict(os.environ, env, clear=True),
             patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_markdown_to_pdf",
                 {
                     "markdown": "# Notes\n\n- One\n- Two",
@@ -3367,7 +3363,7 @@ class TestMarkdownPDFWriteback:
                 },
             )
 
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
         assert data["uploaded"] is True
         assert data["name"] == "Team Notes"
         assert data["transport"] == "cloud"
@@ -3407,7 +3403,7 @@ class TestMarkdownPDFWriteback:
                 return_value=False,
             ) as maybe_restart,
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_markdown_to_pdf",
                 {
                     "markdown": "# Deferred",
@@ -3416,7 +3412,7 @@ class TestMarkdownPDFWriteback:
                 },
             )
 
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
         assert data["uploaded"] is True
         assert data["refresh_pending"] is True
         assert "remarkable_refresh" in data["_hint"]
@@ -3468,7 +3464,7 @@ class TestMarkdownPDFWriteback:
                 side_effect=capture_upload,
             ),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_markdown_to_pdf",
                 {
                     "markdown": "# Portable",
@@ -3476,7 +3472,7 @@ class TestMarkdownPDFWriteback:
                 },
             )
 
-        data = json.loads(result[0][0].text)
+        data = json.loads(result.content[0].text)
         assert data["uploaded"] is True
         assert captured == {
             "local_name": "document.pdf",
@@ -3524,8 +3520,8 @@ class TestCloudWriteDispatch:
                 client.get_meta_items.return_value = []
                 client.create_folder.return_value = new_folder
                 with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
-                    result = await mcp.call_tool("remarkable_mkdir", {"folder_name": "Projects"})
-                data = json.loads(result[0][0].text)
+                    result = await _call_tool("remarkable_mkdir", {"folder_name": "Projects"})
+                data = json.loads(result.content[0].text)
                 assert data["created"] is True
                 assert data["transport"] == "cloud"
                 assert data["uuid"] == "folder-xyz"
@@ -3544,11 +3540,11 @@ class TestCloudWriteDispatch:
                 client = Mock(spec=["get_meta_items", "rename"])
                 client.get_meta_items.return_value = [target]
                 with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
-                    result = await mcp.call_tool(
+                    result = await _call_tool(
                         "remarkable_rename",
                         {"document": "Old Name", "new_name": "New Name"},
                     )
-                data = json.loads(result[0][0].text)
+                data = json.loads(result.content[0].text)
                 assert data["renamed"] is True
                 assert data["transport"] == "cloud"
                 client.rename.assert_called_once_with("doc-1", "New Name")
@@ -3567,11 +3563,11 @@ class TestCloudWriteDispatch:
                 client = Mock(spec=["get_meta_items", "move"])
                 client.get_meta_items.return_value = [target, dest]
                 with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
-                    result = await mcp.call_tool(
+                    result = await _call_tool(
                         "remarkable_move",
                         {"document": "Report", "dest_folder": "Archive"},
                     )
-                data = json.loads(result[0][0].text)
+                data = json.loads(result.content[0].text)
                 assert data["moved"] is True
                 assert data["transport"] == "cloud"
                 client.move.assert_called_once_with("doc-1", "fold-1")
@@ -3590,8 +3586,8 @@ class TestCloudWriteDispatch:
                 client = Mock(spec=["get_meta_items", "delete"])
                 client.get_meta_items.return_value = [target]
                 with patch("remarkable_mcp.write_tools.get_rmapi", return_value=client):
-                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
-                data = json.loads(result[0][0].text)
+                    result = await _call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result.content[0].text)
                 assert data["deleted"] is True
                 assert data["transport"] == "cloud"
                 client.delete.assert_called_once_with("doc-1")
@@ -3618,8 +3614,8 @@ class TestCloudWriteDispatch:
                         return_value=False,
                     ),
                 ):
-                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
-                data = json.loads(result[0][0].text)
+                    result = await _call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result.content[0].text)
                 assert data["_error"]["type"] == "confirmation_unavailable"
                 client.delete.assert_not_called()
             finally:
@@ -3644,8 +3640,8 @@ class TestCloudWriteDispatch:
                         return_value=False,
                     ),
                 ):
-                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
-                data = json.loads(result[0][0].text)
+                    result = await _call_tool("remarkable_delete", {"document": "Old Notes"})
+                data = json.loads(result.content[0].text)
                 assert data["deleted"] is True
                 client.delete.assert_called_once_with("doc-1")
             finally:
@@ -3653,29 +3649,34 @@ class TestCloudWriteDispatch:
 
     @pytest.mark.asyncio
     async def test_cloud_delete_cancelled_by_elicitation(self):
-        """When the user declines elicitation, delete is aborted and nothing changes."""
+        """Modern multi-round elicitation cancellation leaves the device untouched."""
+        from mcp.client import ClientRequestContext
+        from mcp.types import ElicitRequestParams, ElicitResult
+
         from remarkable_mcp.write_tools import register_write_tools
+
+        async def decline(
+            context: ClientRequestContext, params: ElicitRequestParams
+        ) -> ElicitResult:
+            return ElicitResult(action="decline")
 
         with patch.dict(os.environ, self._cloud_env(), clear=True):
             register_write_tools()
             try:
                 client = Mock(spec=["get_meta_items", "delete"])
-                decline = Mock()
-                decline.action = "decline"
-                decline.data = None
                 with (
                     patch("remarkable_mcp.write_tools.get_rmapi", return_value=client),
+                    patch("remarkable_mcp.resources.start_background_loader", return_value=None),
                     patch(
-                        "remarkable_mcp.write_tools.client_supports_elicitation",
-                        return_value=True,
-                    ),
-                    patch(
-                        "mcp.server.fastmcp.Context.elicit",
-                        new=AsyncMock(return_value=decline),
+                        "remarkable_mcp.resources.stop_background_loader",
+                        new_callable=AsyncMock,
                     ),
                 ):
-                    result = await mcp.call_tool("remarkable_delete", {"document": "Old Notes"})
-                data = json.loads(result[0][0].text)
+                    async with Client(mcp, elicitation_callback=decline) as mcp_client:
+                        result = await mcp_client.call_tool(
+                            "remarkable_delete", {"document": "Old Notes"}
+                        )
+                data = json.loads(result.content[0].text)
                 assert data["deleted"] is False
                 assert data["cancelled"] is True
                 client.delete.assert_not_called()
@@ -4252,9 +4253,7 @@ def _ctx_with_extensions(extensions):
         {"extensions": extensions} if extensions is not None else {}
     )
     ctx = Mock()
-    ctx.session = Mock()
-    ctx.session.client_params = Mock()
-    ctx.session.client_params.capabilities = caps
+    ctx.client_capabilities = caps
     return ctx
 
 
@@ -4685,7 +4684,7 @@ class TestRenderCanvasPage:
         result = await _render_canvas_page("Notes", 2, None)
 
         assert isinstance(result, types.CallToolResult)
-        sc = result.structuredContent
+        sc = result.structured_content
         assert sc["page"] == 2
         assert sc["total_pages"] == 3
         assert sc["document_name"] == "Notes"
@@ -4755,14 +4754,14 @@ class TestRegisterAppTools:
 
     @pytest.mark.asyncio
     async def test_register_app_tools_adds_canvas(self, monkeypatch):
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
 
         import remarkable_mcp.app_canvas as app_canvas
         import remarkable_mcp.server as server_mod
 
         # register_app_tools imports mcp from server at call time, so redirect
         # that global to a throwaway server to avoid mutating the real one.
-        local = FastMCP("test-app")
+        local = MCPServer("test-app")
         monkeypatch.setattr(server_mod, "mcp", local)
 
         app_canvas.register_app_tools()
@@ -4772,7 +4771,7 @@ class TestRegisterAppTools:
         canvas = next(t for t in tools if t.name == "remarkable_canvas")
         assert canvas.meta["ui"]["resourceUri"] == "ui://remarkable/canvas"
         # No output schema so we can return either CallToolResult or an error string.
-        assert canvas.outputSchema is None
+        assert canvas.output_schema is None
         resources = await local.list_resources()
         assert any(str(r.uri) == "ui://remarkable/canvas" for r in resources)
 
@@ -4794,13 +4793,13 @@ class TestCanvasRegisteredByDefault:
 
     @pytest.mark.asyncio
     async def test_canvas_tool_present_on_default_server(self):
-        tools = await mcp.list_tools()
+        tools = await _list_tools()
         names = [t.name for t in tools]
         assert "remarkable_canvas" in names
 
     @pytest.mark.asyncio
     async def test_canvas_resource_present_on_default_server(self):
-        resources = await mcp.list_resources()
+        resources = await _list_resources()
         assert any(str(r.uri) == "ui://remarkable/canvas" for r in resources)
 
     @pytest.mark.asyncio
@@ -4811,8 +4810,8 @@ class TestCanvasRegisteredByDefault:
         mock_get_rmapi.return_value = mock_client
         mock_client.get_meta_items.return_value = []
 
-        result = await mcp.call_tool("remarkable_status", {})
-        data = json.loads(result[0][0].text)
+        result = await _call_tool("remarkable_status", {})
+        data = json.loads(result.content[0].text)
         assert "app_enabled" not in data
 
 
@@ -4917,7 +4916,9 @@ class TestCLIFlags:
     def test_default_transport_security_requires_proxy_header_rewrite(self):
         from mcp.server.transport_security import TransportSecurityMiddleware
 
-        middleware = TransportSecurityMiddleware(mcp.settings.transport_security)
+        from remarkable_mcp.server import _transport_security_for_host
+
+        middleware = TransportSecurityMiddleware(_transport_security_for_host("127.0.0.1"))
         assert middleware._validate_host("mcp.example.com") is False
         assert middleware._validate_host("127.0.0.1:8000") is True
         assert middleware._validate_origin("https://openwebui.example.com") is False
@@ -4928,26 +4929,24 @@ class TestCLIFlags:
 
         import remarkable_mcp.server as server
 
-        previous_host = mcp.settings.host
-        previous_port = mcp.settings.port
-        previous_security = mcp.settings.transport_security
-        try:
-            with patch.object(mcp, "run") as fastmcp_run:
-                server.run(
-                    transport="streamable-http",
-                    host="0.0.0.0",
-                    port=9000,
-                )
-            fastmcp_run.assert_called_once_with(transport="streamable-http")
-            middleware = TransportSecurityMiddleware(mcp.settings.transport_security)
-            assert middleware._validate_host("0.0.0.0:9000") is True
-            assert middleware._validate_origin("http://0.0.0.0:3000") is True
-            assert middleware._validate_host("mcp.example.com") is False
-            assert middleware._validate_origin("https://openwebui.example.com") is False
-        finally:
-            mcp.settings.host = previous_host
-            mcp.settings.port = previous_port
-            mcp.settings.transport_security = previous_security
+        security = server._transport_security_for_host("0.0.0.0")
+        with patch.object(mcp, "run") as mcp_run:
+            server.run(
+                transport="streamable-http",
+                host="0.0.0.0",
+                port=9000,
+            )
+        mcp_run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",
+            port=9000,
+            transport_security=security,
+        )
+        middleware = TransportSecurityMiddleware(security)
+        assert middleware._validate_host("0.0.0.0:9000") is True
+        assert middleware._validate_origin("http://0.0.0.0:3000") is True
+        assert middleware._validate_host("mcp.example.com") is False
+        assert middleware._validate_origin("https://openwebui.example.com") is False
 
     def test_read_only_instructions_do_not_advertise_markdown_writeback(self):
         from remarkable_mcp.server import _build_instructions
@@ -5023,18 +5022,18 @@ class TestCanvasWrite:
     @pytest.mark.asyncio
     async def test_empty_strokes_rejected(self):
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author",
                 {"method": "draw", "document": "Sketchbook", "page": 1, "strokes": []},
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["_error"]["type"] == "no_strokes"
 
     @pytest.mark.asyncio
     async def test_unknown_method_is_educational(self):
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
-            result = await mcp.call_tool("remarkable_author", {"method": "frobnicate"})
-            data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_author", {"method": "frobnicate"})
+            data = json.loads(result.content[0].text)
             assert data["_error"]["type"] == "unknown_method"
             assert "draw" in data["_error"]["did_you_mean"]
 
@@ -5077,7 +5076,7 @@ class TestCanvasWrite:
                 strokes_mod, "append_strokes", lambda original, strokes: original + b"NEW"
             ),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author",
                 {
                     "method": "draw",
@@ -5086,7 +5085,7 @@ class TestCanvasWrite:
                     "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "fineliner"}],
                 },
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["written"] is True
             assert data["created_overlay"] is True
             rm = f"{wt.XOCHITL_PATH}/doc-abc/page-1.rm"
@@ -5142,7 +5141,7 @@ class TestCanvasWrite:
                 strokes_mod, "append_strokes", lambda original, strokes: original + b"NEW"
             ),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author",
                 {
                     "method": "draw",
@@ -5158,7 +5157,7 @@ class TestCanvasWrite:
                     "ui_submitted": True,
                 },
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["written"] is True
             assert data["page"] == 1
             assert data["total_pages"] == 2
@@ -5213,7 +5212,7 @@ class TestCanvasWrite:
                 strokes_mod, "append_strokes", lambda original, strokes: original + b"NEW"
             ),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author",
                 {
                     "method": "draw",
@@ -5222,7 +5221,7 @@ class TestCanvasWrite:
                     "strokes": [{"points": [[0.1, 0.2], [0.8, 0.2]], "tool": "highlighter"}],
                 },
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["written"] is True
             assert "caveat" in data and "EPUB" in data["caveat"]
 
@@ -5263,10 +5262,10 @@ class TestCanvasWrite:
             patch.object(wt, "_restart_xochitl") as mock_restart,
             patch.object(wt, "_invalidate_client_cache", lambda c: None),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author", {"method": "add_page", "document": "Sketchbook"}
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["added"] is True
             assert data["page_added"] == 2
             assert data["total_pages"] == 2
@@ -5298,10 +5297,10 @@ class TestCanvasWrite:
             patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
             patch.object(wt, "get_rmapi", lambda: client),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author", {"method": "add_page", "document": "Sketchbook"}
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["_error"]["type"] == "not_a_notebook"
 
     @pytest.mark.asyncio
@@ -5325,10 +5324,10 @@ class TestCanvasWrite:
             patch.object(wt, "_restart_xochitl") as mock_restart,
             patch.object(wt, "_invalidate_client_cache", lambda c: None),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author", {"method": "create_document", "name": "My notes"}
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["created"] is True
             assert data["document"] == "My notes"
             assert data["total_pages"] == 1
@@ -5359,18 +5358,18 @@ class TestCanvasWrite:
             patch.object(wt, "_restart_xochitl"),
             patch.object(wt, "_invalidate_client_cache", lambda c: None),
         ):
-            result = await mcp.call_tool(
+            result = await _call_tool(
                 "remarkable_author",
                 {"method": "create_document", "name": "My notes", "text": "Agenda"},
             )
-            data = json.loads(result[0][0].text)
+            data = json.loads(result.content[0].text)
             assert data["has_text"] is True
 
     @pytest.mark.asyncio
     async def test_create_document_requires_name(self):
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
-            result = await mcp.call_tool("remarkable_author", {"method": "create_document"})
-            data = json.loads(result[0][0].text)
+            result = await _call_tool("remarkable_author", {"method": "create_document"})
+            data = json.loads(result.content[0].text)
             assert data["_error"]["type"] == "missing_parameter"
 
 
@@ -5707,11 +5706,11 @@ class TestDeferRestart:
                 patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
                 patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
             ):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_upload",
                     {"file_path": str(pdf), "defer_restart": True},
                 )
-                data = json.loads(result[0][0].text)
+                data = json.loads(result.content[0].text)
                 assert data["uploaded"] is True
                 assert data["refresh_pending"] is True
                 mock_restart.assert_not_called()
@@ -5738,11 +5737,11 @@ class TestDeferRestart:
                 patch("remarkable_mcp.write_tools._defer_restart_enabled", return_value=False),
                 patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
             ):
-                result = await mcp.call_tool(
+                result = await _call_tool(
                     "remarkable_upload",
                     {"file_path": str(pdf)},
                 )
-                data = json.loads(result[0][0].text)
+                data = json.loads(result.content[0].text)
                 assert data["uploaded"] is True
                 assert data["refresh_pending"] is False
                 mock_restart.assert_called_once_with(client)
@@ -5756,7 +5755,7 @@ class TestDeferRestart:
         with patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}):
             register_write_tools()
         try:
-            tools = await mcp.list_tools()
+            tools = await _list_tools()
             assert "remarkable_refresh" in [t.name for t in tools]
 
             client = self._make_ssh_client()
@@ -5765,8 +5764,8 @@ class TestDeferRestart:
                 patch("remarkable_mcp.write_tools._restart_xochitl") as mock_restart,
                 patch.dict(os.environ, {"REMARKABLE_USE_SSH": "1"}),
             ):
-                result = await mcp.call_tool("remarkable_refresh", {})
-                data = json.loads(result[0][0].text)
+                result = await _call_tool("remarkable_refresh", {})
+                data = json.loads(result.content[0].text)
                 assert data["refreshed"] is True
                 mock_restart.assert_called_once_with(client)
         finally:
@@ -5781,7 +5780,7 @@ class TestDeferRestart:
         with patch.dict(os.environ, env, clear=True):
             register_write_tools()
             try:
-                tools = await mcp.list_tools()
+                tools = await _list_tools()
                 assert "remarkable_refresh" not in [t.name for t in tools]
             finally:
                 self._cleanup_tools()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,8 @@ requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
     "python_full_version < '3.11'",
 ]
 
@@ -548,49 +549,51 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "h11", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2-jsfetch"
+version = "1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -761,15 +764,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -779,9 +782,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -800,6 +816,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1123,20 +1151,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,15 +1235,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1356,7 +1361,7 @@ requires-dist = [
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "google-cloud-vision", marker = "extra == 'ocr'", specifier = ">=3.0.0" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.27.0,<2.0.0" },
+    { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pymupdf", specifier = ">=1.26.7" },
     { name = "pytesseract", specifier = ">=0.3.10" },
@@ -1660,6 +1665,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace MCP Python SDK 1.28 `FastMCP` with stable SDK 2.x `MCPServer` (`mcp>=2,<3`)
- keep stdio as the default and preserve the secure loopback Streamable HTTP endpoint
- serve `2026-07-28` and every earlier SDK-supported revision from one server
- preserve all tools, resources, prompts, MCP Apps UI metadata/resource, embedded resources, structured output, annotations, context injection, lifespan/background loading, and process-local reMarkable configuration
- route sampling OCR and destructive delete confirmation through SDK 2 `Resolve` compatibility APIs so modern clients use multi-round input and legacy clients keep their back-channel behavior
- incorporate reviewed release cleanup from `e6ce199`: all-test CI/release gates, corrected release ordering, concise/full tool docs, credential redaction, nonblocking client resolution, wildcard HTTP rejection, optional registry token metadata, and runtime/package cleanup
- preserve current-main SSH serialization/cache reliability and make missing local upload files surface as `FileNotFoundError` instead of a false “OpenSSH missing” error
- make `permanent=True` delete elicitation explicitly warn that deletion is irreversible and cannot be recovered from Trash; ordinary delete explicitly says it moves the item to Trash
- add `defer_restart` to every `remarkable_author` method with accurate `refresh_pending` responses and `remarkable_refresh()` guidance

Implemented against the official [v2 migration guide](https://py.sdk.modelcontextprotocol.io/migration/) and [v2 overview](https://py.sdk.modelcontextprotocol.io/whats-new/).

## Compatibility evidence

- `uv run ruff check .` and `uv run ruff format --check .`
- complete isolated suites on every supported interpreter:
  - Python **3.10**: **344 passed, 10 skipped**
  - Python **3.11**: **344 passed, 10 skipped**
  - Python **3.12**: **344 passed, 10 skipped**
  - skips are live-device integration tests; no live writes were performed
- dual-era in-memory tests cover catalogs, MCP Apps metadata/resource, sampling OCR, normal/permanent delete elicitation wording, sealed multi-round retries, local fallback behavior, and one-fetch/one-render sampling preparation
- `remarkable_author` draw/add-page/create-document tests cover immediate restart and deferred restart with `refresh_pending=true`
- raw stdio initialize/list/call succeeded for **2024-11-05**, **2025-03-26**, **2025-06-18**, and **2025-11-25**; v2 discover/list/call succeeded for **2026-07-28**
- Streamable HTTP list/call succeeded for modern `2026-07-28` and legacy `2025-11-25` clients on the same `/mcp` endpoint
- HTTP security checks: invalid Host → **421**, invalid Origin → **403**, allowed loopback Host reached MCP request validation; wildcard CLI binds are rejected
- public-interface diff against current main: **13 tools, 6 prompts, 1 resource, 0 templates** on both sides; no default tool/resource/prompt schema loss
- `uv build --clear`, isolated wheel install/CLI startup, and wheel metadata check for `mcp>=2,<3`
- Copilot CLI started the consolidated local stdio MCP and called `remarkable_status` successfully with a hermetic read-only local-dir configuration
- `server.json` parses and now correctly marks `REMARKABLE_TOKEN` optional

## Expected protocol-level differences

The interface diff reports five expected SDK/spec envelope changes rather than catalog changes:

- SDK 2 advertises list-change/resource-subscription capabilities
- modern results include `resultType` and server metadata under `_meta`
- modern discovery reports the application version (`0.1.0`) instead of the old SDK version (`1.28.1`)

## Remaining limitations

- the built-in runner is intentionally single-process. SDK 2's default request-state key is process-local; a future multi-worker HTTP deployment must configure shared `RequestStateSecurity` keys, and legacy sessions require sticky routing
- sampling and roots remain available for legacy clients but are deprecated by the `2026-07-28` specification; remarkable-mcp uses the supported multi-round resolver carrier for modern sampling OCR
- validation used fixtures, mocks, hermetic unavailable-local-dir processes, and read-only protocol checks; no live tablet writes were performed