### PR TITLE
fix(usb): make metadata cache concurrency-safe

### DIFF
--- a/remarkable_mcp/usb_web.py
+++ b/remarkable_mcp/usb_web.py
@@ -21,8 +21,10 @@ Benefits:
 - Officially supported by reMarkable
 """
 
+import asyncio
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -120,6 +122,11 @@ class USBWebClient:
         self.timeout = timeout
         self._documents: List[Document] = []
         self._documents_by_id: Dict[str, Document] = {}
+        self._metadata_loaded_all = False
+        self._metadata_lock = threading.RLock()
+        self._metadata_condition = threading.Condition(self._metadata_lock)
+        self._metadata_loading = False
+        self._metadata_generation = 0
         try:
             max_concurrency = int(os.environ.get("REMARKABLE_USB_MAX_CONCURRENCY", "2"))
         except ValueError as exc:
@@ -191,11 +198,14 @@ class USBWebClient:
             raise RuntimeError(f"USB web interface request failed: {e}")
 
     async def run_method_async(self, func, *args, **kwargs):
-        """Await USB operations on its bounded dispatcher."""
+        """Await USB operations while keeping HTTP I/O on the bounded dispatcher."""
         if func.__name__ == "get_meta_items":
             limit = args[0] if args else kwargs.get("limit")
-            if self._documents and (limit is None or len(self._documents) >= limit):
+            if self._get_cached_meta_items(limit) is not None:
                 return func(*args, **kwargs)
+            # Metadata waiters must not occupy dispatcher workers needed by
+            # independent downloads. The traversal's _request calls remain bounded.
+            return await asyncio.to_thread(func, *args, **kwargs)
         return await self._dispatcher.call_async(
             func.__name__.replace("_", "-"),
             lambda: func(*args, **kwargs),
@@ -209,6 +219,9 @@ class USBWebClient:
 
     def close(self) -> None:
         self._dispatcher.close()
+
+    async def aclose(self) -> None:
+        await asyncio.to_thread(self._dispatcher.close)
 
     def check_connection(self) -> bool:
         """Check if USB web interface is accessible."""
@@ -250,6 +263,62 @@ class USBWebClient:
             current_page=entry.get("CurrentPage", 0),
         )
 
+    def _get_cached_meta_items_locked(self, limit: Optional[int]) -> Optional[List[Document]]:
+        if self._metadata_loaded_all:
+            return self._documents if limit is None else self._documents[:limit]
+        if limit is not None and len(self._documents) >= limit:
+            return self._documents[:limit]
+        return None
+
+    def _get_cached_meta_items(self, limit: Optional[int]) -> Optional[List[Document]]:
+        with self._metadata_lock:
+            return self._get_cached_meta_items_locked(limit)
+
+    def _publish_metadata_locked(self, documents: List[Document], *, loaded_all: bool) -> None:
+        self._documents = documents
+        self._documents_by_id = {document.id: document for document in documents}
+        self._metadata_loaded_all = loaded_all
+
+    def invalidate_metadata_cache(self) -> None:
+        """Clear metadata atomically and reject any traversal already in flight."""
+        with self._metadata_condition:
+            self._documents = []
+            self._documents_by_id = {}
+            self._metadata_loaded_all = False
+            self._metadata_generation += 1
+            self._metadata_condition.notify_all()
+
+    def _load_meta_items(self, limit: Optional[int]) -> tuple[List[Document], bool]:
+        documents = []
+        folders_to_process = [("", DOCUMENTS_URL)]  # (parent_id, url)
+        processed_folders = set()
+
+        while folders_to_process:
+            parent_id, url = folders_to_process.pop(0)
+            if url in processed_folders:
+                continue
+            processed_folders.add(url)
+
+            try:
+                response = self._request(url)
+                entries = response.json()
+            except Exception as exc:
+                raise RuntimeError(f"Failed to fetch documents from {url}: {exc}") from exc
+
+            for index, entry in enumerate(entries):
+                doc = self._parse_document_entry(entry, parent=parent_id)
+                documents.append(doc)
+
+                if doc.is_folder:
+                    folder_url = f"/documents/{doc.id}"
+                    folders_to_process.append((doc.id, folder_url))
+
+                if limit is not None and len(documents) >= limit:
+                    loaded_all = index == len(entries) - 1 and not folders_to_process
+                    return documents, loaded_all
+
+        return documents, True
+
     def get_meta_items(self, limit: Optional[int] = None) -> List[Document]:
         """
         Fetch documents and folders from the tablet via USB web interface.
