### PR TITLE
fix(ssh): refresh ambiguous writes during shutdown

### DIFF
--- a/remarkable_mcp/operation_queue.py
+++ b/remarkable_mcp/operation_queue.py
@@ -15,8 +15,8 @@ from typing import Any, Callable, Generic, Optional, TypeVar
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-_operation_cancel_started: ContextVar[Optional[bool]] = ContextVar(
-    "operation_cancel_started",
+_operation_cancel_dirty: ContextVar[Optional[bool]] = ContextVar(
+    "operation_cancel_dirty",
     default=None,
 )
 
@@ -29,11 +29,18 @@ class OperationQueueClosed(RuntimeError):
     """The operation queue is closing and no longer accepts work."""
 
 
-def consume_operation_cancel_started() -> Optional[bool]:
-    """Return and clear whether the current task's cancelled operation had started."""
-    started = _operation_cancel_started.get()
-    _operation_cancel_started.set(None)
-    return started
+def consume_operation_cancel_dirty() -> Optional[bool]:
+    """Return and clear whether the current task's cancelled operation may have mutated."""
+    dirty = _operation_cancel_dirty.get()
+    _operation_cancel_dirty.set(None)
+    return dirty
+
+
+def _uncancel_current_task() -> None:
+    task = asyncio.current_task()
+    uncancel = getattr(task, "uncancel", None)
+    if callable(uncancel):
+        uncancel()
 
 
 @dataclass
@@ -41,10 +48,12 @@ class OperationJob(Generic[T]):
     sequence: int
     operation: str
     callback: Callable[[], T]
+    allow_during_close: bool = False
     future: Future[T] = field(default_factory=Future)
     cancel_event: threading.Event = field(default_factory=threading.Event)
     submitted_at: float = field(default_factory=time.monotonic)
     started_at: Optional[float] = None
+    cancel_dirty: Optional[bool] = None
 
 
 class OperationDispatcher:
@@ -66,6 +75,8 @@ class OperationDispatcher:
         self._state_lock = threading.Lock()
         self._sequence = 0
         self._closing = False
+        self._stopping = False
+        self._stop_signals_sent = False
         self._active_jobs: dict[int, OperationJob[Any]] = {}
         self._active_cancel_hooks: dict[int, Callable[[], None]] = {}
         self._worker_ids: set[int] = set()
@@ -86,11 +97,25 @@ class OperationDispatcher:
             return ident in self._worker_ids
 
     def submit(self, operation: str, callback: Callable[[], T]) -> OperationJob[T]:
+        return self._submit(operation, callback, allow_during_close=False)
+
+    def _submit(
+        self,
+        operation: str,
+        callback: Callable[[], T],
+        *,
+        allow_during_close: bool,
+    ) -> OperationJob[T]:
         with self._state_lock:
-            if self._closing:
+            if self._stopping or (self._closing and not allow_during_close):
                 raise OperationQueueClosed(f"{self.name} is shutting down")
             self._sequence += 1
-            job: OperationJob[T] = OperationJob(self._sequence, operation, callback)
+            job: OperationJob[T] = OperationJob(
+                self._sequence,
+                operation,
+                callback,
+                allow_during_close=allow_during_close,
+            )
             self._queue.put(job)
             return job
 
@@ -109,16 +134,37 @@ class OperationDispatcher:
         if self.in_worker_thread():
             return callback()
         job = self.submit(operation, callback)
+        return await self._await_job(job)
+
+    async def call_async_during_close(self, operation: str, callback: Callable[[], T]) -> T:
+        """Run shutdown-critical cleanup after ordinary submissions are closed."""
+        if self.in_worker_thread():
+            return callback()
+        job = self._submit(operation, callback, allow_during_close=True)
+        return await self._await_job(job)
+
+    async def _await_job(self, job: OperationJob[T]) -> T:
+        wrapped = asyncio.wrap_future(job.future)
         try:
-            return await asyncio.wrap_future(job.future)
-        except asyncio.CancelledError:
+            return await asyncio.shield(wrapped)
+        except asyncio.CancelledError as cancellation:
             self.cancel(job)
-            try:
-                await asyncio.shield(asyncio.wrap_future(job.future))
-            except BaseException:
-                pass
-            _operation_cancel_started.set(job.started_at is not None)
-            raise
+            _uncancel_current_task()
+            while not wrapped.done():
+                try:
+                    await asyncio.shield(wrapped)
+                except asyncio.CancelledError:
+                    _uncancel_current_task()
+                except BaseException:
+                    break
+            if wrapped.done():
+                try:
+                    wrapped.exception()
+                except BaseException:
+                    pass
+            dirty = job.cancel_dirty
+            _operation_cancel_dirty.set(job.started_at is not None if dirty is None else dirty)
+            raise cancellation
 
     def cancel(self, job: OperationJob[Any]) -> None:
         job.cancel_event.set()
@@ -144,6 +190,13 @@ class OperationDispatcher:
             else:
                 self._active_cancel_hooks[job.sequence] = hook
 
+    def set_current_cancel_dirty(self, dirty: bool) -> None:
+        ident = threading.get_ident()
+        with self._state_lock:
+            job = self._active_jobs.get(ident)
+            if job is not None:
+                job.cancel_dirty = dirty
+
     def diagnostics(self) -> dict[str, Any]:
         with self._state_lock:
             active = sorted(
@@ -157,40 +210,87 @@ class OperationDispatcher:
                 "queue_depth": self._queue.qsize(),
                 "active": active,
                 "closing": self._closing,
+                "stopping": self._stopping,
                 "max_concurrency": self.max_concurrency,
             }
 
     def close(self, timeout: float = 5.0) -> None:
+        self.begin_close()
+        self.finish_close(timeout)
+
+    def begin_close(self) -> None:
+        """Reject ordinary work and cancel it while keeping cleanup workers alive."""
         with self._state_lock:
             if self._closing:
                 return
             self._closing = True
+            active = [job for job in self._active_jobs.values() if not job.allow_during_close]
+            active_sequences = {job.sequence for job in active}
+            hooks = [
+                hook
+                for sequence, hook in self._active_cancel_hooks.items()
+                if sequence in active_sequences
+            ]
+
+        self._drain_queued(preserve_close_allowed=True)
+        for job in active:
+            job.cancel_event.set()
+        for hook in hooks:
+            hook()
+
+    def finish_close(self, timeout: float = 5.0) -> None:
+        """Stop workers after shutdown-critical cleanup has drained."""
+        self.begin_close()
+        with self._state_lock:
+            first_stop = not self._stopping
+            self._stopping = True
             active = list(self._active_jobs.values())
             hooks = list(self._active_cancel_hooks.values())
 
+        if first_stop:
+            self._drain_queued(preserve_close_allowed=False)
+            for job in active:
+                job.cancel_event.set()
+            for hook in hooks:
+                hook()
+            with self._state_lock:
+                if not self._stop_signals_sent:
+                    self._stop_signals_sent = True
+                    worker_count = len(self._workers)
+                else:
+                    worker_count = 0
+            for _ in range(worker_count):
+                self._queue.put(None)
+
+        deadline = time.monotonic() + timeout
+        current_ident = threading.get_ident()
+        for worker in self._workers:
+            if worker.ident == current_ident:
+                continue
+            worker.join(max(0.0, deadline - time.monotonic()))
+
+    def is_closing(self) -> bool:
+        with self._state_lock:
+            return self._closing
+
+    def _drain_queued(self, *, preserve_close_allowed: bool) -> None:
+        preserved: list[OperationJob[Any]] = []
         while True:
             try:
                 queued = self._queue.get_nowait()
             except queue.Empty:
                 break
-            if queued is not None:
+            if queued is not None and preserve_close_allowed and queued.allow_during_close:
+                preserved.append(queued)
+            elif queued is not None:
                 queued.cancel_event.set()
                 if not queued.future.done():
                     queued.future.set_exception(
                         OperationQueueClosed(f"{self.name} shut down before operation started")
                     )
             self._queue.task_done()
-
-        for job in active:
-            job.cancel_event.set()
-        for hook in hooks:
-            hook()
-        for _ in self._workers:
-            self._queue.put(None)
-
-        deadline = time.monotonic() + timeout
-        for worker in self._workers:
-            worker.join(max(0.0, deadline - time.monotonic()))
+        for queued in preserved:
+            self._queue.put(queued)
 
     def _run(self) -> None:
         ident = threading.get_ident()
@@ -202,15 +302,26 @@ class OperationDispatcher:
                 try:
                     if job is None:
                         return
-                    if job.cancel_event.is_set():
-                        if not job.future.done():
-                            job.future.set_exception(
-                                OperationCancelled(f"{job.operation} cancelled before start")
-                            )
-                        continue
                     with self._state_lock:
-                        self._active_jobs[ident] = job
-                    job.started_at = time.monotonic()
+                        cannot_start = self._stopping or (
+                            self._closing and not job.allow_during_close
+                        )
+                        cancelled = job.cancel_event.is_set()
+                        if not cannot_start and not cancelled:
+                            self._active_jobs[ident] = job
+                            job.started_at = time.monotonic()
+                    if cannot_start or cancelled:
+                        if not job.future.done():
+                            if cannot_start:
+                                error = OperationQueueClosed(
+                                    f"{self.name} shut down before operation started"
+                                )
+                            else:
+                                error = OperationCancelled(
+                                    f"{job.operation} cancelled before start"
+                                )
+                            job.future.set_exception(error)
+                        continue
                     if self._trace_enabled():
                         logger.warning(
                             "%s queue start id=%d operation=%s wait=%.3fs depth=%d",

--- a/remarkable_mcp/ssh.py
+++ b/remarkable_mcp/ssh.py
@@ -34,6 +34,7 @@ from remarkable_mcp.ssh_reliability import (
     SSHRefreshCoordinator,
     SSHReliabilityError,
     SSHRemoteCommandError,
+    _uncancel_current_task,
     classify_pre_execution_failure,
 )
 
@@ -226,8 +227,19 @@ class SSHClient:
         """Await one coherent SSH operation without occupying the default executor."""
         return await self._dispatcher.call_async(operation, callback)
 
+    async def run_refresh_operation_async(
+        self,
+        operation: str,
+        callback: Callable[[], T],
+    ) -> T:
+        """Allow a refresh already owed by an in-flight write to drain on shutdown."""
+        return await self._dispatcher.call_async_during_close(operation, callback)
+
     def in_dispatcher_thread(self) -> bool:
         return self._dispatcher.in_worker_thread()
+
+    def is_closing(self) -> bool:
+        return self._dispatcher.is_closing()
 
     def reliability_status(self) -> dict[str, Any]:
         return {
@@ -239,8 +251,42 @@ class SSHClient:
         self._dispatcher.close()
 
     async def aclose(self) -> None:
-        await self._refresh_coordinator.close()
-        await asyncio.to_thread(self._dispatcher.close)
+        timeout = self._dispatcher.shutdown_timeout()
+        self._dispatcher.begin_close()
+        cancellation: Optional[asyncio.CancelledError] = None
+        drain_task = asyncio.create_task(self._refresh_coordinator.close(timeout))
+        try:
+            await asyncio.shield(drain_task)
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+            _uncancel_current_task()
+            await drain_task
+        finally:
+            finish_task = asyncio.create_task(self._finish_dispatcher_close(timeout))
+            try:
+                await asyncio.shield(finish_task)
+            except asyncio.CancelledError as exc:
+                if cancellation is None:
+                    cancellation = exc
+                _uncancel_current_task()
+                await finish_task
+        if cancellation is not None:
+            raise cancellation
+
+    async def _finish_dispatcher_close(self, timeout: float) -> None:
+        loop = asyncio.get_running_loop()
+        finished = loop.create_future()
+
+        def finish() -> None:
+            try:
+                self._dispatcher.finish_close(timeout)
+            except BaseException as exc:
+                loop.call_soon_threadsafe(finished.set_exception, exc)
+            else:
+                loop.call_soon_threadsafe(finished.set_result, None)
+
+        threading.Thread(target=finish, name="SSH-close", daemon=True).start()
+        await finished
 
     async def run_method_async(
         self,
@@ -411,6 +457,7 @@ class SSHClient:
         cancel_event = self._dispatcher.current_cancel_event()
         while True:
             if cancel_event.is_set():
+                self._dispatcher.set_current_cancel_dirty(False)
                 raise SSHJobCancelled(f"{operation} cancelled before attempt {attempt + 1}")
             attempt += 1
             process = None
@@ -444,7 +491,12 @@ class SSHClient:
                     if self._dispatcher.current_cancel_event().is_set():
                         self._terminate_process(process)
                         stdout, stderr = process.communicate()
-                        raise SSHJobCancelled(f"{operation} cancelled")
+                        failure = self._cancelled_process_failure(
+                            operation, process.returncode, stderr
+                        )
+                        if failure is not None:
+                            raise failure
+                        break
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
                         self._terminate_process(process)
@@ -455,6 +507,12 @@ class SSHClient:
                         )
                     try:
                         stdout, stderr = process.communicate(timeout=min(0.1, remaining))
+                        if cancel_event.is_set():
+                            failure = self._cancelled_process_failure(
+                                operation, process.returncode, stderr
+                            )
+                            if failure is not None:
+                                raise failure
                         break
                     except subprocess.TimeoutExpired:
                         continue
@@ -499,6 +557,7 @@ class SSHClient:
                 delay,
             )
             if cancel_event.wait(delay):
+                self._dispatcher.set_current_cancel_dirty(False)
                 raise SSHJobCancelled(f"{operation} cancelled during retry backoff")
 
     @staticmethod
@@ -516,6 +575,23 @@ class SSHClient:
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=1)
+
+    def _cancelled_process_failure(
+        self,
+        operation: str,
+        returncode: Optional[int],
+        stderr: bytes,
+    ) -> Optional[SSHReliabilityError]:
+        if returncode == 0:
+            return None
+        remote_started = _REMOTE_EXECUTION_MARKER in stderr
+        self._dispatcher.set_current_cancel_dirty(remote_started)
+        if remote_started:
+            return SSHExecutionUnknownError(
+                f"{operation} was cancelled after remote execution started; "
+                "the command may have applied and was not retried"
+            )
+        return SSHJobCancelled(f"{operation} cancelled before remote execution started")
 
     @staticmethod
     def _command_failure(

--- a/remarkable_mcp/ssh_reliability.py
+++ b/remarkable_mcp/ssh_reliability.py
@@ -15,7 +15,7 @@ from remarkable_mcp.operation_queue import (
     OperationCancelled,
     OperationDispatcher,
     OperationQueueClosed,
-    consume_operation_cancel_started,
+    consume_operation_cancel_dirty,
 )
 
 logger = logging.getLogger(__name__)
@@ -206,9 +206,18 @@ class SSHDispatcher(OperationDispatcher):
             )
         return result
 
+    @staticmethod
+    def shutdown_timeout() -> float:
+        return _env_float(
+            "REMARKABLE_SSH_SHUTDOWN_TIMEOUT",
+            5.0,
+            minimum=0.1,
+            maximum=60.0,
+        )
+
     def close(self, timeout: Optional[float] = None) -> None:
         if timeout is None:
-            timeout = _env_float("REMARKABLE_SSH_SHUTDOWN_TIMEOUT", 5.0, minimum=0.1, maximum=60.0)
+            timeout = self.shutdown_timeout()
         super().close(timeout)
 
 
@@ -237,6 +246,7 @@ class SSHRefreshCoordinator:
         )
         self._lock = asyncio.Lock()
         self._generation: Optional[_RefreshGeneration] = None
