### PR TITLE
feat(export): add single-document PDF and Markdown export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ OpenWebUI, and other compatible tools.
 - Search names, tags, and extracted text.
 - Read typed text, PDF and EPUB text, highlights, and annotations.
 - Render notebooks and annotated PDFs as PNG or SVG.
+- Export one document as a complete PDF or sectioned Markdown resource.
 - Run handwriting OCR through Google Vision or Tesseract.
 - Upload files and manage folders in supported transports.
 - Render Markdown as PDF and upload it to the tablet.
@@ -271,7 +272,7 @@ AI assistants use the tools to read documents, search content, and more:
 
 ## Connection Modes
 
-All modes support reading and rendering. Cloud and SSH support full library
+All modes support reading, rendering, and single-document export. Cloud and SSH support full library
 management. USB web supports upload but does not accept a destination folder.
 Local directory mode is
 read-only.
@@ -425,8 +426,12 @@ Or copy the `SKILL.md` from this repository into your `~/.openclaw/skills/remark
 | `remarkable_recent` | Get recently modified documents |
 | `remarkable_status` | Check connection status and the per-transport capability matrix |
 | `remarkable_image` | Get PNG/SVG images of pages with optional OCR |
+| `remarkable_export` | Export one document as a temporary PDF or Markdown resource |
 
-These six tools are read-only and return structured JSON with next-step hints.
+The read/search/render tools are read-only. `remarkable_export` never changes the
+tablet, but it writes a bounded temporary file on the MCP server host and therefore
+declares `readOnlyHint=false`. Export links expire after 15 minutes and the server
+retains at most eight at a time.
 Supported transports also register write tools by default; pass `--read-only` to
 disable them. See [Write Tools](#write-tools-by-transport). Clients that support
 [MCP Apps](#interactive-canvas-app-mcp-apps) can also open `remarkable_canvas`.
@@ -446,6 +451,9 @@ disable them. See [Write Tools](#write-tools-by-transport). Clients that support
   `total_pages: null` and `total_pages_known: false`.
 - PNG images of PDF-backed pages merge the source page and annotations
   automatically; pass `render_merged=False` for the annotation layer alone.
+- PDF exports preserve physical page order and merge mapped source underlays with
+  annotations by default. Markdown exports keep fixed source/typed/annotation/
+  highlight/OCR sections without guessing document structure.
 - OCR uses Google Vision when configured and otherwise runs locally with Tesseract.
 - Browse and search accept tag filters.
 
@@ -497,6 +505,15 @@ remarkable_image("Logo Sketch", background="#00000000")
 
 # Compatibility mode: return resource URI instead of embedded resource
 remarkable_image("Diagram", compatibility=True)
+
+# Export a complete PDF through a temporary MCP ResourceLink
+remarkable_export("Meeting Notes")
+
+# Export honest, sectioned Markdown with opt-in OCR
+remarkable_export("Journal", output_format="markdown", include_ocr=True)
+
+# Export only full-page annotation layers when archive data is available
+remarkable_export("Research Paper", pdf_mode="annotations")
 ```
 
 > **Note:** PNG rendering uses PyMuPDF for both notebook SVGs and PDF pages, so
@@ -518,9 +535,15 @@ Documents are automatically registered as MCP resources:
 | `remarkableraw:///{path}.epub.txt` | Extracted text from the original EPUB |
 | `remarkableimg:///{path}.page-{N}.png` | PNG image of page N (notebooks only) |
 | `remarkablesvg:///{path}.page-{N}.svg` | SVG vector image of page N (notebooks only) |
+| `remarkableexport:///{format}/{id}` | Temporary generated PDF or Markdown export |
 
 Trashed documents are excluded from tool, canvas, and resource lookup, so a
 trashed item cannot shadow a live document with the same name.
+
+`remarkable_export` returns a `ResourceLink` instead of embedding potentially
+large file content in the tool response. The server stores the file in a private
+temporary directory for 15 minutes, retains at most eight exports, and removes
+managed exports at shutdown. Fetch and save the linked resource for durable use.
 
 [Full resources reference](docs/resources.md)
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -84,6 +84,12 @@ The `io.modelcontextprotocol/ui` extension controls whether a client renders the
 `ui://remarkable/canvas` HTML resource; clients without it still receive the
 image.
 
+`remarkable_export` uses `ResourceLink` instead of `EmbeddedResource`, keeping
+potentially large PDF/Markdown bytes out of the tool result. The linked
+`remarkableexport:///` resource is supported unchanged by both modern and legacy
+SDK2 protocol modes. It is process-local, expires after 15 minutes, and is removed
+on LRU eviction or server shutdown.
+
 ## Authentication and process state
 
 MCP HTTP authorization headers are not used to select a reMarkable account or

