### PR TITLE
fix(tools): align rendering, page counts, and document lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,10 @@ disable them. See [Write Tools](#write-tools-by-transport). Clients that support
 - Empty notebook text can trigger OCR automatically.
 - Search can scan several matching documents.
 - Image tools return visual content that text extraction misses.
+- `remarkable_read.total_pages` is the physical document count; `content_pages`
+  counts extracted-text chunks, and `more` / `next_page` continue those chunks.
+- PNG images of PDF-backed pages merge the source page and annotations
+  automatically; pass `render_merged=False` for the annotation layer alone.
 - OCR uses Google Vision when configured and otherwise runs locally with Tesseract.
 - Browse and search accept tag filters.
 
@@ -476,8 +480,11 @@ remarkable_image("Wireframe", output_format="svg")
 # Get image with OCR text extraction
 remarkable_image("Handwritten Notes", include_ocr=True)
 
-# Composite an imported PDF page with its reMarkable annotations
-remarkable_image("Research Paper", page=3, render_merged=True)
+# Imported PDF pages include their reMarkable annotations automatically
+remarkable_image("Research Paper", page=3)
+
+# Request only the reMarkable annotation layer
+remarkable_image("Research Paper", page=3, render_merged=False)
 
 # Transparent background for compositing
 remarkable_image("Logo Sketch", background="#00000000")
@@ -505,6 +512,9 @@ Documents are automatically registered as MCP resources:
 | `remarkableraw:///{path}.epub.txt` | Extracted text from the original EPUB |
 | `remarkableimg:///{path}.page-{N}.png` | PNG image of page N (notebooks only) |
 | `remarkablesvg:///{path}.page-{N}.svg` | SVG vector image of page N (notebooks only) |
+
+Trashed documents are excluded from tool, canvas, and resource lookup, so a
+trashed item cannot shadow a live document with the same name.
 
 [Full resources reference](docs/resources.md)
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,9 @@ disable them. See [Write Tools](#write-tools-by-transport). Clients that support
 - Image tools return visual content that text extraction misses.
 - `remarkable_read.total_pages` is the physical document count; `content_pages`
   counts extracted-text chunks, and `more` / `next_page` continue those chunks.
+  Raw PDF reads count pages from the already-downloaded PDF. If a raw EPUB's
+  separate archive cannot be read, its text still returns with
+  `total_pages: null` and `total_pages_known: false`.
 - PNG images of PDF-backed pages merge the source page and annotations
   automatically; pass `render_merged=False` for the annotation layer alone.
 - OCR uses Google Vision when configured and otherwise runs locally with Tesseract.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -189,7 +189,11 @@ Examples:
 
 ## Filtering
 
-Archived documents and trash items are **not** registered as resources. Only documents that are actively synced appear.
+Archived documents and trash items are **not** registered as resources. The same
+transport-aware predicate is used for synchronous and background registration,
+tool lookup, canvas lookup, and name suggestions. A trashed item therefore cannot
+shadow a live namesake or appear in page completions. Cloud, SSH, local-directory,
+and USB metadata retain their transport-specific behavior.
 
 ### Root Path Filtering
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -88,6 +88,7 @@ remarkable_read("/Work/Projects/Q4 Planning")
   "content": "Extracted text content...",
   "page": 1,
   "total_pages": 5,
+  "total_pages_known": true,
   "content_pages": 2,
   "total_chars": 12500,
   "more": true,
@@ -105,13 +106,21 @@ remarkable_read("/Work/Projects/Q4 Planning")
 
 ### Pagination
 
-- `total_pages` always reports physical document pages, matching
-  `remarkable_image`.
+- `total_pages` reports physical document pages, matching `remarkable_image`,
+  and `total_pages_known` says whether that count was available.
 - `content_pages` reports extracted-text pagination units. PDF/EPUB source text
   uses ~8000-character chunks; notebook OCR may produce fewer content pages than
   physical pages when blank pages have no text.
 - `page`, `more`, and `next_page` refer to those content pages. This preserves
   bounded text responses without overloading the physical page count.
+- Raw PDF reads count pages from the same source bytes used for text extraction
+  and do not fetch the full document archive. A raw EPUB may need that archive
+  for its physical page count; if the archive is unavailable, the extracted
+  content still succeeds with `total_pages: null`, `total_pages_known: false`,
+  and a `page_count_note`.
+- On older USB firmware that returns a native PDF instead of an rmdoc archive,
+  `content_type="text"` returns source text without annotations, while
+  `content_type="annotations"` returns `annotations_not_available`.
 
 When `more: true`, use the `page` parameter to continue reading.
 
@@ -417,6 +426,9 @@ used when configured; otherwise OCR runs locally with Tesseract.
 - SVG remains annotation-only; explicit `render_merged=True` with SVG returns
   SVG plus an explanatory note.
 - Compatibility responses preserve the same merge choice and expose `merged`.
+- If older USB firmware returns only a native PDF export, PNG still renders via
+  that export. SVG and explicit `render_merged=False` require the unavailable
+  rmdoc annotation layer and return clear errors.
 - RGBA colors (8-digit hex) allow transparency control
 
 ---

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -45,7 +45,7 @@ With this configuration:
 |-----------|------|---------|-------------|
 | `document` | string | *required* | Document name or full path |
 | `content_type` | string | `"text"` | What content to extract |
-| `page` | int | `1` | Page number for pagination |
+| `page` | int | `1` | Extracted-content page number for bounded text pagination |
 | `grep` | string | `None` | Search for keywords in content |
 | `include_ocr` | bool | `False` | Enable OCR for handwritten content |
 
@@ -61,7 +61,7 @@ With this configuration:
 # Read first page of a document
 remarkable_read("Meeting Notes")
 
-# Read a specific page
+# Read the third extracted-content chunk
 remarkable_read("Research Paper.pdf", page=3)
 
 # Search for keywords
@@ -88,10 +88,12 @@ remarkable_read("/Work/Projects/Q4 Planning")
   "content": "Extracted text content...",
   "page": 1,
   "total_pages": 5,
-  "total_chars": 2500,
+  "content_pages": 2,
+  "total_chars": 12500,
   "more": true,
+  "next_page": 2,
   "modified": "2025-11-28T10:30:00Z",
-  "_hint": "Page 1/5. Next: remarkable_read('Meeting Notes', page=2)."
+  "_hint": "Content page 1/2; document has 5 physical pages. Next: remarkable_read('Meeting Notes', page=2)."
 }
 ```
 
@@ -103,8 +105,13 @@ remarkable_read("/Work/Projects/Q4 Planning")
 
 ### Pagination
 
-- **PDF/EPUB**: Pages are ~8000 character chunks of extracted text
-- **Notebooks**: Pages correspond to actual notebook pages (especially useful with OCR)
+- `total_pages` always reports physical document pages, matching
+  `remarkable_image`.
+- `content_pages` reports extracted-text pagination units. PDF/EPUB source text
+  uses ~8000-character chunks; notebook OCR may produce fewer content pages than
+  physical pages when blank pages have no text.
+- `page`, `more`, and `next_page` refer to those content pages. This preserves
+  bounded text responses without overloading the physical page count.
 
 When `more: true`, use the `page` parameter to continue reading.
 
@@ -213,6 +220,7 @@ remarkable_search("project", tags=["work"])
       "modified": "2025-11-28T10:30:00Z",
       "content": "...context around matches...",
       "total_pages": 2,
+      "content_pages": 1,
       "grep_matches": 5,
       "truncated": true
     }
@@ -334,7 +342,7 @@ remarkable_status()
 | `output_format` | string | `"png"` | Output format: `"png"` or `"svg"` |
 | `include_ocr` | bool | `False` | Enable OCR on the image |
 | `compatibility` | bool | `False` | Return resource URI instead of embedded resource |
-| `render_merged` | bool | `False` | Composite an imported PDF page with its reMarkable annotations (PNG only) |
+| `render_merged` | bool \| null | `None` (auto) | PNG compositing mode: auto-merge PDF-backed pages, `True` to request merging explicitly, or `False` for annotations only |
 
 ### Background Colors
 
@@ -372,8 +380,11 @@ remarkable_image("Handwritten Notes", include_ocr=True)
 # Compatibility mode: return resource URI instead of embedded resource
 remarkable_image("Diagram", compatibility=True)
 
-# Composite a PDF page with annotations
-remarkable_image("Research Paper", page=3, render_merged=True)
+# PDF-backed PNG pages merge the source page and annotations automatically
+remarkable_image("Research Paper", page=3)
+
+# Return only the reMarkable annotation layer
+remarkable_image("Research Paper", page=3, render_merged=False)
 ```
 
 ### Response Format
@@ -386,9 +397,10 @@ When `compatibility=True`, returns a JSON object with the resource URI:
 
 ```json
 {
-  "resource_uri": "remarkableimg:///path/doc.page-1.png",
+  "resource_uri": "remarkableimg:///path/doc.page-1.merged.png",
   "page": 1,
   "total_pages": 5,
+  "merged": true,
   "_hint": "Page 1/5. Use resource URI to access the image."
 }
 ```
@@ -398,9 +410,13 @@ used when configured; otherwise OCR runs locally with Tesseract.
 
 ### Notes
 
-- Works best with notebooks and handwritten content
-- For PDFs/EPUBs, renders the annotation layer only (not the underlying document)
-- SVG format is useful for further editing in design tools
+- Native notebooks retain their existing stroke and blank-page rendering.
+- PDF-backed PNG pages merge the source page and annotations by default. Explicit
+  `render_merged=False` preserves annotation-only access, including user-added
+  PDF pages that have no underlay.
+- SVG remains annotation-only; explicit `render_merged=True` with SVG returns
+  SVG plus an explanatory note.
+- Compatibility responses preserve the same merge choice and expose `merged`.
 - RGBA colors (8-digit hex) allow transparency control
 
 ---

--- a/remarkable_mcp/app_canvas.py
+++ b/remarkable_mcp/app_canvas.py
@@ -670,9 +670,10 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     from remarkable_mcp.responses import make_error
     from remarkable_mcp.tools import (
         _apply_root_filter,
+        _find_target_document,
         _get_root_path,
+        _is_cloud_archived,
         _is_within_root,
-        _resolve_root_path,
     )
 
     background = await run_blocking(get_background_color)
@@ -681,21 +682,8 @@ async def _render_canvas_page_impl(document: str, page: int, ctx: Optional[Conte
     items_by_id = get_items_by_id(collection)
 
     root = _get_root_path()
-    actual_document = _resolve_root_path(document) if document.startswith("/") else document
-
-    documents = [item for item in collection if not item.is_folder]
-    target_doc = None
-    document_lower = actual_document.lower().strip("/")
-    for doc in documents:
-        doc_path = get_item_path(doc, items_by_id)
-        if not _is_within_root(doc_path, root):
-            continue
-        if doc.VissibleName.lower() == document_lower:
-            target_doc = doc
-            break
-        if doc_path.lower().strip("/") == document_lower:
-            target_doc = doc
-            break
+    documents = [item for item in collection if not item.is_folder and not _is_cloud_archived(item)]
+    target_doc = _find_target_document(collection, items_by_id, document)
 
     if not target_doc:
         filtered_docs = [

--- a/remarkable_mcp/resources.py
+++ b/remarkable_mcp/resources.py
@@ -265,8 +265,10 @@ def _register_document(
     if doc_id in _registered_docs:
         return False
 
-    # Skip cloud-archived documents (not available on device)
-    if hasattr(doc, "is_cloud_archived") and doc.is_cloud_archived:
+    # Keep resource visibility aligned with tool/canvas document resolution.
+    from remarkable_mcp.tools import _is_cloud_archived
+
+    if _is_cloud_archived(doc):
         return False
 
     # Get the full path

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -123,7 +123,8 @@ Example: `remarkable_image("Notes", include_ocr=True)` returns image with extrac
 
 ### For Large Documents
 Use pagination to avoid overwhelming context. The response includes:
-- `page` / `total_pages` - current position
+- `page` / `content_pages` - current extracted-text position
+- `total_pages` - physical document page count
 - `more` - true if more content exists
 - `next_page` - page number to request next
 

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -40,6 +40,7 @@ from remarkable_mcp.extract import (
     find_similar_documents,
     get_background_color,
     get_cached_ocr_result,
+    get_document_file_type,
     get_document_page_count,
     get_ocr_backend,
     render_mapped_pdf_page_from_document_zip,
@@ -120,7 +121,7 @@ def _find_target_document(collection, items_by_id: dict, document: str):
     actual_document = _resolve_root_path(document) if document.startswith("/") else document
     document_lower = actual_document.lower().strip("/")
     for item in collection:
-        if item.is_folder:
+        if item.is_folder or _is_cloud_archived(item):
             continue
         item_path = get_item_path(item, items_by_id)
         if not _is_within_root(item_path, root):
@@ -177,9 +178,11 @@ DEFAULT_PAGE_SIZE = 8000
 
 def _is_cloud_archived(item) -> bool:
     """Check if an item is cloud-archived (not available on device)."""
-    # SSH mode: check is_cloud_archived property
-    if hasattr(item, "is_cloud_archived"):
-        return item.is_cloud_archived
+    # SSH/local-dir/USB expose an explicit property. Require a real bool so
+    # permissive proxy objects do not accidentally hide otherwise valid items.
+    archived = getattr(item, "is_cloud_archived", None)
+    if isinstance(archived, bool):
+        return archived
     # Cloud mode: check parent == "trash"
     parent = item.Parent if hasattr(item, "Parent") else getattr(item, "parent", "")
     return parent == "trash"
@@ -205,6 +208,14 @@ def _modified_sort_key(item) -> float:
         except (OverflowError, OSError, ValueError):
             return 0.0
     return 0.0
+
+
+def _count_pdf_pages(pdf_bytes: bytes) -> int:
+    """Count pages in a native PDF returned instead of an rmdoc archive."""
+    import fitz
+
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as document:
+        return len(document)
 
 
 def _ocr_png_tesseract(png_path: Path) -> Optional[str]:
@@ -317,6 +328,8 @@ async def remarkable_read(
     - Start with page=1 (default)
     - Check "more" field - if true, there's more content
     - Use "next_page" value to get the next page
+    - "total_pages" is the physical document count; "content_pages" is the
+      extracted-text count used by page/more/next_page
 
     Use grep to search for specific content on the current page.
 
@@ -325,7 +338,8 @@ async def remarkable_read(
     <parameters>
     - document: Document name or path (use remarkable_browse to find documents)
     - content_type: "text" (full), "raw" (PDF/EPUB only), "annotations" (notes only)
-    - page: Page number (default: 1). For notebooks, this is the notebook page.
+    - page: Extracted-content page number (default: 1). Physical document pages
+      are reported separately as total_pages.
     - grep: Optional regex pattern to filter content (searches current page)
     - include_ocr: Enable handwriting OCR for annotations (default: False)
     </parameters>
@@ -348,7 +362,9 @@ async def remarkable_read(
         page_size = DEFAULT_PAGE_SIZE
 
         root = _get_root_path()
-        documents = [item for item in collection if not item.is_folder]
+        documents = [
+            item for item in collection if not item.is_folder and not _is_cloud_archived(item)
+        ]
         target_doc = _find_target_document(collection, items_by_id, document)
 
         if not target_doc:
@@ -370,6 +386,25 @@ async def remarkable_read(
 
         doc_path = get_item_path(target_doc, items_by_id)
         file_type = await run_blocking(get_file_type, client, target_doc)
+        archive_bytes: Optional[bytes] = None
+
+        async def load_archive() -> bytes:
+            nonlocal archive_bytes
+            if archive_bytes is None:
+                archive_bytes = await run_blocking(client.download, target_doc)
+            return archive_bytes
+
+        async def count_archive_pages() -> int:
+            raw_doc = await load_archive()
+            if raw_doc.lstrip().startswith(b"%PDF"):
+                return await run_blocking(_count_pdf_pages, raw_doc)
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                tmp.write(raw_doc)
+                tmp_path = Path(tmp.name)
+            try:
+                return await run_blocking(get_document_page_count, tmp_path)
+            finally:
+                tmp_path.unlink(missing_ok=True)
 
         # Collect content based on content_type
         text_parts = []
@@ -425,7 +460,7 @@ async def remarkable_read(
                     content = cached
 
             if not notebook_pages and is_notebook:
-                raw_doc = await run_blocking(client.download, target_doc)
+                raw_doc = await load_archive()
                 with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                     tmp.write(raw_doc)
                     tmp_path = Path(tmp.name)
@@ -447,7 +482,7 @@ async def remarkable_read(
             if not (is_notebook and notebook_pages):
                 if content is None:
                     # Need to extract if we haven't already
-                    raw_doc = await run_blocking(client.download, target_doc)
+                    raw_doc = await load_archive()
                     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp.write(raw_doc)
                         tmp_path = Path(tmp.name)
@@ -504,20 +539,29 @@ async def remarkable_read(
                         text_parts.append("\n\n=== Annotations ===\n")
                     text_parts.extend(annotation_parts)
 
-        # For notebooks with OCR: use page-based pagination
-        if notebook_pages:
-            total_pages = len(notebook_pages)
+        physical_pages = int(content.get("pages") or 0) if content else 0
+        if physical_pages <= 0:
+            physical_pages = await count_archive_pages()
+        total_pages = max(1, physical_pages)
 
-            if page > total_pages:
+        # OCR results remain content-pagination units. They can be fewer than
+        # physical pages when blank or non-OCR pages are omitted.
+        if notebook_pages:
+            content_pages = len(notebook_pages)
+
+            if page > content_pages:
                 return make_error(
                     error_type="page_out_of_range",
-                    message=f"Page {page} does not exist. "
-                    f"Document has {total_pages} notebook page(s).",
-                    suggestion=f"Use page=1 to {total_pages} to read different pages.",
+                    message=(
+                        f"Content page {page} does not exist. Extracted content has "
+                        f"{content_pages} page(s); the document has {total_pages} "
+                        "physical page(s)."
+                    ),
+                    suggestion=f"Use page=1 to {content_pages} to read extracted content.",
                 )
 
             page_content = notebook_pages[page - 1]
-            has_more = page < total_pages
+            has_more = page < content_pages
 
             # Apply grep filter if specified
             grep_matches = 0
@@ -560,6 +604,7 @@ async def remarkable_read(
                 "content": page_content,
                 "page": page,
                 "total_pages": total_pages,
+                "content_pages": content_pages,
                 "page_type": "notebook",
                 "total_chars": len(page_content),
                 "more": has_more,
@@ -571,11 +616,17 @@ async def remarkable_read(
             if ocr_backend_used:
                 result["ocr_backend"] = ocr_backend_used
 
+            if has_more:
+                result["next_page"] = page + 1
+
             if grep:
                 result["grep"] = grep
                 result["grep_matches"] = grep_matches
 
-            hint_parts = [f"Notebook page {page}/{total_pages}."]
+            hint_parts = [
+                f"Notebook content page {page}/{content_pages}; "
+                f"document has {total_pages} physical page(s)."
+            ]
             if has_more:
                 doc_name = target_doc.VissibleName
                 hint_parts.append(f"Next: remarkable_read('{doc_name}', page={page + 1}).")
@@ -650,7 +701,10 @@ async def remarkable_read(
             if page > 1:
                 return make_error(
                     error_type="page_out_of_range",
-                    message=f"Page {page} does not exist. Document has 1 page(s).",
+                    message=(
+                        f"Content page {page} does not exist. Extracted content has "
+                        f"1 page; the document has {total_pages} physical page(s)."
+                    ),
                     suggestion="Use page=1 to start from the beginning.",
                 )
             # Return empty result for page 1
@@ -661,7 +715,8 @@ async def remarkable_read(
                 "content_type": content_type,
                 "content": "",
                 "page": 1,
-                "total_pages": 1,
+                "total_pages": total_pages,
+                "content_pages": 1,
                 "total_chars": 0,
                 "more": False,
                 "modified": (
@@ -676,16 +731,20 @@ async def remarkable_read(
 
         if start_idx >= total_chars:
             # Page out of range
-            total_pages = max(1, (total_chars + page_size - 1) // page_size)
+            content_pages = max(1, (total_chars + page_size - 1) // page_size)
             return make_error(
                 error_type="page_out_of_range",
-                message=f"Page {page} does not exist. Document has {total_pages} page(s).",
+                message=(
+                    f"Content page {page} does not exist. Extracted content has "
+                    f"{content_pages} page(s); the document has {total_pages} "
+                    "physical page(s)."
+                ),
                 suggestion="Use page=1 to start from the beginning.",
             )
 
         page_content = full_text[start_idx:end_idx]
         has_more = end_idx < total_chars
-        total_pages = max(1, (total_chars + page_size - 1) // page_size)
+        content_pages = max(1, (total_chars + page_size - 1) // page_size)
 
         result = {
             "document": target_doc.VissibleName,
@@ -695,6 +754,7 @@ async def remarkable_read(
             "content": page_content,
             "page": page,
             "total_pages": total_pages,
+            "content_pages": content_pages,
             "total_chars": total_chars,
             "more": has_more,
             "modified": (
@@ -727,10 +787,14 @@ async def remarkable_read(
 
         if has_more:
             hint_parts.append(
-                f"Page {page}/{total_pages}. Next: remarkable_read('{document}', page={page + 1})"
+                f"Content page {page}/{content_pages}; document has {total_pages} "
+                f"physical page(s). Next: remarkable_read('{document}', page={page + 1})"
             )
         else:
-            hint_parts.append(f"Page {page}/{total_pages} (complete).")
+            hint_parts.append(
+                f"Content page {page}/{content_pages} (complete); "
+                f"document has {total_pages} physical page(s)."
+            )
 
         if content_type == "text" and not raw_available and file_type in ("pdf", "epub"):
             hint_parts.append(
@@ -1191,6 +1255,7 @@ async def remarkable_search(
                 if "_error" not in read_data:
                     doc_result["content"] = read_data.get("content", "")[:2000]  # Limit per doc
                     doc_result["total_pages"] = read_data.get("total_pages", 1)
+                    doc_result["content_pages"] = read_data.get("content_pages", 1)
                     if grep:
                         doc_result["grep_matches"] = read_data.get("grep_matches", 0)
                     if len(read_data.get("content", "")) > 2000:
@@ -1496,6 +1561,7 @@ async def _render_png_page(
     page: int,
     background: str,
     render_merged: bool,
+    allow_pdf_fallback: bool,
 ) -> tuple[Optional[bytes], Optional[str], bool, bool]:
     """Render a PNG with the same fallbacks used by remarkable_image."""
     merged_note = None
@@ -1517,7 +1583,7 @@ async def _render_png_page(
         )
 
     rendered_via_pdf = False
-    if png_data is None:
+    if png_data is None and allow_pdf_fallback:
         png_data, has_source_pdf = await run_blocking(
             render_mapped_pdf_page_from_document_zip, tmp_path, page
         )
@@ -1549,7 +1615,7 @@ async def remarkable_image(
     output_format: str = "png",
     compatibility: bool = False,
     include_ocr: bool = False,
-    render_merged: bool = False,
+    render_merged: Optional[bool] = None,
 ):
     """
     <usecase>Get an image of a specific page from a reMarkable document.</usecase>
@@ -1562,10 +1628,9 @@ async def remarkable_image(
 
     ## Merged PDF + Annotation Rendering
 
-    Set render_merged=True to composite the PDF page with the annotation layer into
-    a single image. This is ideal for annotated PDFs where the annotation-only render
-    is hard to interpret without the printed page context. Only works with PNG format
-    and documents that have a PDF underlay.
+    PNG pages backed by an imported PDF automatically composite the PDF page with
+    its reMarkable annotations. Set render_merged=False for an annotation-only
+    render, or True to explicitly request compositing. SVG remains annotation-only.
 
     ## Response Formats
 
@@ -1581,9 +1646,7 @@ async def remarkable_image(
     Optionally, enable include_ocr=True to extract text from the image using OCR.
     Google Vision is used when configured; otherwise OCR runs locally with Tesseract.
 
-    Note: This works best with notebooks and handwritten content. For PDFs/EPUBs,
-    the annotations layer is rendered (not the underlying PDF content) unless
-    render_merged=True is set.
+    Note: Native notebooks retain their existing stroke rendering behavior.
     </instructions>
     <parameters>
     - document: Document name or path (use remarkable_browse to find documents)
@@ -1595,8 +1658,9 @@ async def remarkable_image(
     - compatibility: If True, return resource URI in JSON instead of embedded resource.
       Use this if your client doesn't support embedded resources in tool responses.
     - include_ocr: Enable OCR text extraction from the image (default: False).
-    - render_merged: Composite PDF page + annotation layer into one image (default: False).
-      Only works with PNG format and documents that have a PDF underlay.
+    - render_merged: PDF compositing mode for PNG: None (default) automatically
+      merges PDF-backed pages, True explicitly requests merging, and False returns
+      the annotation-only layer. SVG output remains annotation-only.
     </parameters>
     <examples>
     - remarkable_image("UI Mockup")  # Get first page as embedded PNG resource
@@ -1606,7 +1670,8 @@ async def remarkable_image(
     - remarkable_image("Diagram", output_format="svg")  # Get as embedded SVG resource
     - remarkable_image("Notes", compatibility=True)  # Return resource URI for retry
     - remarkable_image("Notes", include_ocr=True)  # Get image with OCR text extraction
-    - remarkable_image("Annotated PDF", render_merged=True)  # PDF + annotations composited
+    - remarkable_image("Annotated PDF")  # PDF + annotations composited automatically
+    - remarkable_image("Annotated PDF", render_merged=False)  # Annotation layer only
     </examples>
     """
     try:
@@ -1619,7 +1684,9 @@ async def remarkable_image(
         items_by_id = get_items_by_id(collection)
 
         root = _get_root_path()
-        documents = [item for item in collection if not item.is_folder]
+        documents = [
+            item for item in collection if not item.is_folder and not _is_cloud_archived(item)
+        ]
         target_doc = _find_target_document(collection, items_by_id, document)
 
         if not target_doc:
@@ -1654,6 +1721,10 @@ async def remarkable_image(
 
         try:
             total_pages = await run_blocking(get_document_page_count, tmp_path)
+            file_type = await run_blocking(get_document_file_type, tmp_path)
+            if not file_type:
+                file_type = await run_blocking(get_file_type, client, target_doc)
+            use_merged = render_merged is True or (render_merged is None and file_type == "pdf")
 
             if total_pages == 0:
                 return make_error(
@@ -1681,7 +1752,7 @@ async def remarkable_image(
             is_merged = False
 
             if format_lower == "svg":
-                if render_merged:
+                if render_merged is True:
                     merged_note = (
                         "render_merged is only supported with PNG format; "
                         "returning annotation-only SVG."
@@ -1754,7 +1825,8 @@ async def remarkable_image(
                     tmp_path,
                     page,
                     background,
-                    render_merged,
+                    use_merged,
+                    render_merged is not False,
                 )
 
                 if png_data is None:

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -210,6 +210,11 @@ def _modified_sort_key(item) -> float:
     return 0.0
 
 
+def _is_pdf_payload(data: Optional[bytes]) -> bool:
+    """Return whether transport bytes are a native PDF rather than an rmdoc zip."""
+    return bool(data and data.lstrip().startswith(b"%PDF"))
+
+
 def _count_pdf_pages(pdf_bytes: bytes) -> int:
     """Count pages in a native PDF returned instead of an rmdoc archive."""
     import fitz
@@ -330,6 +335,12 @@ async def remarkable_read(
     - Use "next_page" value to get the next page
     - "total_pages" is the physical document count; "content_pages" is the
       extracted-text count used by page/more/next_page
+    - "total_pages_known" reports whether the physical count was available.
+      Raw PDF reads count the downloaded PDF directly. If a raw EPUB archive
+      cannot be read, content still returns with total_pages=null.
+    - If older USB firmware returns only a native PDF, "text" returns source
+      text without annotations and "annotations" reports that the archive is
+      unavailable instead of trying to parse the PDF as a zip.
 
     Use grep to search for specific content on the current page.
 
@@ -396,7 +407,7 @@ async def remarkable_read(
 
         async def count_archive_pages() -> int:
             raw_doc = await load_archive()
-            if raw_doc.lstrip().startswith(b"%PDF"):
+            if _is_pdf_payload(raw_doc):
                 return await run_blocking(_count_pdf_pages, raw_doc)
             with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                 tmp.write(raw_doc)
@@ -409,6 +420,8 @@ async def remarkable_read(
         # Collect content based on content_type
         text_parts = []
         raw_available = False
+        raw_data: Optional[bytes] = None
+        page_count_note = None
 
         # Get raw PDF/EPUB content if requested or for "text" mode
         if content_type in ("text", "raw") and file_type in ("pdf", "epub"):
@@ -443,6 +456,59 @@ async def remarkable_read(
         ocr_backend_used = None  # Track which OCR backend was used
         content = None  # Will hold extraction result
 
+        async def read_native_pdf_content(pdf_bytes: bytes):
+            nonlocal file_type, page_count_note, raw_available
+            if content_type == "annotations":
+                return None, make_error(
+                    error_type="annotations_not_available",
+                    message=(
+                        "Annotations are unavailable because this transport "
+                        "returned a native PDF instead of a document archive."
+                    ),
+                    suggestion=(
+                        "Use content_type='raw' or 'text', or connect through "
+                        "cloud/SSH or newer USB firmware that supports rmdoc."
+                    ),
+                )
+
+            file_type = "pdf"
+            if not raw_available:
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                    tmp.write(pdf_bytes)
+                    pdf_path = Path(tmp.name)
+                try:
+                    native_text = await run_blocking(extract_text_from_pdf, pdf_path)
+                    if native_text:
+                        text_parts.append(native_text)
+                    raw_available = True
+                finally:
+                    pdf_path.unlink(missing_ok=True)
+
+            try:
+                native_pdf_pages = await run_blocking(_count_pdf_pages, pdf_bytes)
+            except Exception as e:
+                logger.warning(
+                    "Could not count native PDF pages for %s: %s",
+                    target_doc.ID,
+                    e,
+                )
+                native_pdf_pages = 0
+                page_count_note = (
+                    "Physical page count unavailable; source PDF text was "
+                    "returned without annotations."
+                )
+
+            return {
+                "typed_text": [],
+                "highlights": [],
+                "handwritten_text": None,
+                "pages": native_pdf_pages,
+                "page_ids": [],
+                "annotated_pages": [],
+                "ocr_backend": None,
+                "tags": [],
+            }, None
+
         if content_type in ("text", "annotations"):
             # For notebooks (no PDF/EPUB), use page-based pagination
             is_notebook = file_type not in ("pdf", "epub")
@@ -461,31 +527,16 @@ async def remarkable_read(
 
             if not notebook_pages and is_notebook:
                 raw_doc = await load_archive()
-                with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                    tmp.write(raw_doc)
-                    tmp_path = Path(tmp.name)
-
-                try:
-                    content = await run_blocking(
-                        extract_text_from_document_zip,
-                        tmp_path,
-                        include_ocr=include_ocr,
-                        doc_id=target_doc.ID,
-                    )
-                    if content.get("handwritten_text"):
-                        notebook_pages = content["handwritten_text"]
-                        ocr_backend_used = content.get("ocr_backend")
-                finally:
-                    tmp_path.unlink(missing_ok=True)
-
-            # For non-notebooks or when no OCR pages, build annotation sections
-            if not (is_notebook and notebook_pages):
-                if content is None:
-                    # Need to extract if we haven't already
-                    raw_doc = await load_archive()
+                if _is_pdf_payload(raw_doc):
+                    content, native_error = await read_native_pdf_content(raw_doc)
+                    if native_error:
+                        return native_error
+                    is_notebook = False
+                else:
                     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                         tmp.write(raw_doc)
                         tmp_path = Path(tmp.name)
+
                     try:
                         content = await run_blocking(
                             extract_text_from_document_zip,
@@ -493,8 +544,34 @@ async def remarkable_read(
                             include_ocr=include_ocr,
                             doc_id=target_doc.ID,
                         )
+                        if content.get("handwritten_text"):
+                            notebook_pages = content["handwritten_text"]
+                            ocr_backend_used = content.get("ocr_backend")
                     finally:
                         tmp_path.unlink(missing_ok=True)
+
+            # For non-notebooks or when no OCR pages, build annotation sections
+            if not (is_notebook and notebook_pages):
+                if content is None:
+                    # Need to extract if we haven't already
+                    raw_doc = await load_archive()
+                    if _is_pdf_payload(raw_doc):
+                        content, native_error = await read_native_pdf_content(raw_doc)
+                        if native_error:
+                            return native_error
+                    else:
+                        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                            tmp.write(raw_doc)
+                            tmp_path = Path(tmp.name)
+                        try:
+                            content = await run_blocking(
+                                extract_text_from_document_zip,
+                                tmp_path,
+                                include_ocr=include_ocr,
+                                doc_id=target_doc.ID,
+                            )
+                        finally:
+                            tmp_path.unlink(missing_ok=True)
 
                 # Add annotations section
                 annotation_parts = []
@@ -540,9 +617,41 @@ async def remarkable_read(
                     text_parts.extend(annotation_parts)
 
         physical_pages = int(content.get("pages") or 0) if content else 0
-        if physical_pages <= 0:
-            physical_pages = await count_archive_pages()
-        total_pages = max(1, physical_pages)
+        if physical_pages <= 0 and page_count_note is None:
+            if content_type == "raw" and file_type == "pdf":
+                try:
+                    physical_pages = await run_blocking(_count_pdf_pages, raw_data)
+                except Exception as e:
+                    logger.warning("Could not count raw PDF pages for %s: %s", target_doc.ID, e)
+                    page_count_note = (
+                        "Physical page count unavailable; raw PDF content was returned."
+                    )
+            else:
+                try:
+                    physical_pages = await count_archive_pages()
+                except Exception as e:
+                    if content_type != "raw" or file_type != "epub":
+                        raise
+                    logger.warning("Could not count raw EPUB pages for %s: %s", target_doc.ID, e)
+                    page_count_note = (
+                        "Physical page count unavailable because the document archive "
+                        "could not be read; raw EPUB content was returned."
+                    )
+        raw_page_count_unknown = (
+            physical_pages <= 0 and content_type == "raw" and file_type in ("pdf", "epub")
+        )
+        if raw_page_count_unknown and page_count_note is None:
+            page_count_note = (
+                f"Physical page count unavailable; raw {file_type.upper()} content was returned."
+            )
+        page_count_unknown = physical_pages <= 0 and page_count_note is not None
+        total_pages = None if page_count_unknown else max(1, physical_pages)
+        total_pages_known = total_pages is not None
+        physical_page_summary = (
+            f"document has {total_pages} physical page(s)"
+            if total_pages_known
+            else "physical document page count is unavailable"
+        )
 
         # OCR results remain content-pagination units. They can be fewer than
         # physical pages when blank or non-OCR pages are omitted.
@@ -604,6 +713,7 @@ async def remarkable_read(
                 "content": page_content,
                 "page": page,
                 "total_pages": total_pages,
+                "total_pages_known": total_pages_known,
                 "content_pages": content_pages,
                 "page_type": "notebook",
                 "total_chars": len(page_content),
@@ -623,10 +733,7 @@ async def remarkable_read(
                 result["grep"] = grep
                 result["grep_matches"] = grep_matches
 
-            hint_parts = [
-                f"Notebook content page {page}/{content_pages}; "
-                f"document has {total_pages} physical page(s)."
-            ]
+            hint_parts = [f"Notebook content page {page}/{content_pages}; {physical_page_summary}."]
             if has_more:
                 doc_name = target_doc.VissibleName
                 hint_parts.append(f"Next: remarkable_read('{doc_name}', page={page + 1}).")
@@ -703,7 +810,7 @@ async def remarkable_read(
                     error_type="page_out_of_range",
                     message=(
                         f"Content page {page} does not exist. Extracted content has "
-                        f"1 page; the document has {total_pages} physical page(s)."
+                        f"1 page; {physical_page_summary}."
                     ),
                     suggestion="Use page=1 to start from the beginning.",
                 )
@@ -716,6 +823,7 @@ async def remarkable_read(
                 "content": "",
                 "page": 1,
                 "total_pages": total_pages,
+                "total_pages_known": total_pages_known,
                 "content_pages": 1,
                 "total_chars": 0,
                 "more": False,
@@ -727,6 +835,9 @@ async def remarkable_read(
                 f"Document '{target_doc.VissibleName}' has no extractable text content. "
                 "This may be a handwritten notebook - try include_ocr=True for OCR extraction."
             )
+            if page_count_note:
+                result["page_count_note"] = page_count_note
+                hint = f"{hint} {page_count_note}"
             return make_response(result, hint)
 
         if start_idx >= total_chars:
@@ -736,8 +847,7 @@ async def remarkable_read(
                 error_type="page_out_of_range",
                 message=(
                     f"Content page {page} does not exist. Extracted content has "
-                    f"{content_pages} page(s); the document has {total_pages} "
-                    "physical page(s)."
+                    f"{content_pages} page(s); {physical_page_summary}."
                 ),
                 suggestion="Use page=1 to start from the beginning.",
             )
@@ -754,6 +864,7 @@ async def remarkable_read(
             "content": page_content,
             "page": page,
             "total_pages": total_pages,
+            "total_pages_known": total_pages_known,
             "content_pages": content_pages,
             "total_chars": total_chars,
             "more": has_more,
@@ -787,14 +898,16 @@ async def remarkable_read(
 
         if has_more:
             hint_parts.append(
-                f"Content page {page}/{content_pages}; document has {total_pages} "
-                f"physical page(s). Next: remarkable_read('{document}', page={page + 1})"
+                f"Content page {page}/{content_pages}; {physical_page_summary}. "
+                f"Next: remarkable_read('{document}', page={page + 1})"
             )
         else:
             hint_parts.append(
-                f"Content page {page}/{content_pages} (complete); "
-                f"document has {total_pages} physical page(s)."
+                f"Content page {page}/{content_pages} (complete); {physical_page_summary}."
             )
+        if page_count_note:
+            result["page_count_note"] = page_count_note
+            hint_parts.append(page_count_note)
 
         if content_type == "text" and not raw_available and file_type in ("pdf", "epub"):
             hint_parts.append(
@@ -1255,6 +1368,7 @@ async def remarkable_search(
                 if "_error" not in read_data:
                     doc_result["content"] = read_data.get("content", "")[:2000]  # Limit per doc
                     doc_result["total_pages"] = read_data.get("total_pages", 1)
+                    doc_result["total_pages_known"] = read_data.get("total_pages_known", True)
                     doc_result["content_pages"] = read_data.get("content_pages", 1)
                     if grep:
                         doc_result["grep_matches"] = read_data.get("grep_matches", 0)
@@ -1647,6 +1761,9 @@ async def remarkable_image(
     Google Vision is used when configured; otherwise OCR runs locally with Tesseract.
 
     Note: Native notebooks retain their existing stroke rendering behavior.
+    If older USB firmware returns only a native PDF export, PNG remains
+    available; SVG and explicit annotation-only rendering require an rmdoc
+    archive and return a clear error when it is unavailable.
     </instructions>
     <parameters>
     - document: Document name or path (use remarkable_browse to find documents)
@@ -1715,15 +1832,22 @@ async def remarkable_image(
             )
 
         raw_doc = await run_blocking(client.download, target_doc)
-        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-            tmp.write(raw_doc)
-            tmp_path = Path(tmp.name)
+        native_pdf = raw_doc if _is_pdf_payload(raw_doc) else None
+        tmp_path: Optional[Path] = None
+        if native_pdf is None:
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+                tmp.write(raw_doc)
+                tmp_path = Path(tmp.name)
 
         try:
-            total_pages = await run_blocking(get_document_page_count, tmp_path)
-            file_type = await run_blocking(get_document_file_type, tmp_path)
-            if not file_type:
-                file_type = await run_blocking(get_file_type, client, target_doc)
+            if native_pdf is not None:
+                total_pages = await run_blocking(_count_pdf_pages, native_pdf)
+                file_type = "pdf"
+            else:
+                total_pages = await run_blocking(get_document_page_count, tmp_path)
+                file_type = await run_blocking(get_document_file_type, tmp_path)
+                if not file_type:
+                    file_type = await run_blocking(get_file_type, client, target_doc)
             use_merged = render_merged is True or (render_merged is None and file_type == "pdf")
 
             if total_pages == 0:
@@ -1752,6 +1876,15 @@ async def remarkable_image(
             is_merged = False
 
             if format_lower == "svg":
+                if native_pdf is not None:
+                    return make_error(
+                        error_type="svg_not_available",
+                        message=(
+                            "SVG output is unavailable because this transport returned "
+                            "a native PDF instead of a document archive."
+                        ),
+                        suggestion="Retry with output_format='png'.",
+                    )
                 if render_merged is True:
                     merged_note = (
                         "render_merged is only supported with PNG format; "
@@ -1814,20 +1947,40 @@ async def remarkable_image(
                     info = TextContent(type="text", text=info_text)
                     return [info, embedded]
             else:
-                (
-                    png_data,
-                    merged_note,
-                    is_merged,
-                    rendered_via_pdf,
-                ) = await _render_png_page(
-                    client,
-                    target_doc,
-                    tmp_path,
-                    page,
-                    background,
-                    use_merged,
-                    render_merged is not False,
-                )
+                if native_pdf is not None and render_merged is False:
+                    return make_error(
+                        error_type="annotation_only_not_available",
+                        message=(
+                            "Annotation-only rendering is unavailable because this "
+                            "transport returned a native PDF instead of a document archive."
+                        ),
+                        suggestion=(
+                            "Use the default PNG render, or connect through cloud/SSH or "
+                            "newer USB firmware that supports rmdoc."
+                        ),
+                    )
+                if native_pdf is not None:
+                    png_data = await run_blocking(
+                        render_tablet_pdf_page_to_png,
+                        native_pdf,
+                        page,
+                    )
+                    rendered_via_pdf = png_data is not None
+                else:
+                    (
+                        png_data,
+                        merged_note,
+                        is_merged,
+                        rendered_via_pdf,
+                    ) = await _render_png_page(
+                        client,
+                        target_doc,
+                        tmp_path,
+                        page,
+                        background,
+                        use_merged,
+                        render_merged is not False,
+                    )
 
                 if png_data is None:
                     return make_error(
@@ -1944,7 +2097,8 @@ async def remarkable_image(
                     return [info, embedded]
 
         finally:
-            tmp_path.unlink(missing_ok=True)
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
 
     except Exception as e:
         return make_error(

--- a/test_document_contracts.py
+++ b/test_document_contracts.py
@@ -294,20 +294,18 @@ class TestReadPageCounts:
         assert data["next_page"] == 2
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("file_type", ["pdf", "epub"])
-    async def test_raw_reads_still_report_physical_pages(self, file_type):
+    async def test_raw_epub_uses_archive_page_count(self):
         import remarkable_mcp.tools as tools
 
-        document = _document(f"Raw {file_type}", f"raw-{file_type}")
+        document = _document("Raw epub", "raw-epub")
         client = Mock()
         client.get_meta_items.return_value = [document]
         client.download.return_value = b"document archive"
 
         with (
             patch.object(tools, "get_rmapi", return_value=client),
-            patch.object(tools, "get_file_type", return_value=file_type),
+            patch.object(tools, "get_file_type", return_value="epub"),
             patch.object(tools, "download_raw_file", return_value=b"source"),
-            patch.object(tools, "extract_text_from_pdf", return_value="source text"),
             patch.object(tools, "extract_text_from_epub", return_value="source text"),
             patch.object(tools, "get_document_page_count", return_value=6),
         ):
@@ -318,22 +316,25 @@ class TestReadPageCounts:
 
         data = _response_json(result)
         assert data["total_pages"] == 6
+        assert data["total_pages_known"] is True
         assert data["content_pages"] == 1
         assert data["more"] is False
+        client.download.assert_called_once_with(document)
 
     @pytest.mark.asyncio
-    async def test_raw_pdf_counts_usb_native_pdf_fallback(self):
+    async def test_raw_pdf_counts_source_without_archive_download(self):
         import remarkable_mcp.tools as tools
 
-        document = _document("USB PDF", "usb-pdf")
+        document = _document("Raw PDF", "raw-pdf")
         client = Mock()
         client.get_meta_items.return_value = [document]
-        client.download.return_value = _pdf_bytes()
+        client.download.side_effect = AssertionError("raw PDF must not fetch the archive")
+        pdf_bytes = _pdf_bytes()
 
         with (
             patch.object(tools, "get_rmapi", return_value=client),
             patch.object(tools, "get_file_type", return_value="pdf"),
-            patch.object(tools, "download_raw_file", return_value=_pdf_bytes()),
+            patch.object(tools, "download_raw_file", return_value=pdf_bytes) as download_raw,
             patch.object(tools, "extract_text_from_pdf", return_value="source text"),
         ):
             result = await _call_tool(
@@ -344,7 +345,107 @@ class TestReadPageCounts:
         data = _response_json(result)
         assert "_error" not in data
         assert data["total_pages"] == 1
+        assert data["total_pages_known"] is True
         assert data["content_pages"] == 1
+        download_raw.assert_called_once_with(client, document, "pdf")
+        client.download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_raw_epub_archive_failure_preserves_content(self):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Offline EPUB", "offline-epub")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.side_effect = RuntimeError("archive unavailable")
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value="epub"),
+            patch.object(tools, "download_raw_file", return_value=b"source"),
+            patch.object(tools, "extract_text_from_epub", return_value="preserved raw text"),
+        ):
+            result = await _call_tool(
+                "remarkable_read",
+                {"document": document.VissibleName, "content_type": "raw"},
+            )
+
+        data = _response_json(result)
+        assert "_error" not in data
+        assert data["content"] == "preserved raw text"
+        assert data["total_pages"] is None
+        assert data["total_pages_known"] is False
+        assert "archive could not be read" in data["page_count_note"]
+        assert data["page_count_note"] in data["_hint"]
+        client.download.assert_called_once_with(document)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("metadata_file_type", ["pdf", "notebook"])
+    async def test_text_read_native_pdf_skips_unavailable_annotations(
+        self,
+        metadata_file_type,
+    ):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Native PDF text", "native-pdf-text")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        pdf_bytes = _pdf_bytes()
+        client.download.return_value = pdf_bytes
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value=metadata_file_type),
+            patch.object(tools, "download_raw_file", return_value=pdf_bytes),
+            patch.object(tools, "extract_text_from_pdf", return_value="source text"),
+            patch.object(
+                tools,
+                "extract_text_from_document_zip",
+                side_effect=AssertionError("native PDF must not be parsed as a zip"),
+            ),
+        ):
+            result = await _call_tool(
+                "remarkable_read",
+                {"document": document.VissibleName, "content_type": "text"},
+            )
+
+        data = _response_json(result)
+        assert "_error" not in data
+        assert data["content"] == "source text"
+        assert data["total_pages"] == 1
+        assert data["total_pages_known"] is True
+        client.download.assert_called_once_with(document)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("metadata_file_type", ["pdf", "notebook"])
+    async def test_annotations_read_native_pdf_is_explicitly_unavailable(
+        self,
+        metadata_file_type,
+    ):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Native PDF annotations", "native-pdf-annotations")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_bytes()
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value=metadata_file_type),
+            patch.object(
+                tools,
+                "extract_text_from_document_zip",
+                side_effect=AssertionError("native PDF must not be parsed as a zip"),
+            ),
+        ):
+            result = await _call_tool(
+                "remarkable_read",
+                {"document": document.VissibleName, "content_type": "annotations"},
+            )
+
+        data = _response_json(result)
+        assert data["_error"]["type"] == "annotations_not_available"
+        assert "native PDF" in data["_error"]["message"]
 
 
 class TestPdfRenderingDefault:
@@ -545,6 +646,69 @@ class TestPdfRenderingDefault:
         data = _response_json(result)
         assert data["merged"] is False
         assert "render_merged is only supported" not in data["_hint"]
+
+    @pytest.mark.asyncio
+    async def test_native_pdf_download_renders_png_without_zip_parsing(self):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Native PDF image", "native-pdf-image")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_bytes()
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(
+                tools,
+                "get_document_page_count",
+                side_effect=AssertionError("native PDF must not use zip page counting"),
+            ),
+            patch.object(
+                tools,
+                "get_document_file_type",
+                side_effect=AssertionError("native PDF must not use zip type detection"),
+            ),
+        ):
+            result = await _call_tool(
+                "remarkable_image",
+                {"document": document.VissibleName, "compatibility": True},
+            )
+
+        data = _response_json(result)
+        assert "_error" not in data
+        assert data["total_pages"] == 1
+        assert data["render_source"] == "tablet_pdf"
+        assert data["merged"] is False
+        assert data["image_base64"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("arguments", "error_type"),
+        [
+            ({"output_format": "svg"}, "svg_not_available"),
+            ({"render_merged": False}, "annotation_only_not_available"),
+        ],
+    )
+    async def test_native_pdf_download_rejects_archive_only_render_modes(
+        self,
+        arguments,
+        error_type,
+    ):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Native PDF limits", "native-pdf-limits")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_bytes()
+
+        with patch.object(tools, "get_rmapi", return_value=client):
+            result = await _call_tool(
+                "remarkable_image",
+                {"document": document.VissibleName, **arguments},
+            )
+
+        data = _response_json(result)
+        assert data["_error"]["type"] == error_type
 
 
 class TestCanvasArchivedLookup:

--- a/test_document_contracts.py
+++ b/test_document_contracts.py
@@ -1,0 +1,675 @@
+"""Regression tests for document lookup, page counts, and PDF rendering defaults."""
+
+import asyncio
+import io
+import json
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from mcp import types
+
+from remarkable_mcp.server import mcp
+
+
+def _document(name: str, doc_id: str, parent: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        VissibleName=name,
+        ID=doc_id,
+        Parent=parent,
+        ModifiedClient=None,
+        is_folder=False,
+        tags=[],
+    )
+
+
+def _extraction(
+    *,
+    pages: int,
+    typed_text: list[str] | None = None,
+    handwritten_text: list[str] | None = None,
+) -> dict:
+    return {
+        "typed_text": typed_text or [],
+        "highlights": [],
+        "handwritten_text": handwritten_text,
+        "pages": pages,
+        "page_ids": [f"page-{i}" for i in range(1, pages + 1)],
+        "annotated_pages": [],
+        "ocr_backend": "tesseract" if handwritten_text else None,
+        "tags": [],
+    }
+
+
+def _pdf_bytes() -> bytes:
+    import fitz
+
+    pdf = fitz.open()
+    pdf.new_page(width=445, height=594)
+    pdf_bytes = pdf.tobytes()
+    pdf.close()
+    return pdf_bytes
+
+
+def _pdf_archive(*, annotated: bool, user_added: bool) -> bytes:
+    from remarkable_mcp import notebooks
+
+    pdf_bytes = _pdf_bytes()
+
+    page = {"id": "page-1"}
+    if not user_added:
+        page["redir"] = {"value": 0}
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr(
+            "doc.content",
+            json.dumps({"fileType": "pdf", "cPages": {"pages": [page]}}),
+        )
+        archive.writestr("doc.pdf", pdf_bytes)
+        if annotated:
+            archive.writestr("page-1.rm", notebooks.page_rm_bytes("PDF annotation"))
+    return output.getvalue()
+
+
+async def _call_tool(name: str, arguments: dict) -> types.CallToolResult:
+    return await mcp.call_tool(name, arguments)
+
+
+def _response_json(result: types.CallToolResult) -> dict:
+    return json.loads(result.content[0].text)
+
+
+@pytest.fixture(autouse=True)
+def _clear_root_path(monkeypatch):
+    monkeypatch.delenv("REMARKABLE_ROOT_PATH", raising=False)
+
+
+class TestArchivedMetadataShapes:
+    """The shared archive predicate supports every transport's metadata object."""
+
+    def test_cloud_ssh_local_dir_and_usb_shapes(self):
+        from remarkable_mcp.local_dir import Document as LocalDocument
+        from remarkable_mcp.ssh import Document as SSHDocument
+        from remarkable_mcp.sync import Document as CloudDocument
+        from remarkable_mcp.tools import _is_cloud_archived
+        from remarkable_mcp.usb_web import Document as USBDocument
+
+        cloud_trash = CloudDocument("cloud", "", "Cloud", "DocumentType", parent="trash")
+        cloud_live = CloudDocument("cloud-live", "", "Cloud live", "DocumentType")
+        ssh_trash = SSHDocument("ssh", "", "SSH", "DocumentType", parent="trash")
+        local_trash = LocalDocument("local", "", "Local", "DocumentType", parent="trash")
+        local_unsynced = LocalDocument(
+            "local-live",
+            "",
+            "Local live",
+            "DocumentType",
+            synced=False,
+        )
+        usb_parent_named_trash = USBDocument(
+            "usb",
+            "",
+            "USB",
+            "DocumentType",
+            parent="trash",
+        )
+
+        assert _is_cloud_archived(cloud_trash) is True
+        assert _is_cloud_archived(cloud_live) is False
+        assert _is_cloud_archived(ssh_trash) is True
+        assert _is_cloud_archived(local_trash) is True
+        assert _is_cloud_archived(local_unsynced) is False
+        assert _is_cloud_archived(usb_parent_named_trash) is False
+
+
+class TestLiveDocumentLookup:
+    def test_live_namesake_wins_and_trash_only_is_hidden(self):
+        from remarkable_mcp.api import get_items_by_id
+        from remarkable_mcp.tools import _find_target_document
+
+        trashed = _document("Shared name", "trashed", parent="trash")
+        live = _document("Shared name", "live")
+        collection = [trashed, live]
+
+        assert _find_target_document(collection, get_items_by_id(collection), "Shared name") is live
+        assert _find_target_document([trashed], get_items_by_id([trashed]), "Shared name") is None
+
+    @pytest.mark.asyncio
+    async def test_read_and_image_resolve_the_live_namesake(self):
+        import remarkable_mcp.tools as tools
+
+        trashed = _document("Shared name", "trashed", parent="trash")
+        live = _document("Shared name", "live")
+        client = Mock()
+        client.get_meta_items.return_value = [trashed, live]
+        client.download.return_value = b"document archive"
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value="notebook"),
+            patch.object(tools, "get_cached_ocr_result", return_value=None),
+            patch.object(
+                tools,
+                "extract_text_from_document_zip",
+                return_value=_extraction(pages=1, typed_text=["live content"]),
+            ),
+        ):
+            read_result = await _call_tool(
+                "remarkable_read",
+                {"document": "Shared name", "include_ocr": True},
+            )
+
+        assert _response_json(read_result)["content"] == "live content"
+        client.download.assert_called_once_with(live)
+
+        client.reset_mock()
+        client.get_meta_items.return_value = [trashed, live]
+        client.download.return_value = b"document archive"
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_document_page_count", return_value=1),
+            patch.object(tools, "get_document_file_type", return_value="notebook"),
+            patch.object(tools, "render_page_from_document_zip", return_value=b"png"),
+        ):
+            image_result = await _call_tool(
+                "remarkable_image",
+                {
+                    "document": "Shared name",
+                    "render_merged": False,
+                    "compatibility": True,
+                },
+            )
+
+        assert "_error" not in _response_json(image_result)
+        client.download.assert_called_once_with(live)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments"),
+        [
+            ("remarkable_read", {"document": "Meting Notes"}),
+            ("remarkable_image", {"document": "Meting Notes"}),
+        ],
+    )
+    async def test_trashed_documents_are_excluded_from_suggestions(self, tool_name, arguments):
+        import remarkable_mcp.tools as tools
+
+        trashed = _document("Meeting Notes Trash", "trashed", parent="trash")
+        live = _document("Meeting Notes Live", "live")
+        client = Mock()
+        client.get_meta_items.return_value = [trashed, live]
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(
+                tools,
+                "find_similar_documents",
+                return_value=["Meeting Notes Live"],
+            ) as find_similar,
+        ):
+            result = await _call_tool(tool_name, arguments)
+
+        candidates = find_similar.call_args.args[1]
+        assert candidates == [live]
+        assert _response_json(result)["_error"]["did_you_mean"] == ["Meeting Notes Live"]
+
+
+class TestReadPageCounts:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("label", "typed_text", "handwritten_text", "expected_content_pages", "expected_more"),
+        [
+            ("typed", ["typed notes"], None, 1, False),
+            ("handwritten", [], ["ink one", "ink two"], 2, True),
+            ("mixed", ["typed notes"], ["ink"], 1, False),
+            ("blank", [], None, 1, False),
+        ],
+    )
+    async def test_notebook_total_pages_are_physical(
+        self,
+        label,
+        typed_text,
+        handwritten_text,
+        expected_content_pages,
+        expected_more,
+    ):
+        import remarkable_mcp.tools as tools
+
+        document = _document(f"{label} notebook", f"{label}-id")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+        extraction = _extraction(
+            pages=7,
+            typed_text=typed_text,
+            handwritten_text=handwritten_text,
+        )
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value="notebook"),
+            patch.object(tools, "get_cached_ocr_result", return_value=None),
+            patch.object(tools, "extract_text_from_document_zip", return_value=extraction),
+        ):
+            result = await _call_tool(
+                "remarkable_read",
+                {"document": document.VissibleName, "include_ocr": True},
+            )
+
+        data = _response_json(result)
+        assert data["total_pages"] == 7
+        assert data["content_pages"] == expected_content_pages
+        assert data["more"] is expected_more
+        assert data.get("next_page") == (2 if expected_more else None)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("file_type", ["pdf", "epub"])
+    async def test_pdf_and_epub_keep_text_pagination_separate(self, file_type):
+        import remarkable_mcp.tools as tools
+
+        document = _document(f"Long {file_type}", f"{file_type}-id")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+        long_text = "x" * (tools.DEFAULT_PAGE_SIZE + 1)
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value=file_type),
+            patch.object(tools, "download_raw_file", return_value=b"source"),
+            patch.object(tools, "extract_text_from_pdf", return_value=long_text),
+            patch.object(tools, "extract_text_from_epub", return_value=long_text),
+            patch.object(
+                tools,
+                "extract_text_from_document_zip",
+                return_value=_extraction(pages=5),
+            ),
+        ):
+            result = await _call_tool("remarkable_read", {"document": document.VissibleName})
+
+        data = _response_json(result)
+        assert data["total_pages"] == 5
+        assert data["content_pages"] == 2
+        assert data["more"] is True
+        assert data["next_page"] == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("file_type", ["pdf", "epub"])
+    async def test_raw_reads_still_report_physical_pages(self, file_type):
+        import remarkable_mcp.tools as tools
+
+        document = _document(f"Raw {file_type}", f"raw-{file_type}")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value=file_type),
+            patch.object(tools, "download_raw_file", return_value=b"source"),
+            patch.object(tools, "extract_text_from_pdf", return_value="source text"),
+            patch.object(tools, "extract_text_from_epub", return_value="source text"),
+            patch.object(tools, "get_document_page_count", return_value=6),
+        ):
+            result = await _call_tool(
+                "remarkable_read",
+                {"document": document.VissibleName, "content_type": "raw"},
+            )
+
+        data = _response_json(result)
+        assert data["total_pages"] == 6
+        assert data["content_pages"] == 1
+        assert data["more"] is False
+
+    @pytest.mark.asyncio
+    async def test_raw_pdf_counts_usb_native_pdf_fallback(self):
+        import remarkable_mcp.tools as tools
+
+        document = _document("USB PDF", "usb-pdf")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_bytes()
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_file_type", return_value="pdf"),
+            patch.object(tools, "download_raw_file", return_value=_pdf_bytes()),
+            patch.object(tools, "extract_text_from_pdf", return_value="source text"),
+        ):
+            result = await _call_tool(
+                "remarkable_read",
+                {"document": document.VissibleName, "content_type": "raw"},
+            )
+
+        data = _response_json(result)
+        assert "_error" not in data
+        assert data["total_pages"] == 1
+        assert data["content_pages"] == 1
+
+
+class TestPdfRenderingDefault:
+    @pytest.mark.asyncio
+    async def test_schema_exposes_nullable_auto_default(self):
+        tools = await mcp.list_tools()
+        image_tool = next(tool for tool in tools if tool.name == "remarkable_image")
+        schema = image_tool.input_schema["properties"]["render_merged"]
+
+        assert schema["default"] is None
+        assert {"type": "boolean"} in schema["anyOf"]
+        assert {"type": "null"} in schema["anyOf"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("file_type", "render_merged", "expected_merged"),
+        [
+            ("pdf", None, True),
+            ("notebook", None, False),
+            ("pdf", False, False),
+        ],
+    )
+    async def test_auto_mode_only_merges_pdf_backed_png(
+        self,
+        file_type,
+        render_merged,
+        expected_merged,
+    ):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Visual", "visual")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+        arguments = {"document": "Visual", "compatibility": True}
+        if render_merged is not None:
+            arguments["render_merged"] = render_merged
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_document_page_count", return_value=1),
+            patch.object(tools, "get_document_file_type", return_value=file_type),
+            patch.object(
+                tools,
+                "render_merged_page_from_document_zip",
+                return_value=(b"merged png", None),
+            ) as merged_renderer,
+            patch.object(
+                tools, "render_page_from_document_zip", return_value=b"strokes"
+            ) as strokes,
+        ):
+            result = await _call_tool("remarkable_image", arguments)
+
+        data = _response_json(result)
+        assert data["merged"] is expected_merged
+        if expected_merged:
+            merged_renderer.assert_called_once()
+            strokes.assert_not_called()
+        else:
+            merged_renderer.assert_not_called()
+            strokes.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_preserves_user_added_pdf_page_annotation_fallback(self):
+        import remarkable_mcp.tools as tools
+
+        document = _document("PDF with added page", "pdf-added")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+        note = "Page has no PDF underlay (user-added page); annotation-only render."
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_document_page_count", return_value=2),
+            patch.object(tools, "get_document_file_type", return_value="pdf"),
+            patch.object(
+                tools,
+                "render_merged_page_from_document_zip",
+                return_value=(b"annotation png", note),
+            ),
+        ):
+            result = await _call_tool(
+                "remarkable_image",
+                {"document": document.VissibleName, "page": 2, "compatibility": True},
+            )
+
+        data = _response_json(result)
+        assert data["merged"] is False
+        assert "user-added page" in data["_hint"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_annotation_only_skips_pdf_underlay_fallback(self):
+        import remarkable_mcp.tools as tools
+
+        document = _document("Annotation only", "annotation-only")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_document_page_count", return_value=1),
+            patch.object(tools, "get_document_file_type", return_value="pdf"),
+            patch.object(tools, "render_page_from_document_zip", return_value=None),
+            patch.object(
+                tools,
+                "render_mapped_pdf_page_from_document_zip",
+                return_value=(b"pdf underlay", True),
+            ) as pdf_fallback,
+            patch.object(
+                tools,
+                "render_page_full_page_from_document_zip",
+                return_value=(b"blank annotation page", (1404.0, 1872.0)),
+            ) as blank_page,
+        ):
+            result = await _call_tool(
+                "remarkable_image",
+                {
+                    "document": document.VissibleName,
+                    "render_merged": False,
+                    "compatibility": True,
+                },
+            )
+
+        data = _response_json(result)
+        assert "_error" not in data
+        assert data["merged"] is False
+        assert data["render_source"] == "strokes"
+        pdf_fallback.assert_not_called()
+        blank_page.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("annotated", "user_added", "expected_merged"),
+        [
+            (False, False, True),
+            (True, False, True),
+            (False, True, False),
+            (True, True, False),
+        ],
+    )
+    async def test_auto_mode_renders_imported_and_user_added_pdf_pages(
+        self,
+        annotated,
+        user_added,
+        expected_merged,
+    ):
+        import remarkable_mcp.tools as tools
+
+        document = _document("PDF variants", "pdf-variants")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_archive(
+            annotated=annotated,
+            user_added=user_added,
+        )
+
+        with patch.object(tools, "get_rmapi", return_value=client):
+            result = await _call_tool(
+                "remarkable_image",
+                {"document": document.VissibleName, "compatibility": True},
+            )
+
+        data = _response_json(result)
+        assert "_error" not in data
+        assert data["image_base64"]
+        assert data["merged"] is expected_merged
+
+    @pytest.mark.asyncio
+    async def test_svg_auto_mode_remains_annotation_only_without_warning(self):
+        import remarkable_mcp.tools as tools
+
+        document = _document("PDF SVG", "pdf-svg")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = b"document archive"
+
+        with (
+            patch.object(tools, "get_rmapi", return_value=client),
+            patch.object(tools, "get_document_page_count", return_value=1),
+            patch.object(tools, "get_document_file_type", return_value="pdf"),
+            patch.object(
+                tools,
+                "render_page_from_document_zip_svg",
+                return_value="<svg></svg>",
+            ),
+        ):
+            result = await _call_tool(
+                "remarkable_image",
+                {
+                    "document": document.VissibleName,
+                    "output_format": "svg",
+                    "compatibility": True,
+                },
+            )
+
+        data = _response_json(result)
+        assert data["merged"] is False
+        assert "render_merged is only supported" not in data["_hint"]
+
+
+class TestCanvasArchivedLookup:
+    @pytest.mark.asyncio
+    async def test_canvas_resolves_live_namesake(self, monkeypatch):
+        from PIL import Image
+
+        import remarkable_mcp.api as api
+        import remarkable_mcp.extract as extract
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        image = io.BytesIO()
+        Image.new("RGB", (12, 16), "white").save(image, "PNG")
+        trashed = _document("Canvas notes", "trash", parent="trash")
+        live = _document("Canvas notes", "live")
+        client = Mock()
+        client.get_meta_items.return_value = [trashed, live]
+        client.download.return_value = b"document archive"
+
+        monkeypatch.setattr(api, "get_rmapi", lambda: client)
+        monkeypatch.setattr(api, "get_items_by_id", lambda items: {item.ID: item for item in items})
+        monkeypatch.setattr(api, "get_item_path", lambda doc, items: f"/{doc.VissibleName}")
+        monkeypatch.setattr(api, "get_active_transport", lambda: "cloud")
+        monkeypatch.setattr(api, "download_raw_file", lambda client, doc, ext: None)
+        monkeypatch.setattr(extract, "get_background_color", lambda: "#FBFBFB")
+        monkeypatch.setattr(extract, "get_document_page_count", lambda path: 1)
+        monkeypatch.setattr(extract, "get_document_file_type", lambda path: "notebook")
+        monkeypatch.setattr(
+            extract,
+            "render_page_full_page_from_document_zip",
+            lambda path, page, **kwargs: (image.getvalue(), (820.0, 1458.0)),
+        )
+
+        result = await _render_canvas_page("Canvas notes", 1, None)
+
+        assert isinstance(result, types.CallToolResult)
+        assert result.structured_content["document_name"] == "Canvas notes"
+        client.download.assert_called_once_with(live)
+
+    @pytest.mark.asyncio
+    async def test_canvas_excludes_trash_from_suggestions(self, monkeypatch):
+        import remarkable_mcp.api as api
+        import remarkable_mcp.extract as extract
+        from remarkable_mcp.app_canvas import _render_canvas_page
+
+        trashed = _document("Meeting notes trash", "trash", parent="trash")
+        live = _document("Meeting notes live", "live")
+        client = Mock()
+        client.get_meta_items.return_value = [trashed, live]
+        candidates = []
+
+        monkeypatch.setattr(api, "get_rmapi", lambda: client)
+        monkeypatch.setattr(api, "get_items_by_id", lambda items: {item.ID: item for item in items})
+        monkeypatch.setattr(extract, "get_background_color", lambda: "#FBFBFB")
+
+        def find_similar(query, documents):
+            candidates.extend(documents)
+            return ["Meeting notes live"]
+
+        monkeypatch.setattr(extract, "find_similar_documents", find_similar)
+
+        result = await _render_canvas_page("Meting notes", 1, None)
+
+        assert isinstance(result, str)
+        assert candidates == [live]
+        assert json.loads(result)["_error"]["did_you_mean"] == ["Meeting notes live"]
+
+
+class _ResourceRecorder:
+    def __init__(self):
+        self.uris: list[str] = []
+
+    def resource(self, uri, **kwargs):
+        self.uris.append(uri)
+
+        def register(function):
+            return function
+
+        return register
+
+
+@pytest.fixture
+def resource_registry(monkeypatch):
+    import remarkable_mcp.resources as resources
+
+    recorder = _ResourceRecorder()
+    monkeypatch.setattr(resources, "mcp", recorder)
+    monkeypatch.setattr(resources, "_registered_docs", set())
+    monkeypatch.setattr(resources, "_registered_raw", set())
+    monkeypatch.setattr(resources, "_registered_img", set())
+    monkeypatch.setattr(resources, "_registered_uris", set())
+    monkeypatch.setattr(resources, "_img_uri_to_doc", {})
+    return resources, recorder
+
+
+class TestArchivedResourceRegistration:
+    def test_synchronous_registration_skips_trash(self, monkeypatch, resource_registry):
+        import remarkable_mcp.api as api
+
+        resources, recorder = resource_registry
+        trashed = _document("Duplicate", "trash", parent="trash")
+        live = _document("Duplicate", "live")
+        client = Mock()
+        client.get_meta_items.return_value = [trashed, live]
+        client.get_all_file_types.return_value = {"trash": "notebook", "live": "notebook"}
+        monkeypatch.setattr(api, "get_rmapi", lambda: client)
+
+        assert resources.load_all_documents_sync() == 1
+        assert resources._registered_docs == {"live"}
+        assert all("_1" not in uri for uri in recorder.uris)
+
+    @pytest.mark.asyncio
+    async def test_background_registration_skips_trash(self, monkeypatch, resource_registry):
+        import remarkable_mcp.api as api
+
+        resources, recorder = resource_registry
+        trashed = _document("Archived notes", "trash", parent="trash")
+        live = _document("Live notes", "live")
+        client = Mock()
+        client.get_meta_items.return_value = [trashed, live]
+        monkeypatch.setattr(api, "get_rmapi", lambda: client)
+
+        await resources._load_documents_background(asyncio.Event())
+
+        assert resources._registered_docs == {"live"}
+        assert all(
+            "Archived%20notes" not in uri and "Archived notes" not in uri for uri in recorder.uris
+        )

--- a/test_mcp_v2.py
+++ b/test_mcp_v2.py
@@ -60,6 +60,15 @@ async def test_one_server_serves_modern_and_legacy_catalogs():
             assert {tool.name for tool in modern_tools.tools} == {
                 tool.name for tool in legacy_tools.tools
             }
+            modern_image = next(
+                tool for tool in modern_tools.tools if tool.name == "remarkable_image"
+            )
+            legacy_image = next(
+                tool for tool in legacy_tools.tools if tool.name == "remarkable_image"
+            )
+            modern_merge_schema = modern_image.input_schema["properties"]["render_merged"]
+            assert modern_merge_schema == legacy_image.input_schema["properties"]["render_merged"]
+            assert modern_merge_schema["default"] is None
 
             modern_prompts = await modern.list_prompts()
             legacy_prompts = await legacy.list_prompts()

--- a/test_server.py
+++ b/test_server.py
@@ -419,6 +419,9 @@ class TestRemarkableBrowse:
         mock_doc.ID = "doc-123"
         mock_doc.Parent = ""
         mock_doc.ModifiedClient = "2024-01-15"
+        mock_doc.is_folder = False
+        mock_doc.is_cloud_archived = False
+        mock_doc.tags = []
 
         mock_client.get_meta_items.return_value = [mock_doc]
 
@@ -1065,8 +1068,9 @@ class TestMergedRendering:
         # Check that render_merged parameter exists in the input schema
         assert "render_merged" in image_tool.input_schema.get("properties", {})
         merged_schema = image_tool.input_schema["properties"]["render_merged"]
-        assert merged_schema.get("type") == "boolean"
-        assert merged_schema.get("default") is False
+        assert merged_schema.get("default") is None
+        assert {"type": "boolean"} in merged_schema.get("anyOf", [])
+        assert {"type": "null"} in merged_schema.get("anyOf", [])
 
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.get_rmapi")


### PR DESCRIPTION
## Summary

- make `render_merged=None` the smart PNG default: PDF-backed pages composite their source underlay and reMarkable annotations, while explicit `False` remains strictly annotation-only
- make `remarkable_read.total_pages` consistently report physical pages and expose `content_pages` for bounded text/OCR pagination (`more` and `next_page`)
- count raw PDF pages from the already downloaded source without fetching the full archive; make raw EPUB archive counting best-effort so extracted content survives count failures
- handle native-PDF-only USB responses explicitly across text, annotations, PNG, SVG, and annotation-only rendering, including missing/misclassified `fileType` metadata
- reuse `_is_cloud_archived` across read/image lookup, canvas lookup, suggestions, and synchronous/background resource registration so trash cannot shadow live documents
- document the API changes and add focused coverage for typed, handwritten, mixed, blank, PDF, EPUB, user-added, SVG, compatibility, canvas, resource, and transport metadata cases

## Compatibility evidence

- merged current `main` at `b0f51dd` (PRs #172, #173, and #175)
- MCP interface diff negotiated `2026-07-28` on both refs and kept **13 tools, 6 prompts, 1 resource, and 0 resource templates**
- the only interface changes are the deliberate `remarkable_image.render_merged` nullable auto schema/default plus updated `remarkable_read`/server descriptions
- SDK 2 modern and legacy catalogs expose the same updated schema
- read-only smoke validation passed every exposed cloud read/render tool; local-dir, USB, and SSH were unavailable and safely skipped, while unit coverage validates all four metadata shapes

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -v` — 419 passed, 10 skipped
- `uv build`
- isolated wheel install and `remarkable-mcp --help`
- `npx mcp-server-diff@3.0.0` against current `origin/main`
- all GitHub CI, Python 3.10–3.12, CodeQL, NixOS, build, and conformance checks pass

Reported by and preserving contributor credit to @lowercasename for the trash-shadowing report behind #171.

Closes #164
Closes #165
Closes #171