### PR TITLE
fix(smoke): clean USB uploads by visible name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Start with the first mode that fits your setup.
 
 | Order | Mode | Setup | Writes | Use when |
 |---:|---|---|---|---|
-| 1 | USB web | Connect the tablet and enable USB web | Upload to root | You want the shortest setup without a subscription or developer mode |
+| 1 | USB web | Connect the tablet and enable USB web | Upload; destination chosen by tablet | You want the shortest setup without a subscription or developer mode |
 | 2 | Local directory | Install and sign in to the desktop app | No | You want offline, device-free reads from the desktop cache |
 | 3 | Cloud | Register once; Connect subscription required | Full document and folder management | You need wireless or remote access |
 | 4 | SSH | Enable developer mode and configure SSH | Full management and native authoring | You need direct filesystem access or native ink writes |
@@ -272,7 +272,8 @@ AI assistants use the tools to read documents, search content, and more:
 ## Connection Modes
 
 All modes support reading and rendering. Cloud and SSH support full library
-management. USB web supports upload to the root folder. Local directory mode is
+management. USB web supports upload but does not accept a destination folder.
+Local directory mode is
 read-only.
 
 | Mode | Setup | Subscription | Offline | Tablet required | Raw source | Upload | Folder operations¹ |
@@ -594,7 +595,7 @@ Write tools let you upload, organize, and manage documents on your reMarkable. *
 
 | Feature | Local Directory | Cloud Mode | SSH Mode | USB Web Mode |
 |---------|:---------------:|:----------:|:--------:|:------------:|
-| Upload | ❌ | ✅ | ✅ | ✅ (to root) |
+| Upload | ❌ | ✅ | ✅ | ✅ (tablet-selected folder) |
 | Mkdir | ❌ | ✅ | ✅ | ❌ |
 | Move | ❌ | ✅ | ✅ | ❌ |
 | Rename | ❌ | ✅ | ✅ | ❌ |
@@ -642,7 +643,7 @@ Or set the environment variable:
 
 | Tool | Description |
 |------|-------------|
-| `remarkable_upload(file_path, parent_folder, document_name, defer_restart)` | Upload a PDF or EPUB file (cloud, SSH, and USB web; USB web uses the requested name but uploads to root) |
+| `remarkable_upload(file_path, parent_folder, document_name, defer_restart)` | Upload a PDF or EPUB file (cloud, SSH, and USB web; USB web preserves the name but ignores `parent_folder`) |
 | `remarkable_markdown_to_pdf(markdown, document_name, parent_folder, defer_restart)` | Render Markdown as a paginated PDF and upload it (cloud, SSH, and USB web) |
 | `remarkable_mkdir(folder_name, parent, defer_restart)` | Create a new folder (cloud and SSH) |
 | `remarkable_move(document, dest_folder, defer_restart)` | Move a document or folder (cloud and SSH) |

--- a/docs/usb-web-setup.md
+++ b/docs/usb-web-setup.md
@@ -1,6 +1,8 @@
 # USB Web Interface Setup Guide
 
-The USB web interface provides read, render, and root-folder upload over USB.
+The USB web interface provides read, render, and upload over USB. Its upload
+endpoint preserves the filename but has no destination-folder parameter; the
+tablet web service chooses the folder.
 
 ## Overview
 

--- a/remarkable_mcp/write_tools.py
+++ b/remarkable_mcp/write_tools.py
@@ -1375,8 +1375,9 @@ def register_write_tools():
         are supported. Works in all three transports:
         - Cloud: uploaded via the sync protocol; supports parent_folder + document_name
         - SSH: transferred over SSH, metadata created; supports parent_folder + document_name
-        - USB web: uploaded via POST /upload; lands at the root (the multipart
-          filename carries document_name because the endpoint has no rename field)
+        - USB web: uploaded via POST /upload. The multipart filename carries
+          document_name, parent_folder is ignored, and the tablet web service
+          chooses the destination folder.
 
         Requires write mode (the default; disabled with --read-only).
         </instructions>