+        self._generations: dict[int, _RefreshGeneration] = {}
         self._next_generation = 1
         self._deferred_dirty = False
         self._refresh_count = 0
@@ -280,11 +290,16 @@ class SSHRefreshCoordinator:
         except BaseException as exc:
             mutation_error = exc
             if isinstance(exc, asyncio.CancelledError):
-                dirty = bool(consume_operation_cancel_started())
+                dirty = bool(consume_operation_cancel_dirty())
             else:
                 dirty = not isinstance(
                     exc,
-                    (SSHPreExecutionError, SSHJobCancelled, OperationCancelled),
+                    (
+                        SSHPreExecutionError,
+                        SSHJobCancelled,
+                        OperationCancelled,
+                        OperationQueueClosed,
+                    ),
                 )
 
         leader = False
@@ -309,10 +324,17 @@ class SSHRefreshCoordinator:
         except asyncio.CancelledError as exc:
             cancellation = exc
             _uncancel_current_task()
-            if leader:
-                await leader_task
-            else:
-                await asyncio.shield(generation.future)
+            try:
+                if leader:
+                    await leader_task
+                else:
+                    await asyncio.shield(generation.future)
+            except BaseException as drain_error:
+                if not isinstance(drain_error, asyncio.CancelledError):
+                    logger.warning(
+                        "SSH safety refresh failed while preserving cancellation: %s",
+                        drain_error,
+                    )
 
         if cancellation is not None:
             raise cancellation
