### PR TITLE
fix(nixos): use native service path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,19 @@ jobs:
 
       - name: Install built wheel
         run: uv run --isolated --no-project --with dist/*.whl remarkable-mcp --help
+  nixos-module:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.11.1
+
+      - name: Check module syntax
+        run: nix-instantiate --parse remarkable-mcp-bridge.nix >/dev/null
+
+      - name: Evaluate default NixOS module
+        run: >-
+          nix-instantiate --eval --strict
+          -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/0e251e24a4f24e036a084b6b4b2d2491af4167f4.tar.gz
+          tests/nixos-module-eval.nix

--- a/README.md
+++ b/README.md
@@ -383,7 +383,9 @@ loopback default:
 ```
 
 The service user must have its reMarkable credentials under
-`/var/lib/remarkable-mcp` (or the configured `home`).
+`/var/lib/remarkable-mcp` (or the configured `home`). The module adds
+Tesseract to the service's executable search path; install the configured
+`command` separately.
 
 ---
 

--- a/remarkable-mcp-bridge.nix
+++ b/remarkable-mcp-bridge.nix
@@ -94,9 +94,9 @@ in
       description = "reMarkable MCP Streamable HTTP bridge";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+      path = [ pkgs.tesseract ];
       environment = cfg.extraEnvironment // {
         HOME = toString cfg.home;
-        PATH = "${pkgs.tesseract}/bin:/run/current-system/sw/bin";
       };
       serviceConfig = {
         Type = "simple";

--- a/tests/nixos-module-eval.nix
+++ b/tests/nixos-module-eval.nix
@@ -1,0 +1,22 @@
+let
+  evaluated = import <nixpkgs/nixos/lib/eval-config.nix> {
+    modules = [
+      ../remarkable-mcp-bridge.nix
+      {
+        services.remarkable-mcp.enable = true;
+        system.stateVersion = "24.11";
+      }
+    ];
+  };
+  config = evaluated.config;
+  service = config.systemd.services.remarkable-mcp-bridge;
+  unitText = config.systemd.units."remarkable-mcp-bridge.service".text;
+in
+assert builtins.elem evaluated.pkgs.tesseract service.path;
+assert service.environment.HOME == "/var/lib/remarkable-mcp";
+assert service.serviceConfig.NoNewPrivileges;
+assert service.serviceConfig.PrivateTmp;
+assert service.serviceConfig.ExecStart
+  == "/opt/remarkable-mcp/.venv/bin/remarkable-mcp --http --host 127.0.0.1 --port 8000";
+assert builtins.isString unitText;
+true


### PR DESCRIPTION
## Summary
- replace the conflicting service `environment.PATH` with native `systemd.services.remarkable-mcp-bridge.path`
- add a pinned NixOS module evaluation that forces systemd unit generation and verifies the default command, Tesseract path, and hardening settings
- clarify that the module supplies Tesseract but does not package the Python application

## Validation
- reproduced the original `systemd.services.remarkable-mcp-bridge.environment.PATH` conflict by evaluating the pre-fix module
- `nix-instantiate --parse remarkable-mcp-bridge.nix`
- default module evaluation returned `true` with Nix and `nix-instantiate` 2.31.2 against nixpkgs `0e251e24a4f24e036a084b6b4b2d2491af4167f4` (`26.11pre-git`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -v` (`364 passed, 10 skipped`)

Closes #162