@@ -1477,8 +1478,9 @@ def register_write_tools():
                     }
                     if parent_folder != "/":
                         result["note"] = (
-                            "USB web upload places files at root. "
-                            "Use SSH mode for folder placement."
+                            "USB web ignores parent_folder. The tablet web "
+                            "service chooses the destination folder. Use SSH or "
+                            "cloud mode for explicit folder placement."
                         )
                     return make_response(
                         result,
@@ -1615,15 +1617,16 @@ def register_write_tools():
         Works in all three transports:
         - Cloud: sync upload with parent_folder and document_name
         - SSH: filesystem upload with parent_folder and document_name
-        - USB web: root upload whose multipart filename is document_name + ".pdf"
+        - USB web: upload whose multipart filename is document_name + ".pdf";
+          parent_folder is ignored and the tablet web service chooses the folder.
 
         Requires write mode (the default; disabled with --read-only).
         </instructions>
         <parameters>
         - markdown: Markdown source text. Must not be empty.
         - document_name: Display name on the tablet (default: "Markdown").
-        - parent_folder: Destination folder (default: root "/"). USB web always
-          uploads to root because its firmware has no folder parameter.
+        - parent_folder: Destination folder (default: root "/"). USB web ignores
+          this parameter because its upload endpoint has no folder argument.
         - defer_restart: SSH only. When True, skip the xochitl restart and call
           remarkable_refresh() once after the batch. Forwarded exactly like
           remarkable_upload; ignored in cloud and USB web modes.

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -58,8 +58,9 @@ tool visibility changes.
 | `remarkable_mkdir` / `rename` / `move` / `delete` | **N/A** | PASS | **N/A** | PASS |
 | `remarkable_author` | **N/A** | **N/A** | **N/A** | PASS |
 
-USB web is read + render + upload-to-root only — the device firmware HTTP server
-exposes no folder/move/rename/delete endpoints, so those tools are not registered
+USB web is read + render + upload only. It preserves the uploaded filename but
+does not accept a destination-folder parameter; the tablet web service chooses
+the folder. Its HTTP API exposes no folder/move/rename/delete endpoints, so those tools are not registered
 in that mode (shown as N/A). Local directory mode is strictly read-only (the
 folder is the desktop app's private sync cache), so no write tool registers
 there. `remarkable_author` requires native `.rm` write-back and is SSH-only
@@ -77,23 +78,23 @@ safe and non-flaky: the cloud client invalidates its in-memory document cache on
 every root commit and blobs are content-addressed (immutable), so there is no
 eventual-consistency window to wait on within a session.
 
-USB-web uploads land at the device root with the requested name ignored, so they
-can't be reliably re-targeted for read-back and are **not** round-tripped (the
-upload row still PASSes on a successful upload call).
+USB-web uploads preserve the multipart filename but ignore `parent_folder`.
+Because the destination folder is chosen by the tablet web service, the upload
+is not round-tripped in USB mode. A later SSH phase resolves the unique filename
+for cleanup.
 
 ## Caveats
 
-- **USB upload leaves a file at the device root.** The USB web interface ignores
-  the requested name/folder and has no delete endpoint, so a full (non-`--read-only`)
-  USB run leaves one clearly-named `smoke-usb-<ts>-…` document on the tablet. If
-  SSH is also available in the same run it is swept automatically; otherwise delete
-  it from the tablet by hand. Use `--read-only` to avoid it entirely.
+- **USB upload can leave a file behind.** USB web has no delete endpoint. If SSH
+  is available in the same run, the harness removes the timestamped filename
+  automatically. Otherwise delete it from the tablet by hand, or use
+  `--read-only`.
 - **SSH requires working key auth.** With `--ssh`/`--usb` the harness disables the
   cloud startup fallback (`REMARKABLE_DISABLE_CLOUD_FALLBACK=1`) so a dead device
   can't silently "pass" via cloud. If SSH key auth isn't set up, the SSH mode waits
   for its connect timeout and is then reported as unavailable.
-- Writes are confined to a unique per-run folder and cleaned up afterwards
-  (cloud/SSH). The only exception is the USB-root upload noted above.
+- Cloud and SSH writes use unique per-run folders and are cleaned up. USB cleanup
+  uses the unique visible filename noted above.
 
   The SSH write phase also launches two folder writes concurrently with automatic
   refresh enabled. It requires both calls to pass and `remarkable_status` to

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -632,8 +632,9 @@ async def run_write_phase(session, mode, rec, registered):
 
     In managed modes (cloud/ssh) the upload is verified end-to-end: the fixture
     is read back and its known text confirmed, so upload PASS means the bytes are
-    actually retrievable. USB-web uploads land at the device root with the name
-    ignored, so they can't be reliably re-targeted and are not round-tripped.
+    actually retrievable. USB-web uploads preserve the multipart filename but
+    ignore parent_folder; the tablet web service chooses the destination folder.
+    They are cleaned up later by unique visible name when SSH is available.
     """
     is_ssh = MODES[mode]["transport"] == "ssh"
     managed = "remarkable_mkdir" in registered  # folder ops exposed -> cloud/ssh
@@ -642,8 +643,8 @@ async def run_write_phase(session, mode, rec, registered):
 
     created = []  # (kind, path) to clean up at the end, children before parents
 
-    # Unique per-run upload payload so the USB-web upload (which lands at root and
-    # ignores document_name) is identifiable for later SSH cleanup.
+    # The timestamped filename is preserved by USB web and is unique enough for
+    # later SSH cleanup regardless of which folder the tablet chooses.
     tmp_pdf = pathlib.Path(tempfile.gettempdir()) / f"{runid}-doc.pdf"
     shutil.copyfile(FIXTURE_PDF, tmp_pdf)
 
@@ -718,8 +719,8 @@ async def run_write_phase(session, mode, rec, registered):
             uploaded_path = f"{upload_parent.rstrip('/')}/{runid}-doc"
             if state == PASS and not managed:
                 note = (
-                    "uploaded to device root (USB web ignores name/folder); "
-                    "swept in the SSH phase if SSH is available this run"
+                    "uploaded with the fixture filename (USB web ignores "
+                    "parent_folder); swept by name in the SSH phase when available"
                 )
             elif state == PASS and managed:
                 # End-to-end check: read the just-uploaded fixture back and
@@ -738,7 +739,10 @@ async def run_write_phase(session, mode, rec, registered):
                 if managed:
                     created.append(("doc", uploaded_path))
                 else:
-                    rec.modes[mode].setdefault("usb_root_leftover", f"/{runid}-doc")
+                    rec.modes[mode].setdefault(
+                        "usb_upload_leftover",
+                        tmp_pdf.name,
+                    )
             elif managed and is_err is False and exc is None:
                 # Upload itself succeeded (only the read-back failed), so the doc
                 # still exists and must be cleaned up despite the FAIL verdict.
@@ -839,13 +843,14 @@ async def run_write_phase(session, mode, rec, registered):
 
         # --- delete (cleanup) -------------------------------------------
         if "remarkable_delete" in registered:
-            # Also sweep any USB-web leftover from an earlier usb phase this run.
+            # Also sweep any USB-web leftover from an earlier USB phase. The web
+            # service chooses its folder, so resolve the unique visible name.
             if is_ssh:
                 for data in rec.modes.values():
-                    leftover = data.get("usb_root_leftover")
+                    leftover = data.get("usb_upload_leftover")
                     if leftover:
                         created.append(("doc", leftover))
-                        data.pop("usb_root_leftover", None)
+                        data.pop("usb_upload_leftover", None)
 
             delete_states = []
             for _kind, path in created:


### PR DESCRIPTION
## Summary

- update the USB web contract to match current Paper Pro behavior: the filename is preserved, `parent_folder` is ignored, and the tablet web service chooses the destination folder
- clean smoke uploads by their unique visible filename instead of an invented extensionless root path
- remove stale root-only and ignored-name claims from user and smoke documentation

## Device evidence

A live full transport run uploaded `smoke-usb-1786742622-doc.pdf` into `/Stories/ws`. The old harness recorded `/smoke-usb-1786742622-doc`, so the later SSH cleanup could not resolve it. The exact leftover was removed by UUID after diagnosis.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` (419 passed, 10 skipped)

The subsequent live run could not exercise USB cleanup because USB web became unavailable after the earlier xochitl write/refresh sequence. That separate Paper Pro recovery failure is tracked in reopened #157.