@@ -373,15 +395,42 @@ class SSHRefreshCoordinator:
                 if self._explicit_future is follower:
                     self._explicit_future = None
 
-    async def close(self) -> None:
+    async def close(self, timeout: float) -> bool:
+        """Stop new generations and give in-flight refresh work a bounded drain."""
         async with self._lock:
             self._closing = True
-            generation = self._generation
+            explicit = self._explicit_future
             self._update_snapshot_locked()
-            if generation is not None and not generation.future.done():
-                generation.future.set_exception(
-                    SSHDispatcherClosed("Server shut down before refresh completed")
-                )
+            futures = [generation.future for generation in self._generations.values()]
+            if explicit is not None and explicit not in futures:
+                futures.append(explicit)
+        if not futures:
+            return True
+
+        waiter = asyncio.gather(*futures, return_exceptions=True)
+        try:
+            results = await asyncio.wait_for(asyncio.shield(waiter), timeout=timeout)
+        except asyncio.TimeoutError:
+            failure = SSHDispatcherClosed(
+                f"Server shutdown timed out after {timeout:.1f}s waiting for refresh"
+            )
+            async with self._lock:
+                self._deferred_dirty = True
+                for future in futures:
+                    if not future.done():
+                        future.set_exception(failure)
+                        future.exception()
+                self._update_snapshot_locked()
+            await waiter
+            logger.warning("%s; explicit refresh is required on the next connection", failure)
+            return False
+
+        for result in results:
+            if isinstance(result, BaseException) and not isinstance(
+                result, (SSHDispatcherClosed, asyncio.CancelledError)
+            ):
+                logger.warning("SSH refresh did not complete during shutdown: %s", result)
+        return True
 
     def diagnostics(self) -> dict:
         with self._snapshot_lock:
@@ -406,6 +455,7 @@ class SSHRefreshCoordinator:
                 )
                 self._next_generation += 1
                 self._generation = generation
+                self._generations[generation.number] = generation
             generation.participants += 1
             self._update_snapshot_locked()
             return generation
@@ -446,6 +496,7 @@ class SSHRefreshCoordinator:
                 generation.future.set_result(None)
         finally:
             async with self._lock:
+                self._generations.pop(generation.number, None)
                 if self._generation is generation:
                     self._generation = None
                 self._update_snapshot_locked()

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -390,9 +390,9 @@ def _pending_refresh_error(error_type: str, message: str, suggestion: str) -> st
 
 async def _refresh_ssh_client(ssh_client: SSHClient) -> None:
     try:
-        await ssh_client.run_operation_async(
+        await ssh_client.run_refresh_operation_async(
             "xochitl-refresh",
-            lambda: _restart_xochitl(ssh_client),
+            lambda: _restart_xochitl(ssh_client, wait_ready=not ssh_client.is_closing()),
         )
     except BaseException:
         _invalidate_client_cache(ssh_client)

--- a/test_server.py
+++ b/test_server.py
@@ -4602,6 +4602,43 @@ class TestOperationDispatcher:
         finally:
             dispatcher.close()
 
+    def test_close_cancels_queued_job_without_starting_it(self):
+        from remarkable_mcp.operation_queue import (
+            OperationDispatcher,
+            OperationQueueClosed,
+        )
+
+        dispatcher = OperationDispatcher(name="test", max_concurrency=1)
+        first_started = threading.Event()
+        release_first = threading.Event()
+        ran_second = False
+
+        def first():
+            first_started.set()
+            assert release_first.wait(2)
+
+        def second():
+            nonlocal ran_second
+            ran_second = True
+
+        first_job = dispatcher.submit("first", first)
+        assert first_started.wait(1)
+        second_job = dispatcher.submit("second", second)
+        closer = threading.Thread(target=lambda: dispatcher.close(timeout=1))
+        closer.start()
+        try:
+            with pytest.raises(OperationQueueClosed):
+                second_job.future.result(timeout=1)
+            assert ran_second is False
+            release_first.set()
+            first_job.future.result(timeout=1)
+            closer.join(1)
+            assert not closer.is_alive()
+        finally:
+            release_first.set()
+            closer.join(1)
+            dispatcher.close(timeout=1)
+
 
 class TestSSHReliabilityPolicy:
     @pytest.mark.parametrize(
@@ -4643,6 +4680,23 @@ class TestSSHReliabilityPolicy:
             )
             is None
         )
+
+    def test_successful_process_wins_cancellation_race(self):
+        import remarkable_mcp.ssh as ssh_mod
+        from remarkable_mcp.ssh import SSHClient
+
+        client = SSHClient()
+        try:
+            assert (
+                client._cancelled_process_failure(
+                    "write",
+                    0,
+                    ssh_mod._REMOTE_EXECUTION_MARKER + b"\n",
+                )
+                is None
+            )
+        finally:
+            client.close()
 
     def test_pre_execution_failure_retries_then_succeeds(self, monkeypatch):
         import remarkable_mcp.ssh as ssh_mod
@@ -4951,6 +5005,351 @@ class TestSSHRefreshCoordinator:
         assert isinstance(results[0], asyncio.CancelledError)
         assert results[1] is None
         assert refreshes == 1
+
+    @pytest.mark.asyncio
+    async def test_close_waits_for_superseded_generation(self, monkeypatch):
+        import asyncio
+
+        from remarkable_mcp.ssh_reliability import (
+            SSHExecutionUnknownError,
+            SSHJobCancelled,
+            SSHRefreshCoordinator,
+        )
+
+        monkeypatch.setenv("REMARKABLE_SSH_REFRESH_DEBOUNCE", "0")
+        monkeypatch.setenv("REMARKABLE_SSH_REFRESH_MAX_WAIT", "0.01")
+        coordinator = SSHRefreshCoordinator()
+        first_started = asyncio.Event()
+        second_started = asyncio.Event()
+        release_first = asyncio.Event()
+        release_second = asyncio.Event()
+        refreshes = 0
+
+        async def first_mutation():
+            first_started.set()
+            await release_first.wait()
+            raise SSHExecutionUnknownError("first generation may have persisted")
+
+        async def second_mutation():
+            second_started.set()
+            await release_second.wait()
+            raise SSHJobCancelled("second generation never started")
+
+        async def refresh():
+            nonlocal refreshes
+            refreshes += 1
+
+        first = asyncio.create_task(
+            coordinator.run_write(
+                first_mutation,
+                refresh,
+                deferred=False,
+                persisted=lambda result: True,
+            )
+        )
+        await first_started.wait()
+        await asyncio.sleep(0.02)
+        second = asyncio.create_task(
+            coordinator.run_write(
+                second_mutation,
+                refresh,
+                deferred=False,
+                persisted=lambda result: True,
+            )
+        )
+        await second_started.wait()
+
+        close = asyncio.create_task(coordinator.close(timeout=1))
+        release_second.set()
+        await asyncio.sleep(0)
+        assert close.done() is False
+        release_first.set()
+
+        results = await asyncio.gather(first, second, return_exceptions=True)
+        assert isinstance(results[0], SSHExecutionUnknownError)
+        assert isinstance(results[1], SSHJobCancelled)
+        assert await close is True
+        assert refreshes == 1
+
+
+class TestSSHShutdownCancellation:
+    class Process:
+        def __init__(self, stderr):
+            self.returncode = None
+            self.stderr = stderr
+            self.entered = threading.Event()
+            self.terminated = threading.Event()
+
+        def communicate(self, timeout=None):
+            import subprocess
+
+            self.entered.set()
+            if not self.terminated.is_set():
+                raise subprocess.TimeoutExpired("ssh", timeout)
+            return b"", self.stderr
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.returncode = -15
+            self.terminated.set()
+
+        def kill(self):
+            self.returncode = -9
+            self.terminated.set()
+
+        def wait(self, timeout=None):
+            assert self.terminated.wait(timeout)
+            return self.returncode
+
+    @staticmethod
+    async def _start_write(client, process):
+        import asyncio
+
+        from remarkable_mcp.write_tools import _refresh_ssh_client
+
+        task = asyncio.create_task(
+            client._refresh_coordinator.run_write(
+                lambda: client.run_operation_async(
+                    "write",
+                    lambda: client._ssh_command_unlocked("touch /tmp/issue-169", 30),
+                ),
+                lambda: _refresh_ssh_client(client),
+                deferred=False,
+                persisted=lambda result: True,
+            )
+        )
+        assert await asyncio.to_thread(process.entered.wait, 1)
+        return task
+
+    @staticmethod
+    def _cached_client(monkeypatch):
+        from remarkable_mcp.ssh import Document, SSHClient
+
+        monkeypatch.setenv("REMARKABLE_SSH_REFRESH_DEBOUNCE", "0")
+        monkeypatch.setenv("REMARKABLE_SSH_SHUTDOWN_TIMEOUT", "1")
+        client = SSHClient()
+        document = Document(id="cached", hash="", name="Cached", doc_type="DocumentType")
+        client._documents = [document]
+        client._documents_by_id = {document.id: document}
+        client._metadata_loaded_all = True
+        client._file_type_cache = {document.id: "pdf"}
+        return client
+
+    @pytest.mark.asyncio
+    async def test_aclose_cancels_before_marker_without_refresh(self, monkeypatch):
+        import remarkable_mcp.ssh as ssh_mod
+        from remarkable_mcp.ssh_reliability import SSHJobCancelled
+
+        client = self._cached_client(monkeypatch)
+        process = self.Process(b"")
+        with (
+            patch.object(ssh_mod.subprocess, "Popen", return_value=process),
+            patch("remarkable_mcp.write_tools._restart_xochitl") as restart,
+        ):
+            task = await self._start_write(client, process)
+            await client.aclose()
+            with pytest.raises(SSHJobCancelled, match="before remote execution"):
+                await task
+            restart.assert_not_called()
+
+        assert client._metadata_loaded_all is True
+        assert client.reliability_status()["refresh"]["refreshes"] == 0
+
+    @pytest.mark.asyncio
+    async def test_aclose_refreshes_once_after_marker_and_invalidates_cache(self, monkeypatch):
+        import remarkable_mcp.api as api
+        import remarkable_mcp.ssh as ssh_mod
+        from remarkable_mcp.ssh_reliability import SSHExecutionUnknownError
+
+        client = self._cached_client(monkeypatch)
+        marker = ssh_mod._REMOTE_EXECUTION_MARKER
+        process = self.Process(marker + b"\n")
+        with (
+            patch.object(ssh_mod.subprocess, "Popen", return_value=process),
+            patch("remarkable_mcp.write_tools._restart_xochitl") as restart,
+            patch.object(api, "_device_client", client),
+        ):
+            task = await self._start_write(client, process)
+            await api.close_device_client()
+            assert api._device_client is None
+            with pytest.raises(SSHExecutionUnknownError, match="was not retried"):
+                await task
+            restart.assert_called_once_with(client, wait_ready=False)
+            await client.aclose()
+            restart.assert_called_once()
+
+        assert client._documents == []
+        assert client._documents_by_id == {}
+        assert client._metadata_loaded_all is False
+        assert client._file_type_cache is None
+        status = client.reliability_status()["refresh"]
+        assert status["refreshes"] == 1
+        assert status["deferred_dirty"] is False
+
+    @pytest.mark.asyncio
+    async def test_close_requires_later_refresh_after_marker(self, monkeypatch):
+        import asyncio
+
+        import remarkable_mcp.ssh as ssh_mod
+        from remarkable_mcp.operation_queue import OperationQueueClosed
+
+        client = self._cached_client(monkeypatch)
+        process = self.Process(ssh_mod._REMOTE_EXECUTION_MARKER + b"\n")
+        with (
+            patch.object(ssh_mod.subprocess, "Popen", return_value=process),
+            patch("remarkable_mcp.write_tools._restart_xochitl") as restart,
+        ):
+            task = await self._start_write(client, process)
+            await asyncio.to_thread(client.close)
+            with pytest.raises(OperationQueueClosed):
+                await task
+            restart.assert_not_called()
+
+        assert client._metadata_loaded_all is False
+        assert client.reliability_status()["refresh"]["deferred_dirty"] is True
+
+    @pytest.mark.asyncio
+    async def test_aclose_retains_dirty_state_when_refresh_fails(self, monkeypatch):
+        import remarkable_mcp.ssh as ssh_mod
+
+        client = self._cached_client(monkeypatch)
+        process = self.Process(ssh_mod._REMOTE_EXECUTION_MARKER + b"\n")
+        with (
+            patch.object(ssh_mod.subprocess, "Popen", return_value=process),
+            patch(
+                "remarkable_mcp.write_tools._restart_xochitl",
+                side_effect=RuntimeError("refresh disconnected"),
+            ) as restart,
+        ):
+            task = await self._start_write(client, process)
+            await client.aclose()
+            with pytest.raises(RuntimeError, match="refresh disconnected"):
+                await task
+            restart.assert_called_once_with(client, wait_ready=False)
+
+        assert client._metadata_loaded_all is False
+        status = client.reliability_status()["refresh"]
+        assert status["refreshes"] == 0
+        assert status["deferred_dirty"] is True
+
+    @pytest.mark.asyncio
+    async def test_task_cancellation_stays_cancelled_after_safety_refresh(self, monkeypatch):
+        import asyncio
+
+        import remarkable_mcp.ssh as ssh_mod
+
+        client = self._cached_client(monkeypatch)
+        process = self.Process(ssh_mod._REMOTE_EXECUTION_MARKER + b"\n")
+        try:
+            with (
+                patch.object(ssh_mod.subprocess, "Popen", return_value=process),
+                patch("remarkable_mcp.write_tools._restart_xochitl") as restart,
+            ):
+                task = await self._start_write(client, process)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                restart.assert_called_once_with(client, wait_ready=True)
+        finally:
+            await client.aclose()
+
+        assert client._metadata_loaded_all is False
+        assert client.reliability_status()["refresh"]["refreshes"] == 1
+
+    @pytest.mark.asyncio
+    async def test_task_cancellation_before_marker_does_not_refresh(self, monkeypatch):
+        import asyncio
+
+        import remarkable_mcp.ssh as ssh_mod
+
+        client = self._cached_client(monkeypatch)
+        process = self.Process(b"")
+        try:
+            with (
+                patch.object(ssh_mod.subprocess, "Popen", return_value=process),
+                patch("remarkable_mcp.write_tools._restart_xochitl") as restart,
+            ):
+                task = await self._start_write(client, process)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                restart.assert_not_called()
+        finally:
+            await client.aclose()
+
+        assert client._metadata_loaded_all is True
+        assert client.reliability_status()["refresh"]["refreshes"] == 0
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_does_not_replace_task_cancellation(self, monkeypatch):
+        import asyncio
+
+        from remarkable_mcp.write_tools import _refresh_ssh_client
+
+        client = self._cached_client(monkeypatch)
+        refresh_started = threading.Event()
+        release_refresh = threading.Event()
+
+        def failed_refresh(*args, **kwargs):
+            refresh_started.set()
+            assert release_refresh.wait(1)
+            raise RuntimeError("refresh disconnected")
+
+        try:
+            with patch(
+                "remarkable_mcp.write_tools._restart_xochitl",
+                side_effect=failed_refresh,
+            ) as restart:
+                task = asyncio.create_task(
+                    client._refresh_coordinator.run_write(
+                        lambda: client.run_operation_async("write", lambda: "saved"),
+                        lambda: _refresh_ssh_client(client),
+                        deferred=False,
+                        persisted=lambda result: result == "saved",
+                    )
+                )
+                assert await asyncio.to_thread(refresh_started.wait, 1)
+                task.cancel()
+                release_refresh.set()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                restart.assert_called_once_with(client, wait_ready=True)
+        finally:
+            release_refresh.set()
+            await client.aclose()
+
+        assert client._metadata_loaded_all is False
+        assert client.reliability_status()["refresh"]["deferred_dirty"] is True
+
+    @pytest.mark.asyncio
+    async def test_aclose_preserves_cancellation_until_cleanup_finishes(self, monkeypatch):
+        import asyncio
+
+        client = self._cached_client(monkeypatch)
+        refresh_started = asyncio.Event()
+        release_refresh = asyncio.Event()
+
+        async def refresh():
+            refresh_started.set()
+            await release_refresh.wait()
+
+        refresh_task = asyncio.create_task(client._refresh_coordinator.refresh_explicit(refresh))
+        await refresh_started.wait()
+        close_task = asyncio.create_task(client.aclose())
+        await asyncio.sleep(0)
+        close_task.cancel()
+        await asyncio.sleep(0)
+        assert close_task.done() is False
+
+        release_refresh.set()
+        await refresh_task
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+        status = client.reliability_status()
+        assert status["operations"]["stopping"] is True
+        assert status["refresh"]["refreshes"] == 1
 
 
 async def _async_value(value):
@@ -6968,7 +7367,7 @@ class TestDeferRestart:
             payloads = [json.loads(result.content[0].text) for result in results]
             assert [payload["created"] for payload in payloads] == [True, True]
             assert all(payload["refresh_pending"] is False for payload in payloads)
-            mock_restart.assert_called_once_with(client)
+            mock_restart.assert_called_once_with(client, wait_ready=True)
         finally:
             client.close()
             self._cleanup_tools()
@@ -7002,7 +7401,7 @@ class TestDeferRestart:
             data = json.loads(result.content[0].text)
             assert data["_error"]["type"] == "write_execution_unknown"
             mock_upload.assert_called_once()
-            mock_restart.assert_called_once_with(client)
+            mock_restart.assert_called_once_with(client, wait_ready=True)
         finally:
             client.close()
             self._cleanup_tools()


### PR DESCRIPTION
## Summary

- classify close-triggered SSH cancellation after the remote marker as execution-unknown without replaying the write
- drain all live refresh generations before stopping dispatcher workers, while keeping queued and pre-marker cancellation clean
- preserve `asyncio.CancelledError` across Python 3.10-3.12 and retain pending recovery when a shutdown refresh fails
- add deterministic coverage for queued, pre-marker, post-marker, close/aclose, refresh success/failure, cache invalidation, and refresh coalescing

## Validation

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 30 files formatted
- `uv run pytest -v` — 375 passed, 10 skipped
- Python 3.10 focused reliability matrix — 31 passed
- Python 3.12 focused reliability matrix — 31 passed
- `uv build` — source distribution and wheel built successfully
- connected Paper Pro probe — authenticated with 400 documents and writes enabled, but SSH was unavailable and the client fell back to cloud; no live mutation was attempted because it would not exercise this SSH shutdown path

Fixes #169