@@ -259,62 +328,44 @@ class USBWebClient:
 
         Returns a list of Document objects.
         """
-        # Return cached documents if available and no limit specified
-        if self._documents and limit is None:
-            return self._documents
-
-        # If we have cached docs and limit is within cache, return slice
-        if self._documents and limit is not None and len(self._documents) >= limit:
-            return self._documents[:limit]
-
-        documents = []
-        folders_to_process = [("", DOCUMENTS_URL)]  # (parent_id, url)
-        processed_folders = set()
-
-        # Recursively fetch all documents from all folders
-        while folders_to_process:
-            parent_id, url = folders_to_process.pop(0)
-
-            # Skip if already processed
-            if url in processed_folders:
-                continue
-            processed_folders.add(url)
-
-            try:
-                response = self._request(url)
-                entries = response.json()
-
-                for entry in entries:
-                    doc = self._parse_document_entry(entry, parent=parent_id)
-                    documents.append(doc)
-
-                    # If it's a folder, add it to the queue
-                    if doc.is_folder:
-                        folder_url = f"/documents/{doc.id}"
-                        folders_to_process.append((doc.id, folder_url))
-
-                    # Check limit
-                    if limit is not None and len(documents) >= limit:
-                        break
-
-                if limit is not None and len(documents) >= limit:
+        with self._metadata_condition:
+            while True:
+                cached = self._get_cached_meta_items_locked(limit)
+                if cached is not None:
+                    return cached
+                if not self._metadata_loading:
+                    self._metadata_loading = True
+                    generation = self._metadata_generation
                     break
+                self._metadata_condition.wait()
 
-            except Exception as e:
-                logger.warning(f"Failed to fetch documents from {url}: {e}")
-                continue
+        try:
+            documents, loaded_all = self._load_meta_items(limit)
+        except BaseException:
+            with self._metadata_condition:
+                self._metadata_loading = False
+                self._metadata_condition.notify_all()
+            raise
 
-        self._documents = documents
-        self._documents_by_id = {d.id: d for d in documents}
+        with self._metadata_condition:
+            try:
+                if generation == self._metadata_generation:
+                    self._publish_metadata_locked(documents, loaded_all=loaded_all)
+            finally:
+                self._metadata_loading = False
+                self._metadata_condition.notify_all()
 
-        logger.info(f"Loaded {len(documents)} documents via USB web interface")
+        logger.info(f"Fetched {len(documents)} documents via USB web interface")
         return documents
 
     def get_doc(self, doc_id: str) -> Optional[Document]:
         """Get a document by ID."""
-        if not self._documents_by_id:
+        while True:
+            with self._metadata_lock:
+                document = self._documents_by_id.get(doc_id)
+                if document is not None or self._metadata_loaded_all:
+                    return document
             self.get_meta_items()
-        return self._documents_by_id.get(doc_id)
 
     # Downloads can be large — use a longer timeout
     DOWNLOAD_TIMEOUT = 120
@@ -394,10 +445,8 @@ class USBWebClient:
 
         Uses the fileType field from the USB web API response.
         """
-        if not self._documents_by_id:
-            self.get_meta_items()
-
-        return {doc_id: self.get_file_type(doc) for doc_id, doc in self._documents_by_id.items()}
+        documents = self.get_meta_items()
+        return {doc.id: self.get_file_type(doc) for doc in documents}
 
 
 def check_usb_web_available(host: str = DEFAULT_USB_HOST) -> bool:

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -629,26 +629,31 @@ def _resolve_document(
 
 def _invalidate_client_cache(client) -> None:
     """Drop the in-memory document cache so the next read reflects the write."""
-    metadata_lock = getattr(client, "_metadata_lock", None)
-    context = metadata_lock if metadata_lock is not None else nullcontext()
-    with context:
-        client._documents = []
-        client._documents_by_id = {}
-        if hasattr(client, "_metadata_loaded_all"):
-            client._metadata_loaded_all = False
-        if hasattr(client, "_metadata_generation"):
-            client._metadata_generation += 1
+    client_state = getattr(client, "__dict__", {})
+    invalidate_metadata = getattr(type(client), "invalidate_metadata_cache", None)
+    if callable(invalidate_metadata):
+        invalidate_metadata(client)
+    else:
+        metadata_lock = client_state.get("_metadata_lock")
+        context = metadata_lock if metadata_lock is not None else nullcontext()
+        with context:
+            client._documents = []
+            client._documents_by_id = {}
+            if "_metadata_loaded_all" in client_state:
+                client._metadata_loaded_all = False
+            if "_metadata_generation" in client_state:
+                client._metadata_generation += 1
 
-    file_type_lock = getattr(client, "_file_type_lock", None)
+    file_type_lock = client_state.get("_file_type_lock")
     context = file_type_lock if file_type_lock is not None else nullcontext()
     with context:
         from remarkable_mcp.local_dir import LocalDirClient
 
         if isinstance(client, (SSHClient, LocalDirClient)):
             client._file_type_cache = None
-        elif hasattr(client, "_file_type_cache"):
+        elif "_file_type_cache" in client_state:
             client._file_type_cache = {}
-        if hasattr(client, "_file_type_generation"):
+        if "_file_type_generation" in client_state:
             client._file_type_generation += 1
 
 
@@ -1462,8 +1467,7 @@ def register_write_tools():
 
                     # Clear cached documents
                     client = get_rmapi()
-                    client._documents = []
-                    client._documents_by_id = {}
+                    _invalidate_client_cache(client)
 
                     result = {
                         "uploaded": True,

--- a/test_server.py
+++ b/test_server.py
@@ -2372,6 +2372,7 @@ class TestUSBWebInterface:
         pdf_doc = next(d for d in docs if d.name == "Test Doc")
         assert pdf_doc.file_type == "pdf"
         assert client.get_file_type(pdf_doc) == "pdf"
+        assert {request.args[0] for request in mock_request.call_args_list} == {"GET"}
 
     @patch("requests.request")
     def test_usb_web_download(self, mock_request):
@@ -2556,12 +2557,21 @@ class TestUSBWebInterface:
         import asyncio
         import time
 
-        from remarkable_mcp.usb_web import USBWebClient
+        from remarkable_mcp.usb_web import Document, USBWebClient
 
         monkeypatch.setenv("REMARKABLE_USE_USB_WEB", "1")
         monkeypatch.delenv("REMARKABLE_USE_SSH", raising=False)
         monkeypatch.setenv("REMARKABLE_USB_MAX_CONCURRENCY", "1")
         client = USBWebClient()
+        cached = Document(
+            id="cached",
+            hash="cached",
+            name="Cached",
+            doc_type="DocumentType",
+        )
+        with client._metadata_lock:
+            client._publish_metadata_locked([cached], loaded_all=True)
+        initial_generation = client._metadata_generation
         active = 0
         max_active = 0
         lock = threading.Lock()
@@ -2601,6 +2611,11 @@ class TestUSBWebInterface:
                 )
             assert all(json.loads(result.content[0].text)["uploaded"] is True for result in results)
             assert max_active == 1
+            with client._metadata_lock:
+                assert client._documents == []
+                assert client._documents_by_id == {}
+                assert client._metadata_loaded_all is False
+                assert client._metadata_generation == initial_generation + len(files)
         finally:
             client.close()
 

--- a/test_usb_web_concurrency.py
+++ b/test_usb_web_concurrency.py
@@ -1,0 +1,284 @@
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+
+from remarkable_mcp.usb_web import DOCUMENTS_URL, Document, USBWebClient
+
+
+def _response(entries=None, *, content=b""):
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = [] if entries is None else entries
+    response.content = content
+    return response
+
+
+def _entry(doc_id, name=None):
+    return {
+        "ID": doc_id,
+        "VissibleName": name or doc_id,
+        "Type": "DocumentType",
+        "fileType": "pdf",
+    }
+
+
+def _folder_entry(doc_id, name=None):
+    return {
+        "ID": doc_id,
+        "VissibleName": name or doc_id,
+        "Type": "CollectionType",
+    }
+
+
+class _EntryTrackingClient(USBWebClient):
+    def __init__(self):
+        super().__init__()
+        self._metadata_entries = 0
+        self._metadata_entries_lock = threading.Lock()
+        self.second_metadata_entry = threading.Event()
+
+    def get_meta_items(self, limit=None):
+        with self._metadata_entries_lock:
+            self._metadata_entries += 1
+            if self._metadata_entries == 2:
+                self.second_metadata_entry.set()
+        return super().get_meta_items(limit)
+
+
+class TestUSBWebMetadataConcurrency:
+    def test_concurrent_initial_loads_share_one_traversal(self):
+        client = _EntryTrackingClient()
+        load_started = threading.Event()
+        release_load = threading.Event()
+        attempts = 0
+        attempts_lock = threading.Lock()
+
+        def request(endpoint):
+            nonlocal attempts
+            assert endpoint == DOCUMENTS_URL
+            with attempts_lock:
+                attempts += 1
+            load_started.set()
+            assert release_load.wait(2)
+            return _response([_entry("doc-1", "One")])
+
+        client._request = request
+        try:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                first = executor.submit(client.get_meta_items)
+                assert load_started.wait(1)
+                second = executor.submit(client.get_meta_items)
+                assert client.second_metadata_entry.wait(1)
+                release_load.set()
+
+                assert [doc.id for doc in first.result(timeout=2)] == ["doc-1"]
+                assert [doc.id for doc in second.result(timeout=2)] == ["doc-1"]
+
+            assert attempts == 1
+        finally:
+            client.close()
+
+    def test_reader_cannot_observe_half_published_cache(self):
+        class PausingClient(USBWebClient):
+            def __init__(self):
+                super().__init__()
+                self.list_published = threading.Event()
+                self.release_publication = threading.Event()
+
+            def _publish_metadata_locked(self, documents, *, loaded_all):
+                self._documents = documents
+                self._metadata_loaded_all = loaded_all
+                self.list_published.set()
+                assert self.release_publication.wait(2)
+                self._documents_by_id = {document.id: document for document in documents}
+
+        client = PausingClient()
+        client._request = lambda endpoint: _response([_entry("doc-1", "One")])
+        reader_started = threading.Event()
+
+        def read_document():
+            reader_started.set()
+            return client.get_doc("doc-1")
+
+        try:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                fill = executor.submit(client.get_meta_items)
+                assert client.list_published.wait(1)
+                reader = executor.submit(read_document)
+                assert reader_started.wait(1)
+                assert not reader.done()
+
+                client.release_publication.set()
+                assert [doc.id for doc in fill.result(timeout=2)] == ["doc-1"]
+                assert reader.result(timeout=2).id == "doc-1"
+        finally:
+            client.release_publication.set()
+            client.close()
+
+    def test_invalidation_during_fill_rejects_stale_publication(self):
+        client = USBWebClient()
+        load_started = threading.Event()
+        release_load = threading.Event()
+        attempts = 0
+
+        def request(endpoint):
+            nonlocal attempts
+            assert endpoint == DOCUMENTS_URL
+            attempts += 1
+            if attempts == 1:
+                load_started.set()
+                assert release_load.wait(2)
+                return _response([_entry("stale")])
+            return _response([_entry("fresh")])
+
+        client._request = request
+        try:
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                fill = executor.submit(client.get_meta_items)
+                assert load_started.wait(1)
+                client.invalidate_metadata_cache()
+                release_load.set()
+                assert [doc.id for doc in fill.result(timeout=2)] == ["stale"]
+
+            with client._metadata_lock:
+                assert client._documents == []
+                assert client._documents_by_id == {}
+                assert client._metadata_loaded_all is False
+
+            assert [doc.id for doc in client.get_meta_items()] == ["fresh"]
+            assert attempts == 2
+        finally:
+            release_load.set()
+            client.close()
+
+    def test_failed_fill_is_not_published_and_next_call_retries(self):
+        client = USBWebClient()
+        root_attempts = 0
+        folder_attempts = 0
+
+        def request(endpoint):
+            nonlocal folder_attempts, root_attempts
+            if endpoint == DOCUMENTS_URL:
+                root_attempts += 1
+                return _response([_folder_entry("folder-1"), _entry("root-doc")])
+            assert endpoint == "/documents/folder-1"
+            folder_attempts += 1
+            if folder_attempts == 1:
+                raise RuntimeError("temporary read failure")
+            return _response([_entry("child-doc")])
+
+        client._request = request
+        try:
+            with pytest.raises(RuntimeError, match="temporary read failure"):
+                client.get_meta_items()
+
+            with client._metadata_lock:
+                assert client._documents == []
+                assert client._documents_by_id == {}
+                assert client._metadata_loaded_all is False
+                assert client._metadata_loading is False
+
+            assert [doc.id for doc in client.get_meta_items()] == [
+                "folder-1",
+                "root-doc",
+                "child-doc",
+            ]
+            assert root_attempts == 2
+            assert folder_attempts == 2
+        finally:
+            client.close()
+
+    def test_successful_empty_fill_is_cached(self):
+        client = USBWebClient()
+        attempts = 0
+
+        def request(endpoint):
+            nonlocal attempts
+            attempts += 1
+            return _response()
+
+        client._request = request
+        try:
+            assert client.get_meta_items() == []
+            assert client.get_meta_items() == []
+            assert client.get_doc("missing") is None
+            assert attempts == 1
+        finally:
+            client.close()
+
+    def test_limited_fill_does_not_claim_complete_cache(self):
+        client = USBWebClient()
+        attempts = 0
+
+        def request(endpoint):
+            nonlocal attempts
+            attempts += 1
+            return _response([_entry("doc-1"), _entry("doc-2")])
+
+        client._request = request
+        try:
+            assert [doc.id for doc in client.get_meta_items(limit=1)] == ["doc-1"]
+            with client._metadata_lock:
+                assert list(client._documents_by_id) == ["doc-1"]
+                assert client._metadata_loaded_all is False
+
+            assert client.get_doc("doc-2").id == "doc-2"
+            assert [doc.id for doc in client.get_meta_items(limit=1)] == ["doc-1"]
+            assert attempts == 2
+        finally:
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_metadata_waiter_does_not_block_independent_download(self, monkeypatch):
+        monkeypatch.setenv("REMARKABLE_USB_MAX_CONCURRENCY", "2")
+        client = _EntryTrackingClient()
+        metadata_started = threading.Event()
+        release_metadata = threading.Event()
+        download_started = threading.Event()
+        doc = Document(
+            id="download-1",
+            hash="download-1",
+            name="Download",
+            doc_type="DocumentType",
+        )
+
+        def request_unqueued(endpoint, method, timeout):
+            assert method == "GET"
+            if endpoint == DOCUMENTS_URL:
+                metadata_started.set()
+                assert release_metadata.wait(2)
+                return _response([_entry("doc-1")])
+            download_started.set()
+            return _response(content=b"downloaded")
+
+        client._request_unqueued = request_unqueued
+        try:
+            first_fill = asyncio.create_task(client.run_method_async(client.get_meta_items))
+            assert await asyncio.to_thread(metadata_started.wait, 1)
+            second_fill = asyncio.create_task(client.run_method_async(client.get_meta_items))
+            assert await asyncio.to_thread(client.second_metadata_entry.wait, 1)
+
+            download = asyncio.create_task(client.run_method_async(client.download, doc))
+            assert await asyncio.to_thread(download_started.wait, 1)
+            assert await asyncio.wait_for(download, 1) == b"downloaded"
+
+            release_metadata.set()
+            first_result, second_result = await asyncio.wait_for(
+                asyncio.gather(first_fill, second_fill), 2
+            )
+            assert [item.id for item in first_result] == ["doc-1"]
+            assert [item.id for item in second_result] == ["doc-1"]
+        finally:
+            release_metadata.set()
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_and_aclose_are_idempotent(self):
+        client = USBWebClient()
+
+        await client.aclose()
+        await client.aclose()
+        client.close()


### PR DESCRIPTION
## Summary

- single-flight USB metadata traversal behind one metadata lock while keeping independent HTTP downloads concurrent
- publish document lists/maps atomically, cache successful empty traversals, and leave failed/partial traversals retryable
- invalidate uploads generation-safely so in-flight stale fills cannot repopulate the cache
- add deterministic coverage for fill/fill, read/publish, invalidate/fill, failure/retry, limited fills, upload invalidation, dispatcher overlap, and close/aclose

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -v` — 372 passed, 10 skipped
- `uv build`
- concurrency regression file repeated 10 times without failure
- existing safe-GET HTTP 408 retry tests pass; metadata traversal is asserted GET-only (no HEAD preflight)
- connected USB read-only smoke attempted with the existing priority-5260 direct-route rule, but the Paper Pro USB interface and USB device were absent, so hardware checks were skipped rather than falling back to another transport

Closes #170