--- a/docs/future-plans.md
+++ b/docs/future-plans.md
@@ -17,8 +17,8 @@ See [#118](https://github.com/SamMorrowDrums/remarkable-mcp/issues/118).
 
 ### Export
 
-Provide reusable PDF and Markdown export for one document, then add folder and
-filter batching. See
+Reusable PDF and Markdown export for one document is available through
+`remarkable_export`. Reuse that primitive for folder and filter batching next. See
 [#27](https://github.com/SamMorrowDrums/remarkable-mcp/issues/27).
 
 ## Search and OCR

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -10,6 +10,7 @@ Documents in your reMarkable library are automatically registered as MCP resourc
 | `remarkableraw:///` | Original PDF/EPUB text | All modes (USB web: PDF) |
 | `remarkableimg:///` | PNG page images (notebooks) | All modes |
 | `remarkablesvg:///` | SVG page images (notebooks) | All modes |
+| `remarkableexport:///` | Temporary generated PDF/Markdown exports | All modes |
 
 ## Text Resources (`remarkable:///`)
 
@@ -138,6 +139,30 @@ remarkablesvg:///Sketches/Logo.page-2.svg
 - For PDFs/EPUBs, the annotation layer would be rendered (not the underlying document)
 - Use the `remarkable_image` tool for more control (custom backgrounds, transparent output)
 
+## Export Resources (`remarkableexport:///`)
+
+`remarkable_export` creates one PDF or Markdown artifact and returns it as an MCP
+`ResourceLink`. Separate resource templates retain the correct content type:
+
+```
+remarkableexport:///pdf/{opaque-export-id}
+remarkableexport:///markdown/{opaque-export-id}
+```
+
+The tool response contains metadata, size, completeness, expiry, and the link, but
+not embedded/base64 file data. Reading the PDF resource returns binary PDF content;
+reading the Markdown resource returns UTF-8 `text/markdown`.
+
+Export resources are intentionally ephemeral:
+
+- stored under a server-managed private temporary directory;
+- readable for 15 minutes after creation;
+- limited to the eight most recently used exports;
+- removed on expiry/eviction and at server shutdown.
+
+They are generated from tablet data but never written back to the tablet. Fetch and
+save a resource if it needs to outlive the server-managed lifecycle.
+
 ## How Resources Are Registered
 
 On server startup, remarkable-mcp:
@@ -146,6 +171,7 @@ On server startup, remarkable-mcp:
 2. Fetches the document list
 3. Registers each document as an MCP resource
 4. Registers raw resources when source files are available
+5. Registers PDF/Markdown export templates (artifacts are created only on demand)
 
 Resources are registered once at startup. If you add new documents, restart the MCP server to pick them up.
 
@@ -171,6 +197,9 @@ content = await client.read_resource("remarkable:///Meeting%20Notes.txt")
 
 # Request raw PDF text (original document only, no annotations)
 pdf_text = await client.read_resource("remarkableraw:///Paper.pdf.txt")
+
+# After remarkable_export returns a ResourceLink:
+exported_file = await client.read_resource(export_link.uri)
 ```
 
 ## Path Encoding
@@ -217,3 +246,4 @@ With this configuration:
 - Text extraction happens on-demand when a resource is accessed
 - Results are cached per session
 - SSH mode is significantly faster than Cloud for resource access
+- Export resources are bounded by the 15-minute/eight-entry lifecycle described above

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -13,8 +13,11 @@ This document describes the read and render tools. Write tools are listed in the
 | [`remarkable_recent`](#remarkable_recent) | Get recently modified documents |
 | [`remarkable_status`](#remarkable_status) | Check connection status |
 | [`remarkable_image`](#remarkable_image) | Get page images (PNG or SVG) |
+| [`remarkable_export`](#remarkable_export) | Export one document as PDF or Markdown |
 
-These tools are read-only and return structured JSON with next-step hints.
+These tools never modify tablet content and return structured next-step hints.
+`remarkable_export` additionally creates a bounded temporary file on the MCP server
+host, so its MCP annotation is `readOnlyHint=false` even under tablet read-only mode.
 
 ## Root Path Filtering
 
@@ -330,7 +333,7 @@ remarkable_status()
 | `connection` | Connection details |
 | `document_count` | Total documents in library (filtered by root if configured) |
 | `write_enabled` | Whether write tools are enabled (the default; `false` only with `--read-only`) |
-| `capabilities` | Effective capabilities for the active transport (read/render/upload/mkdir/move/rename/delete) |
+| `capabilities` | Effective capabilities for the active transport (read/render/export/upload/mkdir/move/rename/delete) |
 | `capabilities_by_transport` | The full per-transport capability matrix |
 | `root_path` | Configured root path filter (only present if set) |
 | `ocr_backend` | Which OCR backend is configured |
@@ -430,6 +433,105 @@ used when configured; otherwise OCR runs locally with Tesseract.
   that export. SVG and explicit `render_merged=False` require the unavailable
   rmdoc annotation layer and return clear errors.
 - RGBA colors (8-digit hex) allow transparency control
+
+---
+
+## remarkable_export
+
+**Export one document as a reusable PDF or Markdown resource.**
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `document` | string | *required* | Document name or full path |
+| `output_format` | `"pdf"` \| `"markdown"` | `"pdf"` | Export format |
+| `pdf_mode` | `"merged"` \| `"annotations"` | `"merged"` | PDF-only rendering mode |
+| `include_ocr` | bool | `False` | Run the existing OCR path for Markdown |
+
+### Delivery and lifecycle
+
+The tool returns a small JSON summary plus an MCP `ResourceLink`. It does not
+embed PDF/Markdown bytes in the tool response and does not accept or invent a host
+output path. The server writes the generated file beneath a private temporary
+directory:
+
+- links expire 15 minutes after creation;
+- at most eight exports are retained, with least-recently-used eviction;
+- expired and evicted links stop resolving;
+- all managed exports are removed at server shutdown.
+
+This local temporary write is why the tool declares `readOnlyHint=false`.
+The reMarkable tablet and library are never modified, and the tool remains
+available when the server runs with `--read-only`.
+
+### PDF behavior
+
+- Physical page order comes from reMarkable `.content` metadata.
+- `pdf_mode="merged"` combines mapped PDF underlays and annotations by default.
+- Native notebooks use complete full-page ink/blank renders.
+- `pdf_mode="annotations"` returns complete annotation layers only.
+- A flattened native PDF (older USB firmware) remains exportable in merged mode,
+  but cannot be separated into annotation-only layers.
+- A page render failure is represented by a labeled placeholder at the same page
+  ordinal and reported with `status: "partial"`; pages are never silently skipped.
+- EPUB source pages use a transport-native PDF when one is available. Otherwise
+  available annotation pages are exported with an explicit partial warning.
+
+### Markdown behavior
+
+Markdown starts with basic front matter containing the stable reMarkable document
+UUID, title, path, source type, physical page count, modified time, tags, and
+completeness. It then uses fixed sections:
+
+1. Source text
+2. Typed text
+3. Annotations
+4. Highlights
+5. OCR
+6. Export notes (only for partial exports)
+
+Extracted text is emitted verbatim. The exporter does not claim to detect headings,
+lists, paragraphs, links, or physical-page attribution that the existing extraction
+result cannot prove. OCR is opt-in and uses the same configured backend and cache as
+`remarkable_read`.
+
+### Examples
+
+```python
+# Complete PDF (source underlay + annotations where available)
+remarkable_export("Meeting Notes")
+
+# Full-page annotation layers only
+remarkable_export("Research Paper", pdf_mode="annotations")
+
+# Markdown with handwriting OCR
+remarkable_export("Journal", output_format="markdown", include_ocr=True)
+```
+
+### Response
+
+```json
+{
+  "document": "Meeting Notes",
+  "document_id": "11111111-2222-3333-4444-555555555555",
+  "path": "/Work/Meeting Notes",
+  "format": "pdf",
+  "filename": "Meeting Notes.pdf",
+  "size": 481203,
+  "pages": 7,
+  "status": "complete",
+  "failed_pages": [],
+  "warnings": [],
+  "resource_uri": "remarkableexport:///pdf/opaque-resource-id",
+  "expires_at": "2026-08-14T22:15:00+00:00",
+  "temporary_local_file": true,
+  "_hint": "Temporary PDF export ready as an MCP resource..."
+}
+```
+
+Fetch and save the accompanying `ResourceLink` before it expires when durable
+storage is required.
 
 ---
 

--- a/remarkable_mcp/export_resources.py
+++ b/remarkable_mcp/export_resources.py
@@ -76,6 +76,7 @@ class ExportResourceStore:
         self._configured_root = root
         self._temporary_directory: TemporaryDirectory[str] | None = None
         self._records: OrderedDict[str, _ExportRecord] = OrderedDict()
+        self._deferred_cleanup: set[Path] = set()
         self._clock = monotonic_clock
         self._utcnow = utcnow or (lambda: datetime.now(timezone.utc))
         self._lock = threading.RLock()
@@ -103,15 +104,38 @@ class ExportResourceStore:
             leaf = stem.rstrip() + suffix
         return leaf
 
-    @staticmethod
-    def _remove_record(record: _ExportRecord) -> None:
-        record.path.unlink(missing_ok=True)
+    def _remove_record(self, record: _ExportRecord) -> None:
+        try:
+            record.path.unlink(missing_ok=True)
+        except OSError:
+            # Windows cannot unlink a file while another thread has it open.
+            # Eviction must still succeed; retry this path on a later prune or
+            # during shutdown cleanup.
+            self._deferred_cleanup.add(record.path)
+            return
         try:
             record.path.parent.rmdir()
-        except OSError:
+        except FileNotFoundError:
             pass
+        except OSError:
+            self._deferred_cleanup.add(record.path)
+
+    def _retry_deferred_cleanup_locked(self) -> None:
+        for path in tuple(self._deferred_cleanup):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                continue
+            try:
+                path.parent.rmdir()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                continue
+            self._deferred_cleanup.discard(path)
 
     def _prune_locked(self, now: float, *, reserve_slot: bool = False) -> None:
+        self._retry_deferred_cleanup_locked()
         expired = [
             export_id
             for export_id, record in self._records.items()
@@ -173,7 +197,10 @@ class ExportResourceStore:
                 self._records[export_id] = record
             return PublishedExport(resource=resource, result=result)
         except Exception:
-            path.unlink(missing_ok=True)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
             try:
                 export_dir.rmdir()
             except OSError:
@@ -209,9 +236,15 @@ class ExportResourceStore:
             for record in self._records.values():
                 self._remove_record(record)
             self._records.clear()
+            self._retry_deferred_cleanup_locked()
             if self._temporary_directory is not None:
-                self._temporary_directory.cleanup()
-                self._temporary_directory = None
+                try:
+                    self._temporary_directory.cleanup()
+                except OSError:
+                    pass
+                else:
+                    self._temporary_directory = None
+                    self._deferred_cleanup.clear()
 
 
 export_store = ExportResourceStore()

--- a/remarkable_mcp/export_resources.py
+++ b/remarkable_mcp/export_resources.py
@@ -1,0 +1,241 @@
+"""Bounded temporary resources for locally generated exports."""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Callable, Generic, Literal, TypeVar
+from uuid import uuid4
+
+ExportFormat = Literal["pdf", "markdown"]
+T = TypeVar("T")
+
+EXPORT_TTL_SECONDS = 15 * 60
+EXPORT_MAX_ENTRIES = 8
+
+_FORMAT_DETAILS: dict[ExportFormat, tuple[str, str]] = {
+    "pdf": (".pdf", "application/pdf"),
+    "markdown": (".md", "text/markdown; charset=utf-8"),
+}
+
+
+@dataclass(frozen=True)
+class ExportResource:
+    """Public metadata for a temporary export resource."""
+
+    export_id: str
+    filename: str
+    output_format: ExportFormat
+    mime_type: str
+    size: int
+    uri: str
+    created_at: datetime
+    expires_at: datetime
+
+
+@dataclass
+class _ExportRecord:
+    resource: ExportResource
+    path: Path
+    expires_monotonic: float
+
+
+@dataclass(frozen=True)
+class PublishedExport(Generic[T]):
+    """A published resource and the exporter-specific build result."""
+
+    resource: ExportResource
+    result: T
+
+
+class ExportResourceStore:
+    """Store a bounded set of expiring export files under one private temp root."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int = EXPORT_TTL_SECONDS,
+        max_entries: int = EXPORT_MAX_ENTRIES,
+        root: Path | None = None,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        utcnow: Callable[[], datetime] | None = None,
+    ):
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+
+        self.ttl_seconds = ttl_seconds
+        self.max_entries = max_entries
+        self._configured_root = root
+        self._temporary_directory: TemporaryDirectory[str] | None = None
+        self._records: OrderedDict[str, _ExportRecord] = OrderedDict()
+        self._clock = monotonic_clock
+        self._utcnow = utcnow or (lambda: datetime.now(timezone.utc))
+        self._lock = threading.RLock()
+
+    def _root(self) -> Path:
+        if self._configured_root is not None:
+            self._configured_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            return self._configured_root
+        if self._temporary_directory is None:
+            self._temporary_directory = TemporaryDirectory(prefix="remarkable-mcp-export-")
+        return Path(self._temporary_directory.name)
+
+    @staticmethod
+    def _safe_filename(filename: str, output_format: ExportFormat) -> str:
+        suffix, _ = _FORMAT_DETAILS[output_format]
+        leaf = Path(filename).name.strip().strip(".")
+        leaf = re.sub(r"[^\w .-]+", "_", leaf, flags=re.UNICODE)
+        leaf = re.sub(r"\s+", " ", leaf).strip()
+        if not leaf:
+            leaf = "remarkable-export"
+        if not leaf.lower().endswith(suffix):
+            leaf += suffix
+        if len(leaf) > 160:
+            stem = Path(leaf).stem[: 160 - len(suffix)]
+            leaf = stem.rstrip() + suffix
+        return leaf
+
+    @staticmethod
+    def _remove_record(record: _ExportRecord) -> None:
+        record.path.unlink(missing_ok=True)
+        try:
+            record.path.parent.rmdir()
+        except OSError:
+            pass
+
+    def _prune_locked(self, now: float, *, reserve_slot: bool = False) -> None:
+        expired = [
+            export_id
+            for export_id, record in self._records.items()
+            if now >= record.expires_monotonic
+        ]
+        for export_id in expired:
+            record = self._records.pop(export_id)
+            self._remove_record(record)
+
+        limit = self.max_entries - 1 if reserve_slot else self.max_entries
+        while len(self._records) > limit:
+            _, record = self._records.popitem(last=False)
+            self._remove_record(record)
+
+    def publish(
+        self,
+        *,
+        filename: str,
+        output_format: ExportFormat,
+        writer: Callable[[Path], T],
+    ) -> PublishedExport[T]:
+        """Build and publish one export, cleaning incomplete drafts on failure."""
+        safe_filename = self._safe_filename(filename, output_format)
+        export_id = uuid4().hex
+        with self._lock:
+            root = self._root()
+        export_dir = root / export_id
+        export_dir.mkdir(mode=0o700)
+        path = export_dir / safe_filename
+
+        try:
+            result = writer(path)
+            if not path.is_file():
+                raise RuntimeError("Exporter did not create the requested file")
+            size = path.stat().st_size
+            if size <= 0:
+                raise RuntimeError("Exporter created an empty file")
+
+            now_monotonic = self._clock()
+            created_at = self._utcnow()
+            _, mime_type = _FORMAT_DETAILS[output_format]
+            resource = ExportResource(
+                export_id=export_id,
+                filename=safe_filename,
+                output_format=output_format,
+                mime_type=mime_type,
+                size=size,
+                uri=f"remarkableexport:///{output_format}/{export_id}",
+                created_at=created_at,
+                expires_at=created_at + timedelta(seconds=self.ttl_seconds),
+            )
+            record = _ExportRecord(
+                resource=resource,
+                path=path,
+                expires_monotonic=now_monotonic + self.ttl_seconds,
+            )
+            with self._lock:
+                self._prune_locked(now_monotonic, reserve_slot=True)
+                self._records[export_id] = record
+            return PublishedExport(resource=resource, result=result)
+        except Exception:
+            path.unlink(missing_ok=True)
+            try:
+                export_dir.rmdir()
+            except OSError:
+                pass
+            raise
+
+    def read_bytes(self, export_id: str, output_format: ExportFormat) -> bytes:
+        """Read a live export and update its LRU position."""
+        now = self._clock()
+        with self._lock:
+            self._prune_locked(now)
+            record = self._records.get(export_id)
+            if record is None or record.resource.output_format != output_format:
+                raise FileNotFoundError("Temporary export was not found or has expired")
+            if not record.path.is_file():
+                self._records.pop(export_id, None)
+                raise FileNotFoundError("Temporary export file is no longer available")
+            self._records.move_to_end(export_id)
+            return record.path.read_bytes()
+
+    def read_text(self, export_id: str, output_format: ExportFormat) -> str:
+        """Read a UTF-8 text export."""
+        return self.read_bytes(export_id, output_format).decode("utf-8")
+
+    def cleanup(self) -> None:
+        """Remove every managed export and the private temporary directory."""
+        with self._lock:
+            for record in self._records.values():
+                self._remove_record(record)
+            self._records.clear()
+            if self._temporary_directory is not None:
+                self._temporary_directory.cleanup()
+                self._temporary_directory = None
+
+
+export_store = ExportResourceStore()
+
+from remarkable_mcp.server import mcp  # noqa: E402
+
+
+@mcp.resource(
+    "remarkableexport:///pdf/{export_id}",
+    name="Temporary reMarkable PDF export",
+    description="A generated PDF export. The link expires 15 minutes after creation.",
+    mime_type="application/pdf",
+)
+def temporary_pdf_export(export_id: str) -> bytes:
+    """Read a live PDF export from the bounded temporary store."""
+    return export_store.read_bytes(export_id, "pdf")
+
+
+@mcp.resource(
+    "remarkableexport:///markdown/{export_id}",
+    name="Temporary reMarkable Markdown export",
+    description="A generated Markdown export. The link expires 15 minutes after creation.",
+    mime_type="text/markdown; charset=utf-8",
+)
+def temporary_markdown_export(export_id: str) -> str:
+    """Read a live Markdown export from the bounded temporary store."""
+    return export_store.read_text(export_id, "markdown")
+
+
+def cleanup_export_resources() -> None:
+    """Clean process-local export artifacts during server shutdown."""
+    export_store.cleanup()

--- a/remarkable_mcp/export_resources.py
+++ b/remarkable_mcp/export_resources.py
@@ -188,11 +188,16 @@ class ExportResourceStore:
             record = self._records.get(export_id)
             if record is None or record.resource.output_format != output_format:
                 raise FileNotFoundError("Temporary export was not found or has expired")
-            if not record.path.is_file():
-                self._records.pop(export_id, None)
-                raise FileNotFoundError("Temporary export file is no longer available")
             self._records.move_to_end(export_id)
-            return record.path.read_bytes()
+            path = record.path
+
+        try:
+            return path.read_bytes()
+        except FileNotFoundError:
+            # Expiry/LRU cleanup may remove the captured path after the lock is
+            # released. Keep the same educational resource-level failure without
+            # serializing large file I/O behind the global store lock.
+            raise FileNotFoundError("Temporary export was not found or has expired") from None
 
     def read_text(self, export_id: str, output_format: ExportFormat) -> str:
         """Read a UTF-8 text export."""

--- a/remarkable_mcp/exporters.py
+++ b/remarkable_mcp/exporters.py
@@ -1,0 +1,460 @@
+"""Reusable PDF and Markdown exporters built on the existing render/extract paths."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Iterator, Literal, Optional
+
+import fitz
+from PIL import Image
+
+from remarkable_mcp.extract import (
+    _resolve_pdf_page_index,
+    render_merged_page_from_extracted_document,
+    render_page_full_page_from_extracted_document,
+)
+
+PdfMode = Literal["merged", "annotations"]
+ExportStatus = Literal["complete", "partial"]
+
+
+@dataclass(frozen=True)
+class ExportMetadata:
+    """Stable source metadata carried into every exported format."""
+
+    document_id: str
+    title: str
+    path: str
+    source_type: str
+    page_count: Optional[int]
+    modified: datetime | str | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RenderedPage:
+    """One physical page in export order."""
+
+    page: int
+    image: bytes | None
+    warning: str | None = None
+    error: str | None = None
+    partial: bool = False
+
+
+@dataclass(frozen=True)
+class ExportBuildResult:
+    """Outcome metadata returned alongside a generated file."""
+
+    status: ExportStatus
+    pages: int
+    failed_pages: tuple[int, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    ocr_backend: str | None = None
+
+
+def _unique_strings(values: Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = str(value).strip()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
+    return tuple(result)
+
+
+def _modified_text(modified: datetime | str | None) -> str | None:
+    if isinstance(modified, datetime):
+        return modified.isoformat()
+    if modified is None:
+        return None
+    value = str(modified).strip()
+    return value or None
+
+
+def _pdf_metadata(existing: dict, metadata: ExportMetadata) -> dict[str, str]:
+    result = {key: str(value or "") for key, value in existing.items()}
+    identity = (
+        f"reMarkable document ID: {metadata.document_id}; "
+        f"path: {metadata.path}; source type: {metadata.source_type}"
+    )
+    previous_subject = result.get("subject", "").strip()
+    result["subject"] = f"{previous_subject}\n{identity}".strip()
+    result["title"] = metadata.title
+
+    keywords = [part.strip() for part in result.get("keywords", "").split(",") if part.strip()]
+    keywords.extend(f"remarkable-document-id:{metadata.document_id}" for _ in range(1))
+    keywords.extend(metadata.tags)
+    result["keywords"] = ", ".join(_unique_strings(keywords))
+    result["producer"] = "remarkable-mcp (PyMuPDF)"
+    if not result.get("creator"):
+        result["creator"] = "remarkable-mcp"
+    return result
+
+
+def write_native_pdf_export(
+    pdf_bytes: bytes,
+    destination: Path,
+    metadata: ExportMetadata,
+) -> ExportBuildResult:
+    """Preserve an existing complete PDF while adding stable source metadata."""
+    if not pdf_bytes.lstrip().startswith(b"%PDF"):
+        raise ValueError("Native PDF export did not contain PDF data")
+
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as document:
+        page_count = len(document)
+        if page_count == 0:
+            raise ValueError("Native PDF export has no pages")
+        document.set_metadata(_pdf_metadata(document.metadata, metadata))
+        document.save(str(destination), garbage=3, deflate=True)
+
+    return ExportBuildResult(status="complete", pages=page_count)
+
+
+def _page_size(image_bytes: bytes) -> tuple[float, float]:
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        width, height = image.size
+    if width <= 0 or height <= 0:
+        raise ValueError("Rendered page has invalid dimensions")
+    # Existing merged rendering uses two pixels per PDF point. Applying the same
+    # scale keeps source-PDF exports at their original physical dimensions.
+    return max(1.0, width / 2), max(1.0, height / 2)
+
+
+def write_rendered_pdf_export(
+    destination: Path,
+    metadata: ExportMetadata,
+    pages: Iterable[RenderedPage],
+) -> ExportBuildResult:
+    """Assemble ordered rendered pages, retaining failed ordinals as placeholders."""
+    output = fitz.open()
+    failed_pages: list[int] = []
+    warnings: list[str] = []
+    expected_page = 1
+    previous_size = (445.0, 594.0)
+    partial = False
+
+    try:
+        for rendered in pages:
+            if rendered.page != expected_page:
+                raise ValueError(
+                    f"Rendered pages must be sequential: expected {expected_page}, "
+                    f"received {rendered.page}"
+                )
+            expected_page += 1
+
+            if rendered.warning:
+                warnings.append(f"Page {rendered.page}: {rendered.warning}")
+            partial = partial or rendered.partial
+
+            image_bytes = rendered.image
+            if image_bytes is not None:
+                try:
+                    previous_size = _page_size(image_bytes)
+                    page = output.new_page(width=previous_size[0], height=previous_size[1])
+                    page.insert_image(page.rect, stream=image_bytes)
+                    continue
+                except Exception as exc:
+                    rendered = RenderedPage(
+                        page=rendered.page,
+                        image=None,
+                        error=f"Rendered image could not be added to PDF: {exc}",
+                        partial=True,
+                    )
+
+            partial = True
+            failed_pages.append(rendered.page)
+            reason = rendered.error or "Page could not be rendered"
+            warnings.append(f"Page {rendered.page}: {reason}")
+            page = output.new_page(width=previous_size[0], height=previous_size[1])
+            message = (
+                f"reMarkable export placeholder\n\n"
+                f"Physical page {rendered.page} could not be rendered.\n\n{reason}"
+            )
+            margin = max(6.0, min(36.0, previous_size[0] * 0.08, previous_size[1] * 0.08))
+            font_size = max(6.0, min(12.0, previous_size[0] / 30))
+            remaining = page.insert_textbox(
+                fitz.Rect(
+                    margin,
+                    margin,
+                    previous_size[0] - margin,
+                    previous_size[1] - margin,
+                ),
+                message,
+                fontsize=font_size,
+                color=(0.65, 0.0, 0.0),
+            )
+            if remaining < 0:
+                page.insert_text(
+                    (margin, margin + font_size),
+                    message,
+                    fontsize=max(5.0, font_size / 2),
+                    color=(0.65, 0.0, 0.0),
+                )
+
+        page_count = len(output)
+        if page_count == 0:
+            raise ValueError("Document has no physical pages to export")
+        if metadata.page_count is not None and page_count != metadata.page_count:
+            raise ValueError(
+                f"Export produced {page_count} pages but metadata declares "
+                f"{metadata.page_count} physical pages"
+            )
+
+        output.set_metadata(_pdf_metadata({}, metadata))
+        output.save(str(destination), garbage=3, deflate=True)
+    finally:
+        output.close()
+
+    unique_warnings = _unique_strings(warnings)
+    return ExportBuildResult(
+        status="partial" if partial or failed_pages else "complete",
+        pages=page_count,
+        failed_pages=tuple(failed_pages),
+        warnings=unique_warnings,
+    )
+
+
+def render_archive_pages(
+    archive_path: Path,
+    metadata: ExportMetadata,
+    *,
+    pdf_mode: PdfMode = "merged",
+    background_color: str | None = None,
+) -> Iterator[RenderedPage]:
+    """Render every physical page from one archive extraction in device order."""
+    if metadata.page_count is None or metadata.page_count <= 0:
+        raise ValueError("Physical page count is unavailable")
+
+    with tempfile.TemporaryDirectory(prefix="remarkable-export-archive-") as tmpdir:
+        extracted = Path(tmpdir)
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            archive.extractall(extracted)
+
+        has_source_pdf = any(extracted.glob("**/*.pdf"))
+        for page_number in range(1, metadata.page_count + 1):
+            try:
+                if pdf_mode == "merged" and metadata.source_type == "pdf" and has_source_pdf:
+                    has_mapped_underlay = (
+                        _resolve_pdf_page_index(extracted, page_number) is not None
+                    )
+                    image, note = render_merged_page_from_extracted_document(
+                        extracted,
+                        page=page_number,
+                        background_color=background_color,
+                    )
+                    partial = image is None or bool(note and has_mapped_underlay)
+                    yield RenderedPage(
+                        page=page_number,
+                        image=image,
+                        warning=note if partial else None,
+                        error=None if image is not None else note,
+                        partial=partial,
+                    )
+                    continue
+
+                full_page = render_page_full_page_from_extracted_document(
+                    extracted,
+                    page=page_number,
+                    background_color=background_color,
+                )
+                warning = None
+                partial = False
+                if pdf_mode == "merged" and metadata.source_type in ("pdf", "epub"):
+                    warning = (
+                        f"{metadata.source_type.upper()} source underlay is unavailable; "
+                        "exported the full-page annotation layer."
+                    )
+                    partial = True
+                yield RenderedPage(
+                    page=page_number,
+                    image=full_page[0] if full_page is not None else None,
+                    warning=warning,
+                    error=None if full_page is not None else "Full-page annotation render failed",
+                    partial=partial,
+                )
+            except Exception as exc:
+                yield RenderedPage(
+                    page=page_number,
+                    image=None,
+                    error=f"Page render raised {type(exc).__name__}: {exc}",
+                    partial=True,
+                )
+
+
+def write_archive_pdf_export(
+    archive_path: Path,
+    destination: Path,
+    metadata: ExportMetadata,
+    *,
+    pdf_mode: PdfMode = "merged",
+    background_color: str | None = None,
+) -> ExportBuildResult:
+    """Render and assemble a PDF from a reMarkable document archive."""
+    return write_rendered_pdf_export(
+        destination,
+        metadata,
+        render_archive_pages(
+            archive_path,
+            metadata,
+            pdf_mode=pdf_mode,
+            background_color=background_color,
+        ),
+    )
+
+
+def _yaml_value(value: object) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _verbatim_block(text: str) -> list[str]:
+    longest = max((len(match) for match in re.findall(r"`+", text)), default=0)
+    fence = "`" * max(3, longest + 1)
+    return [f"{fence}text", text.rstrip(), fence]
+
+
+def _heading_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip() or "Untitled reMarkable document"
+
+
+def write_markdown_export(
+    destination: Path,
+    metadata: ExportMetadata,
+    *,
+    source_text: str | None,
+    extraction: dict | None,
+    include_ocr: bool,
+    warnings: Iterable[str] = (),
+) -> ExportBuildResult:
+    """Write an honest, sectioned Markdown representation of extracted content."""
+    content = extraction or {}
+    export_warnings = _unique_strings(warnings)
+    status: ExportStatus = "partial" if export_warnings else "complete"
+    modified = _modified_text(metadata.modified)
+
+    lines = [
+        "---",
+        f"title: {_yaml_value(metadata.title)}",
+        f"remarkable_document_id: {_yaml_value(metadata.document_id)}",
+        f"remarkable_path: {_yaml_value(metadata.path)}",
+        f"source_type: {_yaml_value(metadata.source_type)}",
+        f"physical_pages: {_yaml_value(metadata.page_count)}",
+        f"modified: {_yaml_value(modified)}",
+        f"export_status: {_yaml_value(status)}",
+    ]
+    if metadata.tags:
+        lines.append("tags:")
+        lines.extend(f"  - {_yaml_value(tag)}" for tag in metadata.tags)
+    else:
+        lines.append("tags: []")
+    lines.extend(["---", "", f"# {_heading_text(metadata.title)}", ""])
+
+    lines.extend(["## Source text", ""])
+    if source_text is None:
+        if metadata.source_type == "notebook":
+            lines.append("_Not applicable to a native notebook._")
+        else:
+            lines.append("_Source text was not available from this transport._")
+    elif source_text.strip():
+        lines.extend(_verbatim_block(source_text))
+    else:
+        lines.append("_No source text was extracted._")
+    lines.append("")
+
+    lines.extend(["## Typed text", ""])
+    typed_text = [str(value) for value in content.get("typed_text") or [] if str(value).strip()]
+    if typed_text:
+        for index, value in enumerate(typed_text, 1):
+            if len(typed_text) > 1:
+                lines.extend([f"### Typed excerpt {index}", ""])
+            lines.extend(_verbatim_block(value))
+            lines.append("")
+    else:
+        lines.extend(["_No typed text was extracted._", ""])
+
+    lines.extend(["## Annotations", ""])
+    annotated_pages = sorted(
+        content.get("annotated_pages") or [],
+        key=lambda entry: int(entry.get("page") or 0),
+    )
+    if annotated_pages:
+        for entry in annotated_pages:
+            marks: list[str] = []
+            if entry.get("has_handwriting"):
+                marks.append("handwriting")
+            highlight_count = len(entry.get("highlights") or [])
+            if highlight_count:
+                marks.append(f"{highlight_count} highlight" + ("s" if highlight_count != 1 else ""))
+            page_id = entry.get("page_id")
+            identity = f"; page ID `{page_id}`" if page_id else ""
+            lines.append(
+                f"- Physical page {entry.get('page')}{identity}: "
+                + (", ".join(marks) or "annotated")
+            )
+    else:
+        lines.append("_No annotated pages were identified._")
+    lines.append("")
+
+    lines.extend(["## Highlights", ""])
+    highlights = [str(value) for value in content.get("highlights") or [] if str(value).strip()]
+    if highlights:
+        for index, value in enumerate(highlights, 1):
+            lines.extend([f"### Highlight {index}", ""])
+            lines.extend(_verbatim_block(value))
+            lines.append("")
+    else:
+        lines.extend(["_No highlighted text was extracted._", ""])
+
+    lines.extend(["## OCR", ""])
+    ocr_backend = content.get("ocr_backend")
+    if include_ocr:
+        if ocr_backend:
+            lines.extend([f"Backend: `{ocr_backend}`", ""])
+        handwritten = [
+            str(value) for value in content.get("handwritten_text") or [] if str(value).strip()
+        ]
+        if handwritten:
+            lines.extend(
+                [
+                    "_OCR excerpts remain in extraction order. Sparse OCR results are "
+                    "not assigned to physical pages when the extractor cannot prove "
+                    "that mapping._",
+                    "",
+                ]
+            )
+            for index, value in enumerate(handwritten, 1):
+                lines.extend([f"### OCR excerpt {index}", ""])
+                lines.extend(_verbatim_block(value))
+                lines.append("")
+        else:
+            lines.extend(["_No OCR text was extracted._", ""])
+    else:
+        lines.extend(["_OCR was not requested for this export._", ""])
+
+    if export_warnings:
+        lines.extend(["## Export notes", ""])
+        lines.extend(f"- {warning}" for warning in export_warnings)
+        lines.append("")
+
+    destination.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    pages = metadata.page_count or int(content.get("pages") or 0)
+    return ExportBuildResult(
+        status=status,
+        pages=pages,
+        warnings=export_warnings,
+        ocr_backend=str(ocr_backend) if ocr_backend else None,
+    )

--- a/remarkable_mcp/exporters.py
+++ b/remarkable_mcp/exporters.py
@@ -157,12 +157,15 @@ def write_rendered_pdf_export(
 
             image_bytes = rendered.image
             if image_bytes is not None:
+                page_count_before = len(output)
                 try:
                     previous_size = _page_size(image_bytes)
                     page = output.new_page(width=previous_size[0], height=previous_size[1])
                     page.insert_image(page.rect, stream=image_bytes)
                     continue
                 except Exception as exc:
+                    while len(output) > page_count_before:
+                        output.delete_page(page_count_before)
                     rendered = RenderedPage(
                         page=rendered.page,
                         image=None,

--- a/remarkable_mcp/extract.py
+++ b/remarkable_mcp/extract.py
@@ -1400,35 +1400,46 @@ def render_page_full_page_from_document_zip(
         with zipfile.ZipFile(zip_path, "r") as zf:
             zf.extractall(tmpdir_path)
 
-        rm_files = _get_ordered_rm_files(tmpdir_path)
-        page_order = _get_page_order(tmpdir_path)
-
-        if page_order:
-            if page < 1 or page > len(page_order):
-                return None
-            rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
-        else:
-            # No page metadata: fall back to filesystem order of .rm files.
-            if page < 1 or page > len(rm_files):
-                return None
-            rm_file = rm_files[page - 1]
-
-        if rm_file is not None and rm_file.exists():
-            return render_rm_file_full_page_png(rm_file, background_color=background_color)
-
-        # The page exists in cPages but has no .rm layer yet (a blank page):
-        # render a blank full page at the document's paper size so the viewer
-        # still shows it. (The write tool will return no_page_layer until the
-        # page has a drawable layer / has been added via remarkable_add_page.)
-        paper_w, paper_h = _document_paper_size(rm_files)
-        svg = _svg_full_page([], paper_w, paper_h)
-        scale = FULL_PAGE_TARGET_LONG_EDGE / max(paper_w, paper_h)
-        png = _svg_string_to_png(
-            svg, max(1, round(paper_w * scale)), max(1, round(paper_h * scale)), background_color
+        return render_page_full_page_from_extracted_document(
+            tmpdir_path,
+            page=page,
+            background_color=background_color,
         )
-        if png is None:
+
+
+def render_page_full_page_from_extracted_document(
+    tmpdir_path: Path, page: int = 1, background_color: Optional[str] = None
+) -> Optional[Tuple[bytes, Tuple[float, float]]]:
+    """Render a full page from an already extracted document archive."""
+    rm_files = _get_ordered_rm_files(tmpdir_path)
+    page_order = _get_page_order(tmpdir_path)
+
+    if page_order:
+        if page < 1 or page > len(page_order):
             return None
-        return png, (paper_w, paper_h)
+        rm_file = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+    else:
+        # No page metadata: fall back to filesystem order of .rm files.
+        if page < 1 or page > len(rm_files):
+            return None
+        rm_file = rm_files[page - 1]
+
+    if rm_file is not None and rm_file.exists():
+        return render_rm_file_full_page_png(rm_file, background_color=background_color)
+
+    # The page exists in cPages but has no .rm layer yet (a blank page):
+    # render a blank full page at the document's paper size so the viewer
+    # still shows it. (The write tool will return no_page_layer until the
+    # page has a drawable layer / has been added via remarkable_add_page.)
+    paper_w, paper_h = _document_paper_size(rm_files)
+    svg = _svg_full_page([], paper_w, paper_h)
+    scale = FULL_PAGE_TARGET_LONG_EDGE / max(paper_w, paper_h)
+    png = _svg_string_to_png(
+        svg, max(1, round(paper_w * scale)), max(1, round(paper_h * scale)), background_color
+    )
+    if png is None:
+        return None
+    return png, (paper_w, paper_h)
 
 
 def document_zip_has_pdf_underlay(zip_path: Path) -> bool:
@@ -1704,11 +1715,6 @@ def render_merged_page_from_document_zip(
         Tuple of (png_bytes, note) where note is an informational message
         or None. Returns (None, error_note) on failure.
     """
-    import io
-
-    import fitz
-    from PIL import Image as PILImage
-
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
 
@@ -1716,172 +1722,180 @@ def render_merged_page_from_document_zip(
             with zipfile.ZipFile(zip_path, "r") as zf:
                 zf.extractall(tmpdir_path)
         except Exception:
-            # Fall back to annotation-only
-            png = render_page_from_document_zip(zip_path, page, background_color)
-            return png, "Could not extract zip; returned annotation-only render."
+            return None, "Could not extract document archive."
 
-        # Find the PDF file in the extracted directory. If multiple are present
-        # (rare), prefer the one whose stem matches the .content document id so
-        # selection is deterministic.
-        pdf_files = list(tmpdir_path.glob("**/*.pdf"))
-        if not pdf_files:
-            # Notebook (no PDF underlay): render the page's own strokes,
-            # selected by id so multi-page notebooks with a blank page don't
-            # shift (see _select_rm_file_for_page).
-            rm_files = _get_ordered_rm_files(tmpdir_path)
-            target = _select_rm_file_for_page(tmpdir_path, rm_files, page)
-            if target is None:
-                return None, f"Page {page} has no annotation strokes."
-            png = render_rm_file_to_png(target, background_color=background_color)
-            return png, "No PDF underlay found; returned annotation-only render."
+        return render_merged_page_from_extracted_document(
+            tmpdir_path,
+            page=page,
+            background_color=background_color,
+            canvas_width=canvas_width,
+            canvas_height=canvas_height,
+        )
 
-        content_stems = {p.stem for p in tmpdir_path.glob("*.content")}
-        matching = [p for p in pdf_files if p.stem in content_stems]
-        pdf_path = matching[0] if matching else sorted(pdf_files)[0]
-        pdf_bytes = pdf_path.read_bytes()
 
-        rm_files = _get_ordered_rm_files(tmpdir_path)
-        total_pages = len(_get_page_order(tmpdir_path)) or len(rm_files)
+def render_merged_page_from_extracted_document(
+    tmpdir_path: Path,
+    page: int = 1,
+    background_color: Optional[str] = None,
+    canvas_width: Optional[int] = None,
+    canvas_height: Optional[int] = None,
+) -> tuple[Optional[bytes], Optional[str]]:
+    """Render a merged page from an already extracted document archive."""
+    import io
 
-        if page < 1 or page > total_pages:
-            return None, f"Page {page} out of range (document has {total_pages} pages)."
+    import fitz
+    from PIL import Image as PILImage
 
-        # Select the .rm for this page by id (see _select_rm_file_for_page). A
-        # page with no strokes yields None and composites to the bare PDF page.
-        target_rm_file: Optional[Path] = _select_rm_file_for_page(tmpdir_path, rm_files, page)
+    # Find the PDF file in the extracted directory. If multiple are present
+    # (rare), prefer the one whose stem matches the .content document id so
+    # selection is deterministic.
+    pdf_files = list(tmpdir_path.glob("**/*.pdf"))
+    if not pdf_files:
+        full_page = render_page_full_page_from_extracted_document(
+            tmpdir_path,
+            page=page,
+            background_color=background_color,
+        )
+        if full_page is None:
+            return None, f"Page {page} has no renderable annotation layer."
+        return full_page[0], "No PDF underlay found; returned full-page annotation render."
 
-        def annotation_only(reason: str) -> Tuple[Optional[bytes], Optional[str]]:
-            """Fallback when the PDF side of the merge fails: render just the
-            page's own strokes — or nothing, for a strokeless page (every
-            fallback path must tolerate ``target_rm_file`` being None)."""
-            if target_rm_file is None:
-                return None, f"{reason}; page has no annotation strokes."
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, f"{reason}; annotation-only render."
+    content_stems = {p.stem for p in tmpdir_path.glob("*.content")}
+    matching = [p for p in pdf_files if p.stem in content_stems]
+    pdf_path = matching[0] if matching else sorted(pdf_files)[0]
+    pdf_bytes = pdf_path.read_bytes()
 
-        # Determine which PDF page this reMarkable page maps to. Handles both the
-        # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
-        # layouts; the latter is used by many cloud-imported PDFs, which would
-        # otherwise be misread as user-added pages and rendered annotation-only.
-        pdf_page_index: Optional[int] = _resolve_pdf_page_index(tmpdir_path, page)
-
-        if pdf_page_index is None:
-            # No redirect — this page may be a user-added blank page
-            if target_rm_file is None:
-                return None, "Page has no PDF underlay and no annotations."
-            png = render_rm_file_to_png(target_rm_file, background_color=background_color)
-            return png, "Page has no PDF underlay (user-added page); annotation-only render."
-
-        # Get PDF page dimensions to set annotation viewBox correctly
+    rm_files = _get_ordered_rm_files(tmpdir_path)
+    total_pages = len(_get_page_order(tmpdir_path)) or len(rm_files)
+    if total_pages == 0:
         try:
-            doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-            try:
-                if pdf_page_index >= len(doc):
-                    return annotation_only("PDF page index out of range")
-
-                pdf_page = doc[pdf_page_index]
-                pdf_w_pt = pdf_page.rect.width  # PDF width in points
-                pdf_h_pt = pdf_page.rect.height  # PDF height in points
-            finally:
-                doc.close()
+            with fitz.open(stream=pdf_bytes, filetype="pdf") as pdf_document:
+                total_pages = len(pdf_document)
         except Exception:
-            return annotation_only("Could not read PDF dimensions")
+            total_pages = 0
 
-        # Determine output canvas size
-        out_w = canvas_width or int(pdf_w_pt * 2)  # 2x for decent resolution
-        out_h = canvas_height or int(pdf_h_pt * 2)
+    if page < 1 or page > total_pages:
+        return None, f"Page {page} out of range (document has {total_pages} pages)."
 
-        # 1. Rasterize the PDF page
-        pdf_png = _render_pdf_page_to_png(pdf_bytes, pdf_page_index, out_w, out_h)
-        if pdf_png is None:
-            return annotation_only("PDF rasterization failed")
+    # Select the .rm for this page by id (see _select_rm_file_for_page). A
+    # page with no strokes yields None and composites to the bare PDF page.
+    target_rm_file: Optional[Path] = _select_rm_file_for_page(tmpdir_path, rm_files, page)
 
-        # 2. Render annotation layer to SVG, then to PNG with transparent background
-        ann_svg_path = None
-        ann_png_bytes = None
+    def annotation_only(reason: str) -> Tuple[Optional[bytes], Optional[str]]:
+        """Return a complete annotation page when the PDF side cannot be used."""
+        full_page = render_page_full_page_from_extracted_document(
+            tmpdir_path,
+            page=page,
+            background_color=background_color,
+        )
+        if full_page is None:
+            return None, f"{reason}; page has no renderable annotation layer."
+        return full_page[0], f"{reason}; returned full-page annotation render."
 
+    # Determine which PDF page this reMarkable page maps to. Handles both the
+    # formatVersion 2 (cPages.redir) and formatVersion 1 (redirectionPageMap)
+    # layouts; the latter is used by many cloud-imported PDFs, which would
+    # otherwise be misread as user-added pages and rendered annotation-only.
+    pdf_page_index: Optional[int] = _resolve_pdf_page_index(tmpdir_path, page)
+
+    if pdf_page_index is None:
+        return annotation_only("Page has no PDF underlay (user-added page)")
+
+    # Get PDF page dimensions to set annotation viewBox correctly
+    try:
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
         try:
-            with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
-                ann_svg_path = Path(tmp_svg.name)
+            if pdf_page_index >= len(doc):
+                return annotation_only("PDF page index out of range")
 
-            if target_rm_file is not None and _rm_to_svg(target_rm_file, ann_svg_path):
-                # Read the SVG and adjust viewBox to match PDF page bounds.
-                #
-                # rmscene emits stroke/highlight coordinates in the reMarkable
-                # device coordinate grid, NOT in PDF points: x=0 is the horizontal
-                # centre of the page and y=0 the top, and one PDF point is
-                # `_rm_units_per_point()` units (see that function for the scale
-                # and how to make it device-derived). To map the whole page
-                # [0,W]x[0,H] pt into the output canvas, set the SVG viewBox to the
-                # rmscene rectangle that covers it: (-W*k/2, 0, W*k, H*k) with
-                # k = units-per-point. (The previous code assumed k=1, i.e.
-                # rmscene units == points, which placed strokes far outside the
-                # page and filled it black.)
-                svg_content = ann_svg_path.read_text()
-
-                blocks = _v6_blocks(target_rm_file)
-                paper_size = _v6_paper_size(blocks) if blocks is not None else None
-                points_per_unit = _points_per_unit(paper_size)
-                viewbox = _annotation_page_viewbox(
-                    pdf_w_pt,
-                    pdf_h_pt,
-                    points_per_unit,
-                    centered_x=blocks is not None,
-                )
-                svg_content = _rewrite_svg_root(
-                    svg_content,
-                    viewbox=viewbox,
-                    width=out_w,
-                    height=out_h,
-                )
-
-                # Render SVG to PNG with a transparent background.
-                ann_png_bytes = _svg_string_to_png(
-                    svg_content,
-                    out_w,
-                    out_h,
-                    None,
-                )
-                if ann_png_bytes is None:
-                    raise RuntimeError("PyMuPDF could not rasterize the annotation SVG")
-        except Exception as exc:
-            # Annotation rendering failed; we'll just return the PDF, but
-            # record the failure so callers can surface it as a note.
-            logger.debug("Annotation overlay rendering failed: %s", exc)
-            ann_render_error = exc
-        else:
-            ann_render_error = None
+            pdf_page = doc[pdf_page_index]
+            pdf_w_pt = pdf_page.rect.width
+            pdf_h_pt = pdf_page.rect.height
         finally:
-            if ann_svg_path:
-                ann_svg_path.unlink(missing_ok=True)
+            doc.close()
+    except Exception:
+        return annotation_only("Could not read PDF dimensions")
 
-        # 3. Composite: PDF base + annotation overlay
-        try:
-            pdf_img = PILImage.open(io.BytesIO(pdf_png)).convert("RGBA")
+    # Determine output canvas size
+    out_w = canvas_width or int(pdf_w_pt * 2)
+    out_h = canvas_height or int(pdf_h_pt * 2)
 
-            if ann_png_bytes:
-                ann_img = PILImage.open(io.BytesIO(ann_png_bytes)).convert("RGBA")
-                # Resize annotation to match PDF if needed
-                if ann_img.size != pdf_img.size:
-                    ann_img = ann_img.resize(pdf_img.size, PILImage.LANCZOS)
-                composite = PILImage.alpha_composite(pdf_img, ann_img)
-                merged_note = None
-            else:
-                composite = pdf_img
-                merged_note = (
-                    "Annotation overlay failed to render; returned PDF page without annotations."
-                    if ann_render_error is not None
-                    else None
-                )
+    # 1. Rasterize the PDF page
+    pdf_png = _render_pdf_page_to_png(pdf_bytes, pdf_page_index, out_w, out_h)
+    if pdf_png is None:
+        return annotation_only("PDF rasterization failed")
 
-            # Convert to RGB for PNG output (no alpha needed in final)
-            composite = composite.convert("RGB")
-            buf = io.BytesIO()
-            composite.save(buf, format="PNG")
-            return buf.getvalue(), merged_note
-        except Exception:
-            # Last resort: return annotation-only from already-extracted .rm file
-            return annotation_only("Compositing failed")
+    # 2. Render annotation layer to SVG, then to PNG with transparent background
+    ann_svg_path = None
+    ann_png_bytes = None
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as tmp_svg:
+            ann_svg_path = Path(tmp_svg.name)
+
+        if target_rm_file is not None and _rm_to_svg(target_rm_file, ann_svg_path):
+            # rmscene coordinates use the device paper grid, not PDF points. Set
+            # the root viewBox to the calibrated page rectangle before rasterizing.
+            svg_content = ann_svg_path.read_text()
+
+            blocks = _v6_blocks(target_rm_file)
+            paper_size = _v6_paper_size(blocks) if blocks is not None else None
+            points_per_unit = _points_per_unit(paper_size)
+            viewbox = _annotation_page_viewbox(
+                pdf_w_pt,
+                pdf_h_pt,
+                points_per_unit,
+                centered_x=blocks is not None,
+            )
+            svg_content = _rewrite_svg_root(
+                svg_content,
+                viewbox=viewbox,
+                width=out_w,
+                height=out_h,
+            )
+
+            ann_png_bytes = _svg_string_to_png(
+                svg_content,
+                out_w,
+                out_h,
+                None,
+            )
+            if ann_png_bytes is None:
+                raise RuntimeError("PyMuPDF could not rasterize the annotation SVG")
+    except Exception as exc:
+        # Annotation rendering failed; return the PDF page but expose the loss.
+        logger.debug("Annotation overlay rendering failed: %s", exc)
+        ann_render_error = exc
+    else:
+        ann_render_error = None
+    finally:
+        if ann_svg_path:
+            ann_svg_path.unlink(missing_ok=True)
+
+    # 3. Composite: PDF base + annotation overlay
+    try:
+        pdf_img = PILImage.open(io.BytesIO(pdf_png)).convert("RGBA")
+
+        if ann_png_bytes:
+            ann_img = PILImage.open(io.BytesIO(ann_png_bytes)).convert("RGBA")
+            if ann_img.size != pdf_img.size:
+                ann_img = ann_img.resize(pdf_img.size, PILImage.LANCZOS)
+            composite = PILImage.alpha_composite(pdf_img, ann_img)
+            merged_note = None
+        else:
+            composite = pdf_img
+            merged_note = (
+                "Annotation overlay failed to render; returned PDF page without annotations."
+                if ann_render_error is not None
+                else None
+            )
+
+        composite = composite.convert("RGB")
+        buf = io.BytesIO()
+        composite.save(buf, format="PNG")
+        return buf.getvalue(), merged_note
+    except Exception:
+        return annotation_only("Compositing failed")
 
 
 def get_document_page_count(zip_path: Path) -> int:

--- a/remarkable_mcp/prompts.py
+++ b/remarkable_mcp/prompts.py
@@ -80,10 +80,10 @@ def export_document_prompt(document_name: str) -> list:
         {
             "role": "user",
             "content": (
-                f"Please extract all the content from my reMarkable document "
-                f"'{document_name}' using remarkable_read('{document_name}'). "
-                "Then format it nicely as markdown, preserving the structure "
-                "and any important formatting."
+                f"Please export my reMarkable document '{document_name}' as Markdown "
+                f"using remarkable_export('{document_name}', "
+                "output_format='markdown'). Return the temporary resource link and "
+                "its expiry so I can save it."
             ),
         }
     ]

--- a/remarkable_mcp/server.py
+++ b/remarkable_mcp/server.py
@@ -90,7 +90,7 @@ def _build_instructions() -> str:
     # desktop app's private sync cache).
     write_mode = not read_only_mode and not local_dir_mode
 
-    read_only_note = "" if write_mode else " All operations are read-only."
+    read_only_note = "" if write_mode else " All tablet and library operations are read-only."
 
     instructions = (
         "# reMarkable MCP Server\n\n"
@@ -103,6 +103,8 @@ def _build_instructions() -> str:
 - `remarkable_recent(limit)` - Get recently modified documents
 - `remarkable_status()` - Check connection and diagnose issues
 - `remarkable_image(document, page, include_ocr)` - Get a PNG image with optional OCR
+- `remarkable_export(document, output_format)` - Export one document as a
+  temporary PDF or Markdown resource
 
 ## Recommended Workflows
 
@@ -120,6 +122,11 @@ Use `remarkable_image` when you need visual context:
 
 Example: `remarkable_image("UI Mockup", page=1)` returns a PNG image
 Example: `remarkable_image("Notes", include_ocr=True)` returns image with extracted text
+
+### Exporting a Document
+Use `remarkable_export` for a complete PDF or structured Markdown artifact.
+Exports never modify the tablet, but they do create a server-managed temporary
+local file. The returned resource link expires after 15 minutes.
 
 ### For Large Documents
 Use pagination to avoid overwhelming context. The response includes:
@@ -139,6 +146,7 @@ Use pagination to avoid overwhelming context. The response includes:
 Documents are registered as resources for direct access:
 - `remarkable:///{path}.txt` - Get full extracted text content in one request
 - `remarkableimg:///{path}.page-{N}.png` - Get PNG image of page N (notebooks only)
+- `remarkableexport:///{format}/{id}` - Fetch a temporary generated export
 - Use resources when you need complete document content without pagination
 """
     )
@@ -313,8 +321,10 @@ async def lifespan(app: MCPServer) -> AsyncIterator[None]:
         # Stop background loader on shutdown (if running)
         await stop_background_loader(task)
         from remarkable_mcp.api import close_device_client
+        from remarkable_mcp.export_resources import cleanup_export_resources
 
         await close_device_client()
+        cleanup_export_resources()
 
 
 try:

--- a/remarkable_mcp/tools.py
+++ b/remarkable_mcp/tools.py
@@ -1,9 +1,9 @@
 """
 MCP Tools for reMarkable tablet access.
 
-All tools in this module are read-only and idempotent - they only retrieve
-data from your reMarkable (via whichever transport is active: cloud, SSH, or
-USB web) and do not modify any documents.
+Tools in this module never modify the reMarkable library. Most are read-only
+and idempotent; ``remarkable_export`` additionally creates a bounded temporary
+file on the MCP server host and returns it as a resource link.
 """
 
 import base64
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import tempfile
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import List, Literal, Optional
@@ -18,6 +19,7 @@ from typing import List, Literal, Optional
 from mcp.types import (
     BlobResourceContents,
     EmbeddedResource,
+    ResourceLink,
     TextContent,
     TextResourceContents,
     ToolAnnotations,
@@ -33,6 +35,15 @@ from remarkable_mcp.api import (
     get_rmapi,
 )
 from remarkable_mcp.concurrency import run_blocking
+from remarkable_mcp.export_resources import PublishedExport, export_store
+from remarkable_mcp.exporters import (
+    ExportBuildResult,
+    ExportMetadata,
+    PdfMode,
+    write_archive_pdf_export,
+    write_markdown_export,
+    write_native_pdf_export,
+)
 from remarkable_mcp.extract import (
     extract_text_from_document_zip,
     extract_text_from_epub,
@@ -170,6 +181,14 @@ STATUS_ANNOTATIONS = ToolAnnotations(
 IMAGE_ANNOTATIONS = ToolAnnotations(
     title="Get reMarkable Page Image",
     **_BASE_ANNOTATIONS,
+)
+
+EXPORT_ANNOTATIONS = ToolAnnotations(
+    title="Export reMarkable Document",
+    read_only_hint=False,
+    destructive_hint=False,
+    idempotent_hint=False,
+    open_world_hint=False,
 )
 
 # Default page size for pagination (characters) - used for PDFs/EPUBs
@@ -1426,13 +1445,15 @@ async def remarkable_status() -> str:
     troubleshoot.
 
     Capability notes:
-    - Cloud (default): full read/render/upload/mkdir/move/rename/delete — no device
+    - Export is available in every transport and creates only a bounded temporary
+      local resource; it never modifies the tablet.
+    - Cloud (default): full read/render/export/upload/mkdir/move/rename/delete — no device
       needed, works from anywhere your token is valid.
     - SSH: full capabilities over a local/USB connection to the tablet.
-    - USB web: read, render, and upload (to root) only — the tablet's USB web
+    - USB web: read, render, export, and upload (to root) only — the tablet's USB web
       interface firmware exposes no folder/move/rename/delete endpoints. For full
       write parity over a USB cable, use SSH mode pointed at the USB IP.
-    - Local directory: fully offline read/render access to the desktop app's sync
+    - Local directory: fully offline read/render/export access to the desktop app's sync
       cache. Strictly read-only to avoid corrupting app-managed state.
     Write tools (upload/mkdir/move/rename/delete) are enabled by default; run
     with --read-only (or REMARKABLE_READ_ONLY=1) to expose a read-only server.
@@ -1483,11 +1504,12 @@ async def remarkable_status() -> str:
         connection_info = "environment variable" if REMARKABLE_TOKEN else "file (~/.rmapi)"
 
     # What each transport is capable of (independent of read-only mode).
-    # read/render are always available; the booleans below are the write surface.
+    # Read/render/export are always available; the remaining booleans are writes.
     capability_matrix = {
         "cloud": {
             "read": True,
             "render": True,
+            "export": True,
             "upload": True,
             "mkdir": True,
             "move": True,
@@ -1497,6 +1519,7 @@ async def remarkable_status() -> str:
         "ssh": {
             "read": True,
             "render": True,
+            "export": True,
             "upload": True,
             "mkdir": True,
             "move": True,
@@ -1506,6 +1529,7 @@ async def remarkable_status() -> str:
         "usb-web": {
             "read": True,
             "render": True,
+            "export": True,
             "upload": True,
             "mkdir": False,
             "move": False,
@@ -1517,6 +1541,7 @@ async def remarkable_status() -> str:
         "local-dir": {
             "read": True,
             "render": True,
+            "export": True,
             "upload": False,
             "mkdir": False,
             "move": False,
@@ -1556,7 +1581,7 @@ async def remarkable_status() -> str:
         # when not in read-only mode.
         transport_caps = capability_matrix[transport]
         effective_caps = {
-            cap: (supported if cap in ("read", "render") else supported and writes_on)
+            cap: (supported if cap in ("read", "render", "export") else supported and writes_on)
             for cap, supported in transport_caps.items()
         }
 
@@ -1581,6 +1606,9 @@ async def remarkable_status() -> str:
             result["root_path"] = root
 
         hint_parts = [f"Connected successfully via {transport}. Found {doc_count} documents."]
+        hint_parts.append(
+            "Single-document PDF/Markdown export is available and does not modify the tablet."
+        )
         if fell_back:
             hint_parts.append(
                 f"Note: {selected_transport} was selected but unavailable, so it "
@@ -2106,3 +2134,411 @@ async def remarkable_image(
             message=str(e),
             suggestion="Check remarkable_status() to verify your connection.",
         )
+
+
+@dataclass(frozen=True)
+class _DocumentExportResult:
+    build: ExportBuildResult
+    metadata: ExportMetadata
+    representation: str
+    pdf_mode: PdfMode | None = None
+
+
+class _ExportRequestError(Exception):
+    def __init__(self, error_type: str, message: str, suggestion: str):
+        super().__init__(message)
+        self.error_type = error_type
+        self.message = message
+        self.suggestion = suggestion
+
+
+def _extract_source_text_from_bytes(data: bytes, source_type: str) -> str:
+    suffix = f".{source_type}"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(data)
+        path = Path(tmp.name)
+    try:
+        if source_type == "pdf":
+            return extract_text_from_pdf(path)
+        if source_type == "epub":
+            return extract_text_from_epub(path)
+        raise ValueError(f"Unsupported source type: {source_type}")
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _publish_document_export(
+    client,
+    target_doc,
+    metadata: ExportMetadata,
+    *,
+    output_format: Literal["pdf", "markdown"],
+    pdf_mode: PdfMode,
+    include_ocr: bool,
+    background_color: str,
+) -> PublishedExport[_DocumentExportResult]:
+    """Download, build, and publish one export without touching tablet state."""
+
+    def writer(destination: Path) -> _DocumentExportResult:
+        raw_doc = client.download(target_doc)
+        if not raw_doc:
+            raise _ExportRequestError(
+                "document_download_failed",
+                "The transport returned an empty document payload.",
+                "Retry the export or use remarkable_status() to check the connection.",
+            )
+
+        if _is_pdf_payload(raw_doc):
+            page_count = _count_pdf_pages(raw_doc)
+            resolved = replace(metadata, page_count=page_count)
+            if output_format == "pdf":
+                if pdf_mode == "annotations":
+                    raise _ExportRequestError(
+                        "annotation_only_not_available",
+                        (
+                            "Annotation-only PDF export is unavailable because this "
+                            "transport returned a flattened native PDF."
+                        ),
+                        (
+                            "Use pdf_mode='merged', or connect through cloud/SSH, local-dir, "
+                            "or newer USB firmware that exposes an rmdoc archive."
+                        ),
+                    )
+                build = write_native_pdf_export(raw_doc, destination, resolved)
+                return _DocumentExportResult(
+                    build=build,
+                    metadata=resolved,
+                    representation="tablet_pdf",
+                    pdf_mode=pdf_mode,
+                )
+
+            source_text = _extract_source_text_from_bytes(raw_doc, "pdf")
+            warnings = [
+                (
+                    "This transport returned a flattened native PDF. Source/visible text "
+                    "was preserved, but separate typed, annotation, highlight, and OCR "
+                    "layers were unavailable."
+                )
+            ]
+            build = write_markdown_export(
+                destination,
+                resolved,
+                source_text=source_text,
+                extraction=None,
+                include_ocr=include_ocr,
+                warnings=warnings,
+            )
+            return _DocumentExportResult(
+                build=build,
+                metadata=resolved,
+                representation="tablet_pdf",
+            )
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(raw_doc)
+            archive_path = Path(tmp.name)
+
+        try:
+            try:
+                page_count = get_document_page_count(archive_path)
+                archive_type = get_document_file_type(archive_path) or metadata.source_type
+            except Exception as exc:
+                raise _ExportRequestError(
+                    "invalid_document_archive",
+                    f"The downloaded document archive could not be read: {exc}",
+                    "Retry the export. If it persists, try another transport.",
+                ) from exc
+
+            resolved = replace(
+                metadata,
+                source_type=archive_type or "notebook",
+                page_count=page_count if page_count > 0 else None,
+            )
+
+            if output_format == "pdf":
+                # USB web can expose a firmware-rendered PDF for notebooks and
+                # EPUBs. Prefer it in merged mode because it includes source
+                # underlays that the local archive cannot reconstruct.
+                if pdf_mode == "merged" and resolved.source_type != "pdf":
+                    native_pdf = download_raw_file(client, target_doc, "pdf")
+                    if _is_pdf_payload(native_pdf):
+                        native_pages = _count_pdf_pages(native_pdf)
+                        native_metadata = replace(resolved, page_count=native_pages)
+                        build = write_native_pdf_export(native_pdf, destination, native_metadata)
+                        return _DocumentExportResult(
+                            build=build,
+                            metadata=native_metadata,
+                            representation="tablet_pdf",
+                            pdf_mode=pdf_mode,
+                        )
+
+                if resolved.page_count is None and resolved.source_type == "pdf":
+                    source_pdf = download_raw_file(client, target_doc, "pdf")
+                    if _is_pdf_payload(source_pdf):
+                        resolved = replace(resolved, page_count=_count_pdf_pages(source_pdf))
+
+                if resolved.page_count is None:
+                    raise _ExportRequestError(
+                        "page_count_unavailable",
+                        "The physical page count could not be determined for this document.",
+                        (
+                            "Retry with another transport. PDF export cannot preserve page "
+                            "order safely without a physical page count."
+                        ),
+                    )
+
+                build = write_archive_pdf_export(
+                    archive_path,
+                    destination,
+                    resolved,
+                    pdf_mode=pdf_mode,
+                    background_color=background_color,
+                )
+                return _DocumentExportResult(
+                    build=build,
+                    metadata=resolved,
+                    representation="document_archive",
+                    pdf_mode=pdf_mode,
+                )
+
+            warnings: list[str] = []
+            extraction = None
+            try:
+                extraction = extract_text_from_document_zip(
+                    archive_path,
+                    include_ocr=include_ocr,
+                    doc_id=resolved.document_id,
+                )
+                if resolved.page_count is None:
+                    extracted_pages = int(extraction.get("pages") or 0)
+                    if extracted_pages > 0:
+                        resolved = replace(resolved, page_count=extracted_pages)
+            except Exception as exc:
+                warnings.append(f"Annotation extraction failed: {exc}")
+
+            source_text = None
+            if resolved.source_type in ("pdf", "epub"):
+                source_data = download_raw_file(client, target_doc, resolved.source_type)
+                if source_data:
+                    try:
+                        source_text = _extract_source_text_from_bytes(
+                            source_data,
+                            resolved.source_type,
+                        )
+                    except Exception as exc:
+                        warnings.append(
+                            f"{resolved.source_type.upper()} source text extraction failed: {exc}"
+                        )
+                else:
+                    warnings.append(
+                        f"Original {resolved.source_type.upper()} source data was unavailable."
+                    )
+
+            if extraction is None and source_text is None:
+                raise _ExportRequestError(
+                    "no_exportable_content",
+                    "Neither source text nor annotation content could be extracted.",
+                    "Retry with another transport or verify the document opens on the tablet.",
+                )
+
+            build = write_markdown_export(
+                destination,
+                resolved,
+                source_text=source_text,
+                extraction=extraction,
+                include_ocr=include_ocr,
+                warnings=warnings,
+            )
+            return _DocumentExportResult(
+                build=build,
+                metadata=resolved,
+                representation="document_archive",
+            )
+        finally:
+            archive_path.unlink(missing_ok=True)
+
+    extension = "pdf" if output_format == "pdf" else "md"
+    source_name = metadata.title
+    for source_suffix in (".pdf", ".epub"):
+        if source_name.lower().endswith(source_suffix):
+            source_name = source_name[: -len(source_suffix)]
+            break
+    return export_store.publish(
+        filename=f"{source_name}.{extension}",
+        output_format=output_format,
+        writer=writer,
+    )
+
+
+@mcp.tool(annotations=EXPORT_ANNOTATIONS)
+async def remarkable_export(
+    document: str,
+    output_format: Literal["pdf", "markdown"] = "pdf",
+    pdf_mode: Literal["merged", "annotations"] = "merged",
+    include_ocr: bool = False,
+):
+    """
+    <usecase>Export one reMarkable document as a reusable PDF or Markdown file.</usecase>
+    <instructions>
+    Exports a single document without modifying the tablet or its library.
+
+    The generated file is written to a server-managed temporary directory and
+    returned as an MCP ResourceLink. The tool response stays small: it never embeds
+    the PDF/Markdown as base64 and never writes to an arbitrary host path. The
+    resource expires after 15 minutes and may be evicted earlier when more than
+    eight exports are retained. Fetch and save the linked resource for durable use.
+
+    PDF behavior:
+    - `pdf_mode="merged"` (default) preserves complete physical pages, combining
+      mapped PDF underlays and reMarkable annotations.
+    - `pdf_mode="annotations"` exports full-page annotation layers only when the
+      transport provides a document archive.
+    - Pages remain in physical device order. A render failure produces a labeled
+      placeholder at that ordinal and a partial-export warning; pages are not skipped.
+
+    Markdown behavior:
+    - Preserves basic source metadata and fixed source text, typed text, annotation,
+      highlight, and OCR sections.
+    - OCR is opt-in and uses the same configured/cached OCR path as remarkable_read.
+    - Extracted text is kept verbatim; the exporter does not invent headings, lists,
+      links, or page attribution it cannot prove.
+    </instructions>
+    <parameters>
+    - document: Document name or path (use remarkable_browse to find documents).
+    - output_format: "pdf" (default) or "markdown".
+    - pdf_mode: PDF-only mode, "merged" (default) or "annotations".
+    - include_ocr: Enable existing handwriting OCR for Markdown (default: False).
+    </parameters>
+    <examples>
+    - remarkable_export("Meeting Notes")
+    - remarkable_export("Research Paper", output_format="pdf", pdf_mode="annotations")
+    - remarkable_export("Journal", output_format="markdown", include_ocr=True)
+    </examples>
+    """
+    if output_format == "markdown" and pdf_mode != "merged":
+        return make_error(
+            error_type="invalid_export_options",
+            message="pdf_mode applies only to PDF exports.",
+            suggestion="Use pdf_mode='merged' for Markdown, or choose output_format='pdf'.",
+        )
+    if output_format == "pdf" and include_ocr:
+        return make_error(
+            error_type="invalid_export_options",
+            message="include_ocr applies only to Markdown exports.",
+            suggestion="Set include_ocr=False, or choose output_format='markdown'.",
+        )
+
+    try:
+        client = await run_blocking(get_rmapi)
+        collection = await run_blocking(client.get_meta_items)
+        items_by_id = get_items_by_id(collection)
+        target_doc = _find_target_document(collection, items_by_id, document)
+        if target_doc is None:
+            root = _get_root_path()
+            candidates = [
+                item
+                for item in collection
+                if not item.is_folder
+                and not _is_cloud_archived(item)
+                and _is_within_root(get_item_path(item, items_by_id), root)
+            ]
+            similar = find_similar_documents(document, candidates)
+            return make_error(
+                error_type="document_not_found",
+                message=f"Document not found: '{document}'",
+                suggestion="Use remarkable_browse() to find the exact document name or path.",
+                did_you_mean=similar if similar else None,
+            )
+
+        full_path = get_item_path(target_doc, items_by_id)
+        display_path = _apply_root_filter(full_path)
+        source_type = await run_blocking(get_file_type, client, target_doc)
+        metadata = ExportMetadata(
+            document_id=target_doc.ID,
+            title=target_doc.VissibleName,
+            path=display_path,
+            source_type=source_type,
+            page_count=None,
+            modified=getattr(target_doc, "ModifiedClient", None),
+            tags=tuple(getattr(target_doc, "tags", None) or ()),
+        )
+        background = await run_blocking(get_background_color)
+        published = await run_blocking(
+            _publish_document_export,
+            client,
+            target_doc,
+            metadata,
+            output_format=output_format,
+            pdf_mode=pdf_mode,
+            include_ocr=include_ocr,
+            background_color=background,
+        )
+    except _ExportRequestError as exc:
+        return make_error(
+            error_type=exc.error_type,
+            message=exc.message,
+            suggestion=exc.suggestion,
+        )
+    except Exception as exc:
+        return make_error(
+            error_type="export_failed",
+            message=str(exc),
+            suggestion=(
+                "Retry the export, or use remarkable_status() to verify the active transport."
+            ),
+        )
+
+    resource = published.resource
+    result = published.result
+    build = result.build
+    response = {
+        "document": result.metadata.title,
+        "document_id": result.metadata.document_id,
+        "path": result.metadata.path,
+        "source_type": result.metadata.source_type,
+        "format": output_format,
+        "mime_type": resource.mime_type,
+        "filename": resource.filename,
+        "size": resource.size,
+        "pages": build.pages,
+        "status": build.status,
+        "failed_pages": list(build.failed_pages),
+        "warnings": list(build.warnings),
+        "representation": result.representation,
+        "resource_uri": resource.uri,
+        "expires_at": resource.expires_at,
+        "temporary_local_file": True,
+    }
+    if result.pdf_mode is not None:
+        response["pdf_mode"] = result.pdf_mode
+    if build.ocr_backend:
+        response["ocr_backend"] = build.ocr_backend
+
+    hint = (
+        f"Temporary {output_format.upper()} export ready as an MCP resource "
+        f"({resource.size} bytes). It expires at {resource.expires_at.isoformat()}; "
+        "fetch and save the resource for durable storage. The tablet was not modified."
+    )
+    if build.status == "partial":
+        hint = f"Partial export: {'; '.join(build.warnings) or 'some pages failed'}. {hint}"
+
+    info = TextContent(type="text", text=make_response(response, hint))
+    link = ResourceLink(
+        type="resource_link",
+        name=resource.filename,
+        title=f"{result.metadata.title} ({output_format.upper()} export)",
+        uri=resource.uri,
+        description=(
+            f"Temporary export of reMarkable document {result.metadata.document_id}; "
+            f"expires {resource.expires_at.isoformat()}."
+        ),
+        mime_type=resource.mime_type,
+        size=resource.size,
+        meta={
+            "documentId": result.metadata.document_id,
+            "documentPath": result.metadata.path,
+            "expiresAt": resource.expires_at.isoformat(),
+            "temporaryLocalFile": True,
+        },
+    )
+    return [info, link]

--- a/smoke/run_smoke.py
+++ b/smoke/run_smoke.py
@@ -89,6 +89,7 @@ ALL_TOOLS = [
     "remarkable_search",
     "remarkable_read",
     "remarkable_image",
+    "remarkable_export",
     "remarkable_canvas",
     "remarkable_upload",
     "remarkable_mkdir",
@@ -105,6 +106,7 @@ READ_TOOLS = {
     "remarkable_search",
     "remarkable_read",
     "remarkable_image",
+    "remarkable_export",
     "remarkable_canvas",
 }
 WRITE_TOOLS = {
@@ -162,6 +164,7 @@ MODES = {
 TIMEOUTS = {
     "remarkable_status": 60,
     "remarkable_image": 120,
+    "remarkable_export": 240,
     "remarkable_canvas": 120,
     "remarkable_author": 120,
     "remarkable_refresh": 120,
@@ -533,6 +536,9 @@ def _detail_for(tool, payload):
         return {k: payload.get(k) for k in keys if k in payload}
     if tool in ("remarkable_browse", "remarkable_recent", "remarkable_search"):
         return {"count": payload.get("count")}
+    if tool == "remarkable_export":
+        keys = ("status", "format", "pages", "size", "representation")
+        return {key: payload.get(key) for key in keys if key in payload}
     err = _error_type(payload)
     if err:
         return {"error_type": err}
@@ -565,7 +571,7 @@ async def verify_upload_roundtrip(session, doc_path):
 
 
 async def run_read_phase(session, mode, rec, registered):
-    """browse, recent, search, read, image, canvas -- expected OK where exposed."""
+    """Browse, read, render, and export without modifying tablet data."""
     # browse
     if "remarkable_browse" in registered:
         payload, is_err, exc = await call_tool(
@@ -622,6 +628,67 @@ async def run_read_phase(session, mode, rec, registered):
         if not note and target:
             note = f"target: {target}"
         rec.record(mode, tool, state, note, _detail_for(tool, payload))
+
+    # Export is a read-only tablet operation but returns a temporary ResourceLink.
+    # Fetch the linked Markdown to validate both the tool and resource lifecycle
+    # without uploading or mutating anything on the device.
+    if "remarkable_export" in registered:
+        if not target:
+            rec.record(
+                mode,
+                "remarkable_export",
+                SKIP,
+                "no document available to export in this mode",
+            )
+        else:
+            try:
+                result = await asyncio.wait_for(
+                    session.call_tool(
+                        "remarkable_export",
+                        {
+                            "document": target,
+                            "output_format": "markdown",
+                            "include_ocr": False,
+                        },
+                    ),
+                    timeout=TIMEOUTS["remarkable_export"],
+                )
+                payload = _parse_payload(result)
+                err_type = _error_type(payload)
+                links = [
+                    content
+                    for content in result.content
+                    if getattr(content, "type", None) == "resource_link"
+                ]
+                if err_type:
+                    state, note = FAIL, f"error: {err_type}"
+                elif getattr(result, "is_error", False):
+                    state, note = FAIL, "tool reported isError"
+                elif not links:
+                    state, note = FAIL, "tool returned no ResourceLink"
+                else:
+                    resource = await asyncio.wait_for(
+                        session.read_resource(links[0].uri),
+                        timeout=TIMEOUTS["remarkable_export"],
+                    )
+                    markdown = resource.contents[0].text
+                    if "remarkable_document_id:" in markdown and "## Source text" in markdown:
+                        state, note = PASS, f"resource round-trip OK; target: {target}"
+                    else:
+                        state, note = FAIL, "linked Markdown resource was incomplete"
+            except asyncio.TimeoutError:
+                state, note = FAIL, f"timed out after {TIMEOUTS['remarkable_export']}s"
+                payload = {}
+            except Exception as exc:  # noqa: BLE001 - include transport/client failure
+                state, note = FAIL, f"{type(exc).__name__}: {exc}"
+                payload = {}
+            rec.record(
+                mode,
+                "remarkable_export",
+                state,
+                note,
+                _detail_for("remarkable_export", payload),
+            )
 
 
 async def run_write_phase(session, mode, rec, registered):

--- a/test_export_tool.py
+++ b/test_export_tool.py
@@ -1,0 +1,359 @@
+"""Single-document export tool contracts across representative transports."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import fitz
+import pytest
+from mcp import types
+
+from remarkable_mcp.export_resources import export_store
+from remarkable_mcp.server import mcp
+
+
+def _document(name: str, doc_id: str = "doc-1"):
+    return SimpleNamespace(
+        VissibleName=name,
+        ID=doc_id,
+        Parent="",
+        ModifiedClient=None,
+        is_folder=False,
+        tags=["exported"],
+    )
+
+
+def _pdf_bytes(pages: int = 2) -> bytes:
+    document = fitz.open()
+    for number in range(1, pages + 1):
+        page = document.new_page(width=445, height=594)
+        page.insert_text((40, 50), f"source page {number}")
+    data = document.tobytes()
+    document.close()
+    return data
+
+
+def _notebook_archive(doc_id: str = "doc-1", text: str = "Typed export content") -> bytes:
+    from remarkable_mcp import notebooks
+
+    page_id = "page-1"
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr(
+            f"{doc_id}.content",
+            json.dumps({"fileType": "notebook", "cPages": {"pages": [{"id": page_id}]}}),
+        )
+        archive.writestr(f"{page_id}.rm", notebooks.page_rm_bytes(text))
+    return output.getvalue()
+
+
+def _annotated_pdf_archive(doc_id: str = "doc-1") -> bytes:
+    from remarkable_mcp import notebooks
+
+    page_id = "page-1"
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr(
+            f"{doc_id}.content",
+            json.dumps(
+                {
+                    "fileType": "pdf",
+                    "cPages": {
+                        "pages": [{"id": page_id, "redir": {"value": 0}}],
+                    },
+                }
+            ),
+        )
+        archive.writestr(f"{doc_id}.pdf", _pdf_bytes(1))
+        archive.writestr(f"{page_id}.rm", notebooks.page_rm_bytes("PDF annotation"))
+    return output.getvalue()
+
+
+def _json_result(result: types.CallToolResult) -> dict:
+    return json.loads(result.content[0].text)
+
+
+def _resource_link(result: types.CallToolResult) -> types.ResourceLink:
+    return next(content for content in result.content if isinstance(content, types.ResourceLink))
+
+
+@pytest.fixture(autouse=True)
+def _clean_export_store():
+    export_store.cleanup()
+    yield
+    export_store.cleanup()
+
+
+class TestExportToolContract:
+    @pytest.mark.asyncio
+    async def test_tool_metadata_describes_temporary_local_write(self):
+        tools = await mcp.list_tools()
+        tool = next(item for item in tools if item.name == "remarkable_export")
+
+        assert tool.annotations.read_only_hint is False
+        assert tool.annotations.destructive_hint is False
+        assert tool.input_schema["properties"]["output_format"]["default"] == "pdf"
+        assert tool.input_schema["properties"]["pdf_mode"]["default"] == "merged"
+        assert tool.input_schema["properties"]["include_ocr"]["default"] is False
+        assert "temporary directory" in tool.description
+        assert "without modifying the tablet" in tool.description
+
+    @pytest.mark.asyncio
+    async def test_native_pdf_returns_small_resource_link_with_stable_identity(self):
+        import remarkable_mcp.tools as tool_module
+
+        document = _document("Version 1.2 plan", "stable-pdf-id")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_bytes()
+
+        with (
+            patch.object(tool_module, "get_rmapi", return_value=client),
+            patch.object(tool_module, "get_file_type", return_value="pdf"),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {"document": document.VissibleName, "output_format": "pdf"},
+            )
+
+        data = _json_result(result)
+        assert "_error" not in data, data
+        link = _resource_link(result)
+        assert data["document_id"] == "stable-pdf-id"
+        assert data["filename"] == "Version 1.2 plan.pdf"
+        assert data["status"] == "complete"
+        assert data["temporary_local_file"] is True
+        assert data["resource_uri"] == link.uri
+        assert not any(isinstance(content, types.EmbeddedResource) for content in result.content)
+        assert "base64" not in result.content[0].text.lower()
+
+        resource = await mcp.read_resource(link.uri)
+        assert resource[0].mime_type == "application/pdf"
+        with fitz.open(stream=resource[0].content, filetype="pdf") as exported:
+            assert len(exported) == 2
+            assert "stable-pdf-id" in exported.metadata["subject"]
+            assert [page.get_text().strip() for page in exported] == [
+                "source page 1",
+                "source page 2",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_flattened_pdf_rejects_annotation_only_export(self):
+        import remarkable_mcp.tools as tool_module
+
+        document = _document("Flattened PDF")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _pdf_bytes()
+
+        with (
+            patch.object(tool_module, "get_rmapi", return_value=client),
+            patch.object(tool_module, "get_file_type", return_value="pdf"),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {
+                    "document": document.VissibleName,
+                    "output_format": "pdf",
+                    "pdf_mode": "annotations",
+                },
+            )
+
+        assert _json_result(result)["_error"]["type"] == "annotation_only_not_available"
+        assert not any(isinstance(content, types.ResourceLink) for content in result.content)
+
+    @pytest.mark.asyncio
+    async def test_pdf_archive_merges_complete_page_by_default(self):
+        import remarkable_mcp.tools as tool_module
+
+        document = _document("Annotated PDF", "annotated-id")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _annotated_pdf_archive(document.ID)
+
+        with (
+            patch.object(tool_module, "get_rmapi", return_value=client),
+            patch.object(tool_module, "get_file_type", return_value="pdf"),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {"document": document.VissibleName, "output_format": "pdf"},
+            )
+
+        data = _json_result(result)
+        assert data["status"] == "complete"
+        assert data["pages"] == 1
+        assert data["pdf_mode"] == "merged"
+        resource = await mcp.read_resource(_resource_link(result).uri)
+        with fitz.open(stream=resource[0].content, filetype="pdf") as exported:
+            assert len(exported) == 1
+            assert exported[0].rect.width > 0
+            assert exported[0].rect.height > 0
+
+    @pytest.mark.asyncio
+    async def test_partial_page_diagnostics_are_returned_with_resource(self):
+        import remarkable_mcp.tools as tool_module
+        from remarkable_mcp.exporters import ExportBuildResult
+
+        document = _document("Partial Notebook", "partial-id")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _notebook_archive(document.ID)
+
+        def partial_export(_archive, destination, _metadata, **_kwargs):
+            destination.write_bytes(_pdf_bytes(1))
+            return ExportBuildResult(
+                status="partial",
+                pages=1,
+                failed_pages=(1,),
+                warnings=("Page 1: synthetic failure",),
+            )
+
+        with (
+            patch.object(tool_module, "get_rmapi", return_value=client),
+            patch.object(tool_module, "get_file_type", return_value="notebook"),
+            patch.object(tool_module, "download_raw_file", return_value=None),
+            patch.object(tool_module, "write_archive_pdf_export", side_effect=partial_export),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {"document": document.VissibleName, "output_format": "pdf"},
+            )
+
+        data = _json_result(result)
+        assert data["status"] == "partial"
+        assert data["failed_pages"] == [1]
+        assert data["warnings"] == ["Page 1: synthetic failure"]
+        assert "Partial export" in data["_hint"]
+        assert _resource_link(result)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            {"output_format": "markdown", "pdf_mode": "annotations"},
+            {"output_format": "pdf", "include_ocr": True},
+        ],
+    )
+    async def test_incompatible_options_are_not_silently_ignored(self, arguments):
+        result = await mcp.call_tool(
+            "remarkable_export",
+            {"document": "Anything", **arguments},
+        )
+        assert _json_result(result)["_error"]["type"] == "invalid_export_options"
+
+    @pytest.mark.asyncio
+    async def test_document_not_found_uses_standard_educational_error(self):
+        import remarkable_mcp.tools as tool_module
+
+        client = Mock()
+        client.get_meta_items.return_value = []
+        with patch.object(tool_module, "get_rmapi", return_value=client):
+            result = await mcp.call_tool("remarkable_export", {"document": "Missing"})
+
+        data = _json_result(result)
+        assert data["_error"]["type"] == "document_not_found"
+        assert "remarkable_browse" in data["_error"]["suggestion"]
+
+
+class TestExportTransportFixtures:
+    @pytest.mark.asyncio
+    async def test_local_dir_fixture_exports_markdown(self, tmp_path):
+        from remarkable_mcp.local_dir import LocalDirClient
+
+        doc_id = "local-doc"
+        page_id = "local-page"
+        (tmp_path / f"{doc_id}.metadata").write_text(
+            json.dumps(
+                {
+                    "visibleName": "Local Notes",
+                    "type": "DocumentType",
+                    "parent": "",
+                    "tags": ["offline"],
+                }
+            )
+        )
+        (tmp_path / f"{doc_id}.content").write_text(
+            json.dumps(
+                {
+                    "fileType": "notebook",
+                    "cPages": {"pages": [{"id": page_id}]},
+                }
+            )
+        )
+        page_dir = tmp_path / doc_id
+        page_dir.mkdir()
+        from remarkable_mcp import notebooks
+
+        (page_dir / f"{page_id}.rm").write_bytes(notebooks.page_rm_bytes("Local typed text"))
+        client = LocalDirClient(tmp_path)
+
+        with patch("remarkable_mcp.tools.get_rmapi", return_value=client):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {"document": "Local Notes", "output_format": "markdown"},
+            )
+
+        data = _json_result(result)
+        link = _resource_link(result)
+        assert data["source_type"] == "notebook"
+        assert data["document_id"] == doc_id
+        resource = await mcp.read_resource(link.uri)
+        assert resource[0].mime_type == "text/markdown; charset=utf-8"
+        assert "Local typed text" in resource[0].content
+        assert f'remarkable_document_id: "{doc_id}"' in resource[0].content
+
+    @pytest.mark.asyncio
+    async def test_content_addressed_cloud_fixture_exports_markdown(self):
+        from remarkable_mcp.sync import Document, RemarkableClient
+
+        doc_id = "cloud-doc"
+        page_id = "page-1"
+        archive = _notebook_archive(doc_id, "Cloud typed text")
+        with zipfile.ZipFile(io.BytesIO(archive)) as source:
+            content_bytes = source.read(f"{doc_id}.content")
+            page_bytes = source.read(f"{page_id}.rm")
+
+        document = Document(
+            id=doc_id,
+            hash="document-index",
+            name="Cloud Notes",
+            doc_type="DocumentType",
+            files=[
+                {"id": f"{doc_id}.content", "hash": "content-hash", "size": len(content_bytes)},
+                {"id": f"{page_id}.rm", "hash": "page-hash", "size": len(page_bytes)},
+            ],
+        )
+        index = (
+            "3\n"
+            f"content-hash:0:{doc_id}.content:0:{len(content_bytes)}\n"
+            f"page-hash:0:{page_id}.rm:0:{len(page_bytes)}\n"
+        ).encode()
+        blobs = {
+            "document-index": index,
+            "content-hash": content_bytes,
+            "page-hash": page_bytes,
+        }
+        client = RemarkableClient(user_token="fixture")
+        client._documents = [document]
+        client._documents_by_id = {doc_id: document}
+        client.get_meta_items = Mock(return_value=[document])
+        client._get_file = Mock(side_effect=lambda blob_hash, _name: blobs[blob_hash])
+
+        with patch("remarkable_mcp.tools.get_rmapi", return_value=client):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {"document": "Cloud Notes", "output_format": "markdown"},
+            )
+
+        data = _json_result(result)
+        assert "_error" not in data, data
+        link = _resource_link(result)
+        assert data["document_id"] == doc_id
+        assert data["representation"] == "document_archive"
+        resource = await mcp.read_resource(link.uri)
+        assert "Cloud typed text" in resource[0].content

--- a/test_export_tool.py
+++ b/test_export_tool.py
@@ -232,6 +232,44 @@ class TestExportToolContract:
         assert _resource_link(result)
 
     @pytest.mark.asyncio
+    async def test_insert_image_failure_yields_one_placeholder_resource_page(self):
+        import remarkable_mcp.tools as tool_module
+
+        document = _document("Insertion Failure", "insert-failure-id")
+        client = Mock()
+        client.get_meta_items.return_value = [document]
+        client.download.return_value = _annotated_pdf_archive(document.ID)
+
+        with (
+            patch.object(tool_module, "get_rmapi", return_value=client),
+            patch.object(tool_module, "get_file_type", return_value="pdf"),
+            patch.object(
+                fitz.Page,
+                "insert_image",
+                side_effect=RuntimeError("synthetic insert_image failure"),
+            ),
+        ):
+            result = await mcp.call_tool(
+                "remarkable_export",
+                {"document": document.VissibleName, "output_format": "pdf"},
+            )
+
+        data = _json_result(result)
+        link = _resource_link(result)
+        assert data["status"] == "partial"
+        assert data["pages"] == 1
+        assert data["failed_pages"] == [1]
+        assert "synthetic insert_image failure" in "\n".join(data["warnings"])
+
+        resource = await mcp.read_resource(link.uri)
+        with fitz.open(stream=resource[0].content, filetype="pdf") as exported:
+            assert len(exported) == 1
+            placeholder = exported[0].get_text()
+            assert "Physical page 1 could not be rendered" in placeholder
+            assert "synthetic insert_image" in placeholder
+            assert "failure" in placeholder
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "arguments",
         [

--- a/test_exporters.py
+++ b/test_exporters.py
@@ -1,0 +1,322 @@
+"""Pure exporter and temporary export-resource tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import fitz
+import pytest
+from PIL import Image
+
+from remarkable_mcp.export_resources import ExportResourceStore
+from remarkable_mcp.exporters import (
+    ExportMetadata,
+    RenderedPage,
+    render_archive_pages,
+    write_markdown_export,
+    write_native_pdf_export,
+    write_rendered_pdf_export,
+)
+
+
+def _metadata(*, source_type: str = "notebook", pages: int = 3) -> ExportMetadata:
+    return ExportMetadata(
+        document_id="11111111-2222-3333-4444-555555555555",
+        title="Project Notes",
+        path="/Work/Project Notes",
+        source_type=source_type,
+        page_count=pages,
+        modified=datetime(2026, 8, 14, 12, 30, tzinfo=timezone.utc),
+        tags=("work", "important"),
+    )
+
+
+def _png(color: str, size: tuple[int, int] = (200, 300)) -> bytes:
+    output = io.BytesIO()
+    Image.new("RGB", size, color).save(output, "PNG")
+    return output.getvalue()
+
+
+def _source_pdf() -> bytes:
+    document = fitz.open()
+    document.set_metadata({"author": "Original Author", "subject": "Original subject"})
+    for text in ("first source page", "second source page"):
+        page = document.new_page(width=200, height=300)
+        page.insert_text((30, 40), text)
+    data = document.tobytes()
+    document.close()
+    return data
+
+
+def _archive(path: Path, content: dict, *, include_pdf: bool = False) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("doc.content", json.dumps(content))
+        if include_pdf:
+            archive.writestr("doc.pdf", _source_pdf())
+    return path
+
+
+class TestPdfExporters:
+    def test_rendered_pdf_preserves_order_identity_and_failed_page(self, tmp_path):
+        destination = tmp_path / "export.pdf"
+        result = write_rendered_pdf_export(
+            destination,
+            _metadata(),
+            [
+                RenderedPage(page=1, image=_png("red")),
+                RenderedPage(page=2, image=None, error="synthetic render failure"),
+                RenderedPage(page=3, image=_png("blue")),
+            ],
+        )
+
+        assert result.status == "partial"
+        assert result.failed_pages == (2,)
+        assert "synthetic render failure" in "\n".join(result.warnings)
+
+        with fitz.open(destination) as document:
+            assert len(document) == 3
+            assert document.metadata["title"] == "Project Notes"
+            assert _metadata().document_id in document.metadata["subject"]
+            assert (
+                f"remarkable-document-id:{_metadata().document_id}" in document.metadata["keywords"]
+            )
+            placeholder = document[1].get_text()
+            assert "Physical page 2 could not be" in placeholder
+            assert "synthetic render failure" in placeholder
+
+            first = document[0].get_pixmap(matrix=fitz.Matrix(0.25, 0.25), alpha=False)
+            third = document[2].get_pixmap(matrix=fitz.Matrix(0.25, 0.25), alpha=False)
+            assert first.pixel(5, 5)[0] > first.pixel(5, 5)[2]
+            assert third.pixel(5, 5)[2] > third.pixel(5, 5)[0]
+
+    def test_native_pdf_preserves_pages_and_existing_metadata(self, tmp_path):
+        destination = tmp_path / "native.pdf"
+        result = write_native_pdf_export(
+            _source_pdf(),
+            destination,
+            _metadata(source_type="pdf", pages=2),
+        )
+
+        assert result.status == "complete"
+        assert result.pages == 2
+        with fitz.open(destination) as document:
+            assert [page.get_text().strip() for page in document] == [
+                "first source page",
+                "second source page",
+            ]
+            assert document.metadata["author"] == "Original Author"
+            assert "Original subject" in document.metadata["subject"]
+            assert _metadata().document_id in document.metadata["subject"]
+
+    def test_rendered_pdf_rejects_non_sequential_pages(self, tmp_path):
+        with pytest.raises(ValueError, match="expected 2"):
+            write_rendered_pdf_export(
+                tmp_path / "bad.pdf",
+                _metadata(pages=2),
+                [
+                    RenderedPage(page=1, image=_png("white")),
+                    RenderedPage(page=3, image=_png("white")),
+                ],
+            )
+
+    def test_archive_pages_extract_once_and_preserve_physical_order(self, tmp_path):
+        archive_path = _archive(
+            tmp_path / "notebook.zip",
+            {"fileType": "notebook", "pages": ["p1", "p2", "p3"]},
+        )
+        extracted_roots = []
+
+        def render(root, page, background_color):
+            assert (root / "doc.content").is_file()
+            extracted_roots.append(root)
+            if page == 2:
+                raise ValueError("corrupt page")
+            return _png(("red", "green", "blue")[page - 1]), (1404.0, 1872.0)
+
+        with patch(
+            "remarkable_mcp.exporters.render_page_full_page_from_extracted_document",
+            side_effect=render,
+        ):
+            pages = list(render_archive_pages(archive_path, _metadata(), pdf_mode="merged"))
+
+        assert [page.page for page in pages] == [1, 2, 3]
+        assert pages[1].image is None
+        assert "corrupt page" in pages[1].error
+        assert pages[2].image is not None
+        assert len({str(root) for root in extracted_roots}) == 1
+
+    def test_pdf_archive_distinguishes_user_added_page_from_partial_failure(self, tmp_path):
+        archive_path = _archive(
+            tmp_path / "pdf.zip",
+            {
+                "fileType": "pdf",
+                "cPages": {
+                    "pages": [
+                        {"id": "p1", "redir": {"value": 0}},
+                        {"id": "p2"},
+                        {"id": "p3", "redir": {"value": 1}},
+                    ]
+                },
+            },
+            include_pdf=True,
+        )
+        outcomes = [
+            (_png("white"), None),
+            (_png("white"), "Page has no PDF underlay (user-added page); annotation render."),
+            (
+                _png("white"),
+                "Annotation overlay failed to render; returned PDF page without annotations.",
+            ),
+        ]
+
+        with patch(
+            "remarkable_mcp.exporters.render_merged_page_from_extracted_document",
+            side_effect=outcomes,
+        ):
+            pages = list(
+                render_archive_pages(
+                    archive_path,
+                    _metadata(source_type="pdf"),
+                    pdf_mode="merged",
+                )
+            )
+
+        assert pages[0].partial is False
+        assert pages[1].partial is False
+        assert pages[1].warning is None
+        assert pages[2].partial is True
+
+
+class TestMarkdownExporter:
+    def test_markdown_uses_fixed_sections_and_verbatim_content(self, tmp_path):
+        destination = tmp_path / "notes.md"
+        extraction = {
+            "typed_text": ["# Looks like a heading", "- looks like a list"],
+            "highlights": ["Highlighted `phrase`"],
+            "annotated_pages": [
+                {
+                    "page": 3,
+                    "page_id": "p3",
+                    "has_handwriting": True,
+                    "highlights": [],
+                },
+                {
+                    "page": 1,
+                    "page_id": "p1",
+                    "has_handwriting": False,
+                    "highlights": ["Highlighted `phrase`"],
+                },
+            ],
+            "handwritten_text": ["OCR result"],
+            "ocr_backend": "tesseract",
+            "pages": 3,
+        }
+
+        result = write_markdown_export(
+            destination,
+            _metadata(source_type="pdf"),
+            source_text="## Source-like heading",
+            extraction=extraction,
+            include_ocr=True,
+            warnings=["Source annotations were incomplete."],
+        )
+        text = destination.read_text()
+
+        assert result.status == "partial"
+        assert "remarkable_document_id: " in text
+        assert _metadata().document_id in text
+        assert 'export_status: "partial"' in text
+        assert text.index("## Source text") < text.index("## Typed text")
+        assert text.index("## Typed text") < text.index("## Annotations")
+        assert text.index("## Annotations") < text.index("## Highlights")
+        assert text.index("## Highlights") < text.index("## OCR")
+        assert text.index("Physical page 1") < text.index("Physical page 3")
+        assert "```text\n## Source-like heading\n```" in text
+        assert "```text\n# Looks like a heading\n```" in text
+        assert "Sparse OCR results" in text
+        assert "### OCR excerpt 1" in text
+        assert "## Export notes" in text
+
+    def test_markdown_does_not_run_or_invent_ocr_when_not_requested(self, tmp_path):
+        destination = tmp_path / "notes.md"
+        result = write_markdown_export(
+            destination,
+            _metadata(pages=1),
+            source_text=None,
+            extraction={"pages": 1},
+            include_ocr=False,
+        )
+
+        assert result.status == "complete"
+        assert "_OCR was not requested for this export._" in destination.read_text()
+
+
+class TestExportResourceStore:
+    def test_expiry_and_safe_filename(self, tmp_path):
+        elapsed = [0.0]
+        base = datetime(2026, 8, 14, tzinfo=timezone.utc)
+        store = ExportResourceStore(
+            ttl_seconds=10,
+            max_entries=2,
+            root=tmp_path,
+            monotonic_clock=lambda: elapsed[0],
+            utcnow=lambda: base + timedelta(seconds=elapsed[0]),
+        )
+
+        published = store.publish(
+            filename="../../Unsafe?.pdf",
+            output_format="pdf",
+            writer=lambda path: path.write_bytes(b"%PDF-export"),
+        )
+        assert published.resource.filename == "Unsafe_.pdf"
+        assert store.read_bytes(published.resource.export_id, "pdf") == b"%PDF-export"
+
+        elapsed[0] = 11
+        with pytest.raises(FileNotFoundError, match="expired"):
+            store.read_bytes(published.resource.export_id, "pdf")
+        assert not any(tmp_path.rglob("Unsafe_.pdf"))
+
+    def test_lru_eviction_updates_on_read(self, tmp_path):
+        store = ExportResourceStore(ttl_seconds=60, max_entries=2, root=tmp_path)
+
+        def publish(name):
+            return store.publish(
+                filename=name,
+                output_format="markdown",
+                writer=lambda path: path.write_text(name),
+            )
+
+        first = publish("first.md")
+        second = publish("second.md")
+        assert store.read_text(first.resource.export_id, "markdown") == "first.md"
+        third = publish("third.md")
+
+        with pytest.raises(FileNotFoundError):
+            store.read_text(second.resource.export_id, "markdown")
+        assert store.read_text(first.resource.export_id, "markdown") == "first.md"
+        assert store.read_text(third.resource.export_id, "markdown") == "third.md"
+
+    def test_failed_publish_and_cleanup_remove_managed_files(self, tmp_path):
+        store = ExportResourceStore(ttl_seconds=60, max_entries=2, root=tmp_path)
+
+        def fail(path):
+            path.write_text("partial")
+            raise RuntimeError("writer failed")
+
+        with pytest.raises(RuntimeError, match="writer failed"):
+            store.publish(filename="broken.md", output_format="markdown", writer=fail)
+        assert list(tmp_path.rglob("*")) == []
+
+        published = store.publish(
+            filename="ready.md",
+            output_format="markdown",
+            writer=lambda path: path.write_text("ready"),
+        )
+        assert store.read_text(published.resource.export_id, "markdown") == "ready"
+        store.cleanup()
+        assert list(tmp_path.rglob("*")) == []

--- a/test_exporters.py
+++ b/test_exporters.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import io
 import json
+import threading
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -320,3 +322,84 @@ class TestExportResourceStore:
         assert store.read_text(published.resource.export_id, "markdown") == "ready"
         store.cleanup()
         assert list(tmp_path.rglob("*")) == []
+
+    def test_slow_read_does_not_block_other_store_operations(self, tmp_path):
+        store = ExportResourceStore(ttl_seconds=60, max_entries=4, root=tmp_path)
+
+        def publish(name: str, content: bytes):
+            return store.publish(
+                filename=name,
+                output_format="pdf",
+                writer=lambda path: path.write_bytes(content),
+            )
+
+        slow = publish("slow.pdf", b"slow")
+        other = publish("other.pdf", b"other")
+        slow_started = threading.Event()
+        release_slow_read = threading.Event()
+        original_read_bytes = Path.read_bytes
+
+        def controlled_read(path: Path) -> bytes:
+            if path.name == slow.resource.filename:
+                slow_started.set()
+                assert release_slow_read.wait(timeout=5)
+            return original_read_bytes(path)
+
+        with (
+            patch.object(Path, "read_bytes", controlled_read),
+            ThreadPoolExecutor(max_workers=3) as executor,
+        ):
+            slow_read = executor.submit(store.read_bytes, slow.resource.export_id, "pdf")
+            assert slow_started.wait(timeout=1)
+            try:
+                published = executor.submit(publish, "new.pdf", b"new").result(timeout=1)
+                other_read = executor.submit(
+                    store.read_bytes,
+                    other.resource.export_id,
+                    "pdf",
+                ).result(timeout=1)
+            finally:
+                release_slow_read.set()
+
+            assert published.resource.filename == "new.pdf"
+            assert other_read == b"other"
+            assert slow_read.result(timeout=1) == b"slow"
+
+    def test_eviction_racing_unlocked_read_returns_missing_resource_error(self, tmp_path):
+        store = ExportResourceStore(ttl_seconds=60, max_entries=1, root=tmp_path)
+        target = store.publish(
+            filename="target.pdf",
+            output_format="pdf",
+            writer=lambda path: path.write_bytes(b"target"),
+        )
+        read_started = threading.Event()
+        continue_read = threading.Event()
+        original_read_bytes = Path.read_bytes
+
+        def controlled_read(path: Path) -> bytes:
+            if path.name == target.resource.filename:
+                read_started.set()
+                assert continue_read.wait(timeout=5)
+            return original_read_bytes(path)
+
+        def publish_replacement():
+            return store.publish(
+                filename="replacement.pdf",
+                output_format="pdf",
+                writer=lambda path: path.write_bytes(b"replacement"),
+            )
+
+        with (
+            patch.object(Path, "read_bytes", controlled_read),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            racing_read = executor.submit(store.read_bytes, target.resource.export_id, "pdf")
+            assert read_started.wait(timeout=1)
+            try:
+                replacement = executor.submit(publish_replacement).result(timeout=1)
+            finally:
+                continue_read.set()
+
+            assert replacement.resource.filename == "replacement.pdf"
+            with pytest.raises(FileNotFoundError, match="not found or has expired"):
+                racing_read.result(timeout=1)

--- a/test_exporters.py
+++ b/test_exporters.py
@@ -403,3 +403,37 @@ class TestExportResourceStore:
             assert replacement.resource.filename == "replacement.pdf"
             with pytest.raises(FileNotFoundError, match="not found or has expired"):
                 racing_read.result(timeout=1)
+
+    def test_permission_error_during_eviction_does_not_fail_other_operations(self, tmp_path):
+        store = ExportResourceStore(ttl_seconds=60, max_entries=1, root=tmp_path)
+        locked = store.publish(
+            filename="locked.md",
+            output_format="markdown",
+            writer=lambda path: path.write_text("locked"),
+        )
+        locked_path = next(tmp_path.rglob("locked.md"))
+        original_unlink = Path.unlink
+
+        def windows_locked_unlink(path: Path, *args, **kwargs):
+            if path == locked_path:
+                raise PermissionError("file is open by another process")
+            return original_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", windows_locked_unlink):
+            replacement = store.publish(
+                filename="replacement.md",
+                output_format="markdown",
+                writer=lambda path: path.write_text("replacement"),
+            )
+
+            assert store.read_text(replacement.resource.export_id, "markdown") == "replacement"
+            with pytest.raises(FileNotFoundError, match="not found or has expired"):
+                store.read_text(locked.resource.export_id, "markdown")
+
+            # Shutdown cleanup is best-effort while Windows still denies unlink.
+            store.cleanup()
+            assert locked_path.is_file()
+
+        # A later cleanup pass removes the deferred path once the handle is free.
+        store.cleanup()
+        assert list(tmp_path.rglob("*")) == []

--- a/test_mcp_v2.py
+++ b/test_mcp_v2.py
@@ -1,5 +1,6 @@
 """MCP SDK v2 protocol-era compatibility tests."""
 
+import base64
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -69,6 +70,17 @@ async def test_one_server_serves_modern_and_legacy_catalogs():
             modern_merge_schema = modern_image.input_schema["properties"]["render_merged"]
             assert modern_merge_schema == legacy_image.input_schema["properties"]["render_merged"]
             assert modern_merge_schema["default"] is None
+            modern_export = next(
+                tool for tool in modern_tools.tools if tool.name == "remarkable_export"
+            )
+            legacy_export = next(
+                tool for tool in legacy_tools.tools if tool.name == "remarkable_export"
+            )
+            assert modern_export.input_schema == legacy_export.input_schema
+            assert modern_export.input_schema["properties"]["output_format"]["default"] == "pdf"
+            assert modern_export.input_schema["properties"]["pdf_mode"]["default"] == "merged"
+            assert modern_export.annotations.read_only_hint is False
+            assert legacy_export.annotations.read_only_hint is False
 
             modern_prompts = await modern.list_prompts()
             legacy_prompts = await legacy.list_prompts()
@@ -82,6 +94,26 @@ async def test_one_server_serves_modern_and_legacy_catalogs():
             resource = await modern.read_resource(CANVAS_RESOURCE_URI)
             assert resource.contents[0].mime_type == "text/html;profile=mcp-app"
             assert "<!doctype html>" in resource.contents[0].text
+            modern_templates = await modern.list_resource_templates()
+            legacy_templates = await legacy.list_resource_templates()
+            modern_export_templates = {
+                str(template.uri_template)
+                for template in modern_templates.resource_templates
+                if str(template.uri_template).startswith("remarkableexport:")
+            }
+            legacy_export_templates = {
+                str(template.uri_template)
+                for template in legacy_templates.resource_templates
+                if str(template.uri_template).startswith("remarkableexport:")
+            }
+            assert (
+                modern_export_templates
+                == legacy_export_templates
+                == {
+                    "remarkableexport:///pdf/{export_id}",
+                    "remarkableexport:///markdown/{export_id}",
+                }
+            )
 
             modern_status, legacy_status = (
                 await modern.call_tool("remarkable_status", {}),
@@ -89,6 +121,49 @@ async def test_one_server_serves_modern_and_legacy_catalogs():
             )
             assert json.loads(modern_status.content[0].text)["transport"] == "cloud"
             assert json.loads(legacy_status.content[0].text)["transport"] == "cloud"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_version"),
+    [("auto", "2026-07-28"), ("legacy", "2025-11-25")],
+)
+async def test_export_resource_link_works_in_both_protocol_eras(mode, expected_version):
+    """Large export content stays behind a ResourceLink in both SDK2 modes."""
+    import fitz
+    from mcp import types
+
+    from remarkable_mcp.export_resources import export_store
+
+    document = _document("Protocol Export")
+    api_client = Mock()
+    api_client.get_meta_items.return_value = [document]
+    pdf = fitz.open()
+    pdf.new_page(width=200, height=300).insert_text((20, 30), "protocol export")
+    api_client.download.return_value = pdf.tobytes()
+    pdf.close()
+
+    loader_start, loader_stop = _without_background_loader()
+    export_store.cleanup()
+    with (
+        loader_start,
+        loader_stop,
+        patch("remarkable_mcp.tools.get_rmapi", return_value=api_client),
+        patch("remarkable_mcp.tools.get_file_type", return_value="pdf"),
+    ):
+        async with Client(mcp, mode=mode) as client:
+            assert client.protocol_version == expected_version
+            result = await client.call_tool(
+                "remarkable_export",
+                {"document": document.VissibleName, "output_format": "pdf"},
+            )
+            link = next(
+                content for content in result.content if isinstance(content, types.ResourceLink)
+            )
+            assert "base64" not in result.content[0].text.lower()
+            resource = await client.read_resource(link.uri)
+            assert resource.contents[0].mime_type == "application/pdf"
+            assert base64.b64decode(resource.contents[0].blob).startswith(b"%PDF")
 
 
 @pytest.mark.asyncio

--- a/test_server.py
+++ b/test_server.py
@@ -123,6 +123,7 @@ class TestMCPServerInitialization:
             "remarkable_search",
             "remarkable_status",
             "remarkable_image",
+            "remarkable_export",
             "remarkable_canvas",
         ]
 
@@ -131,13 +132,13 @@ class TestMCPServerInitialization:
 
     @pytest.mark.asyncio
     async def test_tools_count(self):
-        """Cloud default: 6 read tools + always-on canvas + 6 write tools.
+        """Cloud default: 7 read/export tools + always-on canvas + 6 write tools.
 
         ``remarkable_author`` is SSH-only and therefore hidden in cloud mode, so
-        the default (cloud) surface is 13 tools, not 14.
+        the default cloud surface is 14 tools.
         """
         tools = await _list_tools()
-        assert len(tools) == 13, f"Expected 13 tools, got {len(tools)}"
+        assert len(tools) == 14, f"Expected 14 tools, got {len(tools)}"
 
     @pytest.mark.asyncio
     async def test_tool_schemas(self):
@@ -323,10 +324,11 @@ class TestRemarkableStatus:
         matrix = data["capabilities_by_transport"]
         # All four transports are described.
         assert set(matrix) == {"cloud", "ssh", "usb-web", "local-dir"}
-        # Read/render are universal.
+        # Read/render/export are universal.
         for caps in matrix.values():
             assert caps["read"] is True
             assert caps["render"] is True
+            assert caps["export"] is True
         # Cloud and SSH have full write surface; USB web is upload-only.
         for mode in ("cloud", "ssh"):
             assert all(matrix[mode][op] for op in ("upload", "mkdir", "move", "rename", "delete"))
@@ -337,9 +339,10 @@ class TestRemarkableStatus:
             matrix["local-dir"][op] for op in ("upload", "mkdir", "move", "rename", "delete")
         )
 
-        # Effective capabilities for the active transport always cover read/render.
+        # Effective capabilities always cover read/render/export.
         assert data["capabilities"]["read"] is True
         assert data["capabilities"]["render"] is True
+        assert data["capabilities"]["export"] is True
 
     @pytest.mark.asyncio
     @patch("remarkable_mcp.tools.get_rmapi")
@@ -1582,7 +1585,7 @@ class TestE2E:
         """Test that server can list all tools (e2e)."""
         tools = await _list_tools()
 
-        assert len(tools) == 13
+        assert len(tools) == 14
 
         # Check each tool has required properties and starts with remarkable_
         for tool in tools:


### PR DESCRIPTION
## Summary
- add `remarkable_export` for one-document PDF and Markdown exports across all transports
- return bounded 15-minute MCP `ResourceLink` artifacts instead of embedding large base64 payloads or writing implicit host paths
- preserve physical page order and stable document identity, default PDF exports to merged source underlays plus annotations, and retain failed page ordinals as explicit placeholders
- keep Markdown extraction honest with fixed source/typed/annotation/highlight/OCR sections and no inferred hierarchy
- document the temporary local-file lifecycle and add modern/legacy SDK2, local-dir, cloud, pure exporter, and smoke coverage

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -v` (441 passed, 10 skipped)
- `uv build`
- isolated built-wheel CLI/import checks

Refs #27

Fixes